### PR TITLE
Fixed SetMaxVelocity in ParticleEmitter

### DIFF
--- a/Source/Engine/Graphics/ParticleEmitter.cpp
+++ b/Source/Engine/Graphics/ParticleEmitter.cpp
@@ -587,7 +587,7 @@ void ParticleEmitter::SetMinVelocity(float velocity)
 
 void ParticleEmitter::SetMaxVelocity(float velocity)
 {
-    velocityMin_ = velocity;
+    velocityMax_ = velocity;
     MarkNetworkUpdate();
 }
 


### PR DESCRIPTION
velocityMin was set instead of velocityMax
