### PR TITLE
Modification of Resourece Directory and Package File search priority for GetFile and GetResource

### DIFF
--- a/Docs/AngelScriptAPI.h
+++ b/Docs/AngelScriptAPI.h
@@ -1442,8 +1442,8 @@ class ResourceCache
 {
 // Methods:
 void SendEvent(const String&, VariantMap& = VariantMap ( ));
-bool AddResourceDir(const String&);
-void AddPackageFile(PackageFile, bool = false);
+bool AddResourceDir(const String&, uint = - 1);
+void AddPackageFile(PackageFile, uint = - 1);
 bool AddManualResource(Resource);
 void RemoveResourceDir(const String&);
 void RemovePackageFile(PackageFile, bool = true, bool = false);
@@ -1484,6 +1484,10 @@ uint totalMemoryUse;
 Array<String> resourceDirs;
 /* (readonly) */
 Array<PackageFile> packageFiles;
+/* (writeonly) */
+bool searchPackagesFirst;
+/* (readonly) */
+bool seachPackagesFirst;
 bool autoReloadResources;
 };
 

--- a/Docs/ScriptAPI.dox
+++ b/Docs/ScriptAPI.dox
@@ -1383,8 +1383,8 @@ Properties:
 Methods:
 
 - void SendEvent(const String&, VariantMap& = VariantMap ( ))
-- bool AddResourceDir(const String&)
-- void AddPackageFile(PackageFile@, bool = false)
+- bool AddResourceDir(const String&, uint = - 1)
+- void AddPackageFile(PackageFile@, uint = - 1)
 - bool AddManualResource(Resource@)
 - void RemoveResourceDir(const String&)
 - void RemovePackageFile(PackageFile@, bool = true, bool = false)
@@ -1416,6 +1416,8 @@ Properties:
 - uint totalMemoryUse (readonly)
 - String[]@ resourceDirs (readonly)
 - PackageFile@[]@ packageFiles (readonly)
+- bool searchPackagesFirst (writeonly)
+- bool seachPackagesFirst (readonly)
 - bool autoReloadResources
 
 

--- a/Source/Engine/LuaScript/pkgs/Resource/ResourceCache.pkg
+++ b/Source/Engine/LuaScript/pkgs/Resource/ResourceCache.pkg
@@ -9,6 +9,7 @@ class ResourceCache
     void SetMemoryBudget(const String type, unsigned budget);
     
     void SetAutoReloadResources(bool enable);
+    void SetSearchPackagesFirst(bool value);
     
     Resource* GetResource(const String type, const String name);
     
@@ -19,9 +20,11 @@ class ResourceCache
     String GetResourceFileName(const String name) const;
     
     bool GetAutoReloadResources() const;
+    bool GetSearchPackagesFirst() const;
     
     tolua_readonly tolua_property__get_set unsigned totalMemoryUse;
     tolua_readonly tolua_property__get_set bool autoReloadResources;
+    tolua_readonly tolua_property__get_set bool searchPackagesFirst;
 };
 
 ${

--- a/Source/Engine/Script/ResourceAPI.cpp
+++ b/Source/Engine/Script/ResourceAPI.cpp
@@ -94,8 +94,8 @@ static CScriptArray* ResourceCacheGetPackageFiles(ResourceCache* ptr)
 static void RegisterResourceCache(asIScriptEngine* engine)
 {
     RegisterObject<ResourceCache>(engine, "ResourceCache");
-    engine->RegisterObjectMethod("ResourceCache", "bool AddResourceDir(const String&in)", asMETHOD(ResourceCache, AddResourceDir), asCALL_THISCALL);
-    engine->RegisterObjectMethod("ResourceCache", "void AddPackageFile(PackageFile@+, bool addAsFirst = false)", asMETHOD(ResourceCache, AddPackageFile), asCALL_THISCALL);
+    engine->RegisterObjectMethod("ResourceCache", "bool AddResourceDir(const String&in, uint priority = -1)", asMETHOD(ResourceCache, AddResourceDir), asCALL_THISCALL);
+    engine->RegisterObjectMethod("ResourceCache", "void AddPackageFile(PackageFile@+, uint priority = -1)", asMETHOD(ResourceCache, AddPackageFile), asCALL_THISCALL);
     engine->RegisterObjectMethod("ResourceCache", "bool AddManualResource(Resource@+)", asMETHOD(ResourceCache, AddManualResource), asCALL_THISCALL);
     engine->RegisterObjectMethod("ResourceCache", "void RemoveResourceDir(const String&in)", asMETHOD(ResourceCache, RemoveResourceDir), asCALL_THISCALL);
     engine->RegisterObjectMethod("ResourceCache", "void RemovePackageFile(PackageFile@+, bool releaseResources = true, bool forceRelease = false)", asMETHODPR(ResourceCache, RemovePackageFile, (PackageFile*, bool, bool), void), asCALL_THISCALL);
@@ -119,6 +119,8 @@ static void RegisterResourceCache(asIScriptEngine* engine)
     engine->RegisterObjectMethod("ResourceCache", "uint get_totalMemoryUse() const", asMETHOD(ResourceCache, GetTotalMemoryUse), asCALL_THISCALL);
     engine->RegisterObjectMethod("ResourceCache", "Array<String>@ get_resourceDirs() const", asFUNCTION(ResourceCacheGetResourceDirs), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod("ResourceCache", "Array<PackageFile@>@ get_packageFiles() const", asFUNCTION(ResourceCacheGetPackageFiles), asCALL_CDECL_OBJLAST);
+    engine->RegisterObjectMethod("ResourceCache", "void set_searchPackagesFirst(bool)", asMETHOD(ResourceCache, SetSearchPackagesFirst), asCALL_THISCALL);
+    engine->RegisterObjectMethod("ResourceCache", "bool get_seachPackagesFirst() const", asMETHOD(ResourceCache, GetSearchPackagesFirst), asCALL_THISCALL);
     engine->RegisterObjectMethod("ResourceCache", "void set_autoReloadResources(bool)", asMETHOD(ResourceCache, SetAutoReloadResources), asCALL_THISCALL);
     engine->RegisterObjectMethod("ResourceCache", "bool get_autoReloadResources() const", asMETHOD(ResourceCache, GetAutoReloadResources), asCALL_THISCALL);
     engine->RegisterGlobalFunction("ResourceCache@+ get_resourceCache()", asFUNCTION(GetResourceCache), asCALL_CDECL);


### PR DESCRIPTION
Currently GetFile and subsequently GetResource assume two things, that package files want to be searched first and that Resource Directories are always to be searched in the order that they are added. This is less true for Package files, since you can specify to add them to the front of the vector instead.

What I propose is two fold. First there is a function similar to the following:

```
GetSubsystem<ResourceCache>()->SetSearchPackagesFirst(true);
```

Which when calling GetFile or GetResource will use that flag to define which locations to search first, the default behaviour for this will be packages first.

Secondly there is the ability to define the priority of resource directories and package files in this search process. To facilitate this a modification should be made with more granularity than Front or Back that will work along the following lines:

```
GetSubsystem<ResourceCache>()->AddResourceDirectory("Dir");
GetSubsystem<ResourceCache>()->AddResourceDirectory("Dir",3);
```

Where the first would default to the end of the list, and the second would be placed in the "4" spot in the list or at the end if the list is not that big.

---

I'm not totally sure whether this is suitable for widespread Urho, since my usage of it has some requirements for modability in my applications where mods can overwrite scripts that define certain aspects of the logic and so instead of keeping my own map of original name to overridden location I'd prefer to have the underlying resource cache able to do so for me.
