### PR TITLE
Create or Set Window Borderless and Maximize/Minimize Window

### DIFF
--- a/Source/Engine/Engine/Engine.cpp
+++ b/Source/Engine/Engine/Engine.cpp
@@ -274,6 +274,7 @@ bool Engine::Initialize(const VariantMap& parameters)
             GetParameter(parameters, "WindowWidth", 0).GetInt(),
             GetParameter(parameters, "WindowHeight", 0).GetInt(),
             GetParameter(parameters, "FullScreen", true).GetBool(),
+            GetParameter(parameters, "Borderless", false).GetBool(),
             GetParameter(parameters, "WindowResizable", false).GetBool(),
             GetParameter(parameters, "VSync", false).GetBool(),
             GetParameter(parameters, "TripleBuffer", false).GetBool(),
@@ -286,7 +287,7 @@ bool Engine::Initialize(const VariantMap& parameters)
         renderer->SetDrawShadows(GetParameter(parameters, "Shadows", true).GetBool());
         if (renderer->GetDrawShadows() && GetParameter(parameters, "LowQualityShadows", false).GetBool())
             renderer->SetShadowQuality(SHADOWQUALITY_LOW_16BIT);
-
+    
         if (GetParameter(parameters, "Sound", true).GetBool())
         {
             GetSubsystem<Audio>()->SetMode(

--- a/Source/Engine/Graphics/Direct3D9/D3D9Graphics.h
+++ b/Source/Engine/Graphics/Direct3D9/D3D9Graphics.h
@@ -90,7 +90,7 @@ public:
     /// Set window position.
     void SetWindowPosition(int x, int y);
     /// Set screen mode. Return true if successful.
-    bool SetMode(int width, int height, bool fullscreen, bool resizable, bool vsync, bool tripleBuffer, int multiSample);
+    bool SetMode(int width, int height, bool fullscreen, bool borderless, bool resizable, bool vsync, bool tripleBuffer, int multiSample);
     /// Set screen resolution only. Return true if successful.
     bool SetMode(int width, int height);
     /// Set whether the main window uses sRGB conversion on write.
@@ -234,6 +234,8 @@ public:
     bool GetFullscreen() const { return fullscreen_; }
     /// Return whether window is resizable.
     bool GetResizable() const { return resizable_; }
+    /// Return whether window is borderless.
+    bool GetBorderless() const { return borderless_; }
     /// Return whether vertical sync is on.
     bool GetVSync() const { return vsync_; }
     /// Return whether triple buffering is enabled.
@@ -347,6 +349,10 @@ public:
     
     /// Window was resized through user interaction. Called by Input subsystem.
     void WindowResized();
+    /// Maximize the Window
+    void Maximize();
+    /// Minimize the Window
+    void Minimize();
     /// Add a GPU object to keep track of. Called by GPUObject.
     void AddGPUObject(GPUObject* object);
     /// Remove a GPU object. Called by GPUObject.
@@ -393,11 +399,11 @@ public:
     
 private:
     /// Create the application window.
-    bool OpenWindow(int width, int height, bool resizable);
+    bool OpenWindow(int width, int height, bool resizable, bool borderless);
     /// Create the application window icon.
     void CreateWindowIcon();
     /// Adjust the window for new resolution and fullscreen mode.
-    void AdjustWindow(int& newWidth, int& newHeight, bool& newFullscreen);
+    void AdjustWindow(int& newWidth, int& newHeight, bool& newFullscreen, bool& newBorderless);
     /// Create the Direct3D interface.
     bool CreateInterface();
     /// Create the Direct3D device.
@@ -431,6 +437,8 @@ private:
     int multiSample_;
     /// Fullscreen flag.
     bool fullscreen_;
+    /// Borderless flag.
+    bool borderless_;
     /// Resizable flag.
     bool resizable_;
     /// Vertical sync flag.

--- a/Source/Engine/Graphics/GraphicsEvents.h
+++ b/Source/Engine/Graphics/GraphicsEvents.h
@@ -44,6 +44,7 @@ EVENT(E_SCREENMODE, ScreenMode)
     PARAM(P_HEIGHT, Height);                // int
     PARAM(P_FULLSCREEN, Fullscreen);        // bool
     PARAM(P_RESIZABLE, Resizable);          // bool
+    PARAM(P_BORDERLESS, Borderless);        // bool
 }
 
 /// Graphics features checked.

--- a/Source/Engine/Graphics/OpenGL/OGLGraphics.h
+++ b/Source/Engine/Graphics/OpenGL/OGLGraphics.h
@@ -95,7 +95,7 @@ public:
     /// Set window position.
     void SetWindowPosition(int x, int y);
     /// Set screen mode. Return true if successful.
-    bool SetMode(int width, int height, bool fullscreen, bool resizable, bool vsync, bool tripleBuffer, int multiSample);
+    bool SetMode(int width, int height, bool fullscreen, bool borderless, bool resizable, bool vsync, bool tripleBuffer, int multiSample);
     /// Set screen resolution only. Return true if successful.
     bool SetMode(int width, int height);
     /// Set whether the main window uses sRGB conversion on write.
@@ -239,7 +239,9 @@ public:
     int GetMultiSample() const { return multiSample_; }
     /// Return whether window is fullscreen.
     bool GetFullscreen() const { return fullscreen_; }
-    /// Return whether window is resizable.
+    /// Return whether window is borderless.
+    bool GetBorderless() const { return borderless_; }
+    /// Return whether window is resizable
     bool GetResizable() const { return resizable_; }
     /// Return whether vertical sync is on.
     bool GetVSync() const { return vsync_; }
@@ -374,6 +376,10 @@ public:
     void Release(bool clearGPUObjects, bool closeWindow);
     /// Restore GPU objects and reinitialize state. Requires an open window.
     void Restore();
+    /// Maximize the Window
+    void Maximize();
+    /// Minimize the Window
+    void Minimize();
     /// Clean up a render surface from all FBOs.
     void CleanupRenderSurface(RenderSurface* surface);
     /// Mark the FBO needing an update.
@@ -444,6 +450,8 @@ private:
     int multiSample_;
     /// Fullscreen flag.
     bool fullscreen_;
+    /// Borderless flag.
+    bool borderless_;
     /// Resizable flag.
     bool resizable_;
     /// Vertical sync flag.

--- a/Source/Engine/LuaScript/pkgs/Graphics/Graphics.pkg
+++ b/Source/Engine/LuaScript/pkgs/Graphics/Graphics.pkg
@@ -7,12 +7,14 @@ class Graphics : public Object
     void SetWindowPosition(const IntVector2& position);
     void SetWindowPosition(int x, int y);
 
-    bool SetMode(int width, int height, bool fullscreen, bool resizable, bool vsync, bool tripleBuffer, int multiSample);
+    bool SetMode(int width, int height, bool fullscreen, bool borderless, bool resizable, bool vsync, bool tripleBuffer, int multiSample);
     bool SetMode(int width, int height);
     
     void SetSRGB(bool enable);
     void SetFlushGPU(bool enable);
     bool ToggleFullscreen();
+	void Maximize();
+	void Minimize();
     void Close();
     bool TakeScreenShot(Image& destImage);
     
@@ -25,6 +27,7 @@ class Graphics : public Object
     int GetMultiSample() const;
     bool GetFullscreen() const;
     bool GetResizable() const;
+	bool GetBorderless() const;
     bool GetVSync() const;
     bool GetTripleBuffer() const;
     bool GetSRGB() const;
@@ -55,6 +58,7 @@ class Graphics : public Object
     tolua_readonly tolua_property__get_set int multiSample;
     tolua_readonly tolua_property__get_set bool fullscreen;
     tolua_readonly tolua_property__get_set bool resizable;
+	    tolua_readonly tolua_property__get_set bool borderless;
     tolua_readonly tolua_property__get_set bool vSync;
     tolua_readonly tolua_property__get_set bool tripleBuffer;
     tolua_property__get_set bool sRGB;

--- a/Source/Engine/Script/GraphicsAPI.cpp
+++ b/Source/Engine/Script/GraphicsAPI.cpp
@@ -1187,10 +1187,12 @@ static Graphics* GetGraphics()
 static void RegisterGraphics(asIScriptEngine* engine)
 {
     RegisterObject<Graphics>(engine, "Graphics");
-    engine->RegisterObjectMethod("Graphics", "bool SetMode(int, int, bool, bool, bool, bool, int)", asMETHODPR(Graphics, SetMode, (int, int, bool, bool, bool, bool, int), bool), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Graphics", "bool SetMode(int, int, bool, bool, bool, bool, bool, int)", asMETHODPR(Graphics, SetMode, (int, int, bool, bool, bool, bool, bool, int), bool), asCALL_THISCALL);
     engine->RegisterObjectMethod("Graphics", "bool SetMode(int, int)", asMETHODPR(Graphics, SetMode, (int, int), bool), asCALL_THISCALL);
     engine->RegisterObjectMethod("Graphics", "void SetWindowPosition(int, int)", asMETHODPR(Graphics, SetWindowPosition, (int, int), void), asCALL_THISCALL);
     engine->RegisterObjectMethod("Graphics", "bool ToggleFullscreen()", asMETHOD(Graphics, ToggleFullscreen), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Graphics", "void Maximize()", asMETHOD(Graphics, Maximize), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Graphics", "void Minimize()", asMETHOD(Graphics, Minimize), asCALL_THISCALL);
     engine->RegisterObjectMethod("Graphics", "void Close()", asMETHOD(Graphics, Close), asCALL_THISCALL);
     engine->RegisterObjectMethod("Graphics", "bool TakeScreenShot(Image@+)", asMETHOD(Graphics, TakeScreenShot), asCALL_THISCALL);
     engine->RegisterObjectMethod("Graphics", "void set_windowTitle(const String&in)", asMETHOD(Graphics, SetWindowTitle), asCALL_THISCALL);
@@ -1207,6 +1209,7 @@ static void RegisterGraphics(asIScriptEngine* engine)
     engine->RegisterObjectMethod("Graphics", "int get_multiSample() const", asMETHOD(Graphics, GetMultiSample), asCALL_THISCALL);
     engine->RegisterObjectMethod("Graphics", "bool get_fullscreen() const", asMETHOD(Graphics, GetFullscreen), asCALL_THISCALL);
     engine->RegisterObjectMethod("Graphics", "bool get_resizable() const", asMETHOD(Graphics, GetResizable), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Graphics", "bool get_borderless() const", asMETHOD(Graphics, GetBorderless), asCALL_THISCALL);
     engine->RegisterObjectMethod("Graphics", "bool get_vsync() const", asMETHOD(Graphics, GetVSync), asCALL_THISCALL);
     engine->RegisterObjectMethod("Graphics", "bool get_tripleBuffer() const", asMETHOD(Graphics, GetTripleBuffer), asCALL_THISCALL);
     engine->RegisterObjectMethod("Graphics", "bool get_initialized() const", asMETHOD(Graphics, IsInitialized), asCALL_THISCALL);


### PR DESCRIPTION
Several things this time, the first allows you to explicitly state whether a window should be borderless (no window decoration) which has mutual exclusivity with both fullscreen and resizable. It cannot be resizable because a border is required for that and it can't be fullscreen because otherwise SDL sets the window in such a way it removes the point in being a borderless window. The default setting if no width or height is passed in is desktop resolution.

The second change is the ability to Maximize a window via code instead of needing to be resizable to do so. This also includes a change so that if width or height are 0 0 the window is maximized as the default (the old default of 1024 768 has been preserved for when a user un-maximizes a window).
