### PR TITLE
Allow Getting and Setting of Inner XML Text

### DIFF
--- a/Source/Engine/LuaScript/pkgs/Resource/XMLElement.pkg
+++ b/Source/Engine/LuaScript/pkgs/Resource/XMLElement.pkg
@@ -20,6 +20,7 @@ class XMLElement
     
     BoundingBox GetBoundingBox() const;
     
+	String GetValue() const;
     Color GetColor(const String name) const;
     float GetFloat(const String name) const;
     unsigned GetUInt(const String name) const;

--- a/Source/Engine/Resource/XMLElement.cpp
+++ b/Source/Engine/Resource/XMLElement.cpp
@@ -222,6 +222,20 @@ XPathResultSet XMLElement::SelectPrepared(const XPathQuery& query) const
     return XPathResultSet(file_, &result);
 }
 
+bool XMLElement::SetValue(const String& value)
+{
+	return SetValue(value.CString());
+}
+
+bool XMLElement::SetValue(const char* value)
+{
+	if (!file_ || (!node_ && !xpathNode_))
+		return false;
+
+	pugi::xml_node& node = xpathNode_ ? xpathNode_->node() : pugi::xml_node(node_);
+	return node.append_child(pugi::node_pcdata).set_value(value);
+}
+
 bool XMLElement::SetAttribute(const String& name, const String& value)
 {
     return SetAttribute(name.CString(), value.CString());
@@ -561,6 +575,15 @@ bool XMLElement::HasAttribute(const char* name) const
 
     const pugi::xml_node& node = xpathNode_ ? xpathNode_->node() : pugi::xml_node(node_);
     return !node.attribute(name).empty();
+}
+
+String XMLElement::GetValue() const
+{
+	if (!file_ || (!node_ && !xpathNode_))
+		return String::EMPTY;
+
+	const pugi::xml_node& node = xpathNode_ ? xpathNode_->node() : pugi::xml_node(node_);
+	return String(node.child_value());
 }
 
 String XMLElement::GetAttribute(const String& name) const

--- a/Source/Engine/Resource/XMLElement.h
+++ b/Source/Engine/Resource/XMLElement.h
@@ -88,6 +88,11 @@ public:
     /// Select elements/attributes using XPath query.
     XPathResultSet SelectPrepared(const XPathQuery& query) const;
 
+	/// Set the value for an inner node in the following format <node>value</node>.
+	bool SetValue(const String& value);
+	/// Set the value for an inner node in the following format
+	/// <node>value</node>. Must be used on the <node> element.
+	bool SetValue(const char* value);
     /// Set an attribute.
     bool SetAttribute(const String& name, const String& value);
     /// Set an attribute.
@@ -171,7 +176,9 @@ public:
     bool HasAttribute(const String& name) const;
     /// Return whether has an attribute.
     bool HasAttribute(const char* name) const;
-    /// Return attribute, or empty if missing.
+	/// Return inner value, or empty if missing for nodes like <node>value</node>
+	String GetValue() const;
+	/// Return attribute, or empty if missing.
     String GetAttribute(const String& name = String::EMPTY) const;
     /// Return attribute, or empty if missing.
     String GetAttribute(const char* name) const;

--- a/Source/Engine/Script/ResourceAPI.cpp
+++ b/Source/Engine/Script/ResourceAPI.cpp
@@ -225,6 +225,7 @@ static void RegisterXMLElement(asIScriptEngine* engine)
     engine->RegisterObjectMethod("XMLElement", "XMLElement SelectSinglePrepared(const XPathQuery&in)", asMETHOD(XMLElement, SelectSinglePrepared), asCALL_THISCALL);
     engine->RegisterObjectMethod("XMLElement", "XPathResultSet Select(const String&in)", asMETHOD(XMLElement, Select), asCALL_THISCALL);
     engine->RegisterObjectMethod("XMLElement", "XPathResultSet SelectPrepared(const XPathQuery&in)", asMETHOD(XMLElement, SelectPrepared), asCALL_THISCALL);
+	engine->RegisterObjectMethod("XMLElement", "bool SetValue(const String&in)", asMETHODPR(XMLElement, SetValue, (const String&), bool), asCALL_THISCALL);
     engine->RegisterObjectMethod("XMLElement", "bool SetAttribute(const String&in, const String&in)", asMETHODPR(XMLElement, SetAttribute, (const String&, const String&), bool), asCALL_THISCALL);
     engine->RegisterObjectMethod("XMLElement", "bool SetAttribute(const String&in)", asMETHODPR(XMLElement, SetAttribute, (const String&), bool), asCALL_THISCALL);
     engine->RegisterObjectMethod("XMLElement", "bool SetBool(const String&in, bool)", asMETHOD(XMLElement, SetBool), asCALL_THISCALL);
@@ -244,6 +245,7 @@ static void RegisterXMLElement(asIScriptEngine* engine)
     engine->RegisterObjectMethod("XMLElement", "bool SetVector4(const String&in, const Vector4&in)", asMETHOD(XMLElement, SetVector4), asCALL_THISCALL);
     engine->RegisterObjectMethod("XMLElement", "bool SetVectorVariant(const String&in, const Variant&in)", asMETHOD(XMLElement, SetVectorVariant), asCALL_THISCALL);
     engine->RegisterObjectMethod("XMLElement", "bool HasAttribute(const String&in) const", asMETHODPR(XMLElement, HasAttribute, (const String&) const, bool), asCALL_THISCALL);
+	engine->RegisterObjectMethod("XMLElement", "String GetValue() const", asMETHOD(XMLElement, GetValue), asCALL_THISCALL);
     engine->RegisterObjectMethod("XMLElement", "String GetAttribute(const String&in arg0 = String()) const", asMETHODPR(XMLElement, GetAttribute, (const String&) const, String), asCALL_THISCALL);
     engine->RegisterObjectMethod("XMLElement", "String GetAttributeLower(const String&in) const", asMETHODPR(XMLElement, GetAttributeLower, (const String&) const, String), asCALL_THISCALL);
     engine->RegisterObjectMethod("XMLElement", "String GetAttributeUpper(const String&in) const", asMETHODPR(XMLElement, GetAttributeUpper, (const String&) const, String), asCALL_THISCALL);


### PR DESCRIPTION
I noticed when creating a settings file in xml and using the XML api, that there was no way to retrieve the inner text when a node was in the form.

```
<node>text</node> 
```

This adds that functionality as well as adding the ability to create an XMLElement in that format. It only adds getting for Lua though since unlike angelscript it doesn't seem to have the ability to use the Set functions for XML. Functionality works like follows:

```
String text = root.GetChild("node").GetValue();
root.CreateChild("node").SetValue("text");
```

There was one possible change I was toying with in the Set function in that perhaps it should ensure that no other child nodes have been added before allowing the call to succeed.
