### PR TITLE
Add Lua binding to PODVector<RayQueryResult> and Octree::Raycast()

### DIFF
--- a/Source/Engine/Graphics/OctreeQuery.h
+++ b/Source/Engine/Graphics/OctreeQuery.h
@@ -165,6 +165,8 @@ struct RayQueryResult
         node_(0)
     {
     }
+	
+	bool operator != (const RayQueryResult& rhs) const { return position_!=rhs.position_ || normal_!=rhs.normal_ || distance_!=rhs.distance_ || drawable_!=rhs.drawable_ || node_!=rhs.node_ || subObject_!=rhs.subObject_; }
     
     /// Hit position in world space.
     Vector3 position_;

--- a/Source/Engine/LuaScript/pkgs/Container/Vector.pkg
+++ b/Source/Engine/LuaScript/pkgs/Container/Vector.pkg
@@ -1,9 +1,10 @@
 $#include "Vector.h"
 $#include "Vector3.h"
+$#include "OctreeQuery.h"
 
 class PODVector
 {
-    TOLUA_TEMPLATE_BIND(T, Vector3)
+    TOLUA_TEMPLATE_BIND(T, Vector3,RayQueryResult)
     
     PODVector();
     PODVector(const PODVector<T>& vector);
@@ -49,3 +50,5 @@ class PODVector
     tolua_readonly tolua_property__no_prefix unsigned capacity;
     tolua_readonly tolua_property__no_prefix bool empty;
 };
+
+$renaming PODVector<RayQueryResult> @ RayQueryResultVector

--- a/Source/Engine/LuaScript/pkgs/Graphics/Octree.pkg
+++ b/Source/Engine/LuaScript/pkgs/Graphics/Octree.pkg
@@ -9,6 +9,7 @@ class Octree : public Component
     
     // void GetDrawables(OctreeQuery& query) const;
     // void Raycast(RayOctreeQuery& query) const;
+	tolua_outside void OctreeRaycast @ Raycast(PODVector<RayQueryResult> &result, const Ray& ray, RayQueryLevel level, float maxDistance, unsigned char drawableFlags) const;
     // void RaycastSingle(RayOctreeQuery& query) const;
     tolua_outside RayQueryResult OctreeRaycastSingle @ RaycastSingle(const Ray& ray, RayQueryLevel level, float maxDistance, unsigned char drawableFlags) const;
     
@@ -37,5 +38,11 @@ static RayQueryResult OctreeRaycastSingle(const Octree* octree, const Ray& ray, 
         empty.subObject_ = 0;
         return empty;
     }
+}
+
+static void OctreeRaycast(const Octree* octree, PODVector<RayQueryResult> &result, const Ray& ray, RayQueryLevel level, float maxDistance, unsigned char drawableFlags)
+{
+	RayOctreeQuery query(result,ray,level,maxDistance,drawableFlags);
+	octree->Raycast(query);
 }
 $}


### PR DESCRIPTION
Binding for Octree::Raycast to Lua, to allow full raycast instead of single result.
