### PR TITLE
add key_esc to kill quickmenu

### DIFF
--- a/Bin/Data/Scripts/Editor/EditorUI.as
+++ b/Bin/Data/Scripts/Editor/EditorUI.as
@@ -1004,6 +1004,11 @@ void HandleKeyDown(StringHash eventType, VariantMap& eventData)
             UnhideUI();
         else if (console.visible)
             console.visible = false;
+        else if (quickMenu.visible)
+        {
+            quickMenu.visible = false;
+            quickMenu.enabled = false;
+        }
         else
         {
             UIElement@ front = ui.frontElement;


### PR DESCRIPTION
this a user kill the quickmenu by pressing esc

I don't know why i wrote it to use visible = false and enabled = false.  Should we switch it to always enabled but not visible?
