### PR TITLE
Add the ability to specify an offset position for the ToolTip UI Element

### DIFF
--- a/Source/Engine/LuaScript/pkgs/UI/ToolTip.pkg
+++ b/Source/Engine/LuaScript/pkgs/UI/ToolTip.pkg
@@ -6,8 +6,11 @@ class ToolTip : public UIElement
     virtual ~ToolTip();
 
     void SetDelay(float delay);
+    void SetOffset(const IntVector2& offset);
     
     float GetDelay() const;
+    const IntVector2& GetOffset() const;
     
     tolua_property__get_set float delay;
+    tolua_property__get_set IntVector2 offset;
 };

--- a/Source/Engine/Script/UIAPI.cpp
+++ b/Source/Engine/Script/UIAPI.cpp
@@ -532,6 +532,8 @@ static void RegisterToolTip(asIScriptEngine* engine)
     RegisterUIElement<ToolTip>(engine, "ToolTip");
     engine->RegisterObjectMethod("ToolTip", "void set_delay(float)", asMETHOD(ToolTip, SetDelay), asCALL_THISCALL);
     engine->RegisterObjectMethod("ToolTip", "float get_delay() const", asMETHOD(ToolTip, GetDelay), asCALL_THISCALL);
+    engine->RegisterObjectMethod("ToolTip", "void set_offset(const IntVector2&in)", asMETHOD(ToolTip, SetOffset), asCALL_THISCALL);
+    engine->RegisterObjectMethod("ToolTip", "const IntVector2& get_offset() const", asMETHOD(ToolTip, GetDelay), asCALL_THISCALL);
 }
 
 static UI* GetUI()

--- a/Source/Engine/UI/ToolTip.cpp
+++ b/Source/Engine/UI/ToolTip.cpp
@@ -24,6 +24,7 @@
 #include "ToolTip.h"
 #include "Context.h"
 #include "Timer.h"
+#include "Serializable.h"
 
 namespace Urho3D
 {
@@ -33,6 +34,7 @@ extern const char* UI_CATEGORY;
 ToolTip::ToolTip(Context* context) :
     UIElement(context),
     delay_(500.f),
+    offset_(IntVector2::ZERO),
     parentHovered_(false)
 {
     SetVisible(false);
@@ -47,7 +49,8 @@ void ToolTip::RegisterObject(Context* context)
     context->RegisterFactory<ToolTip>(UI_CATEGORY);
 
     COPY_BASE_ATTRIBUTES(ToolTip, UIElement);
-    ACCESSOR_ATTRIBUTE(ToolTip, VAR_FLOAT, "Delay", GetDelay, SetDelay, float, 0.5f, AM_FILE);
+    ACCESSOR_ATTRIBUTE(ToolTip, VAR_FLOAT, "Delay", GetDelay, SetDelay, float, 500.f, AM_FILE);
+    REF_ACCESSOR_ATTRIBUTE(ToolTip, VAR_INTVECTOR2, "Offset", GetOffset, SetOffset, IntVector2, IntVector2::ZERO, AM_FILE);
 }
 
 void ToolTip::Update(float timeStep)
@@ -79,7 +82,7 @@ void ToolTip::Update(float timeStep)
             originalPosition_ = GetPosition();
             IntVector2 screenPosition = GetScreenPosition();
             SetParent(root);
-            SetPosition(screenPosition);
+            SetPosition(screenPosition + offset_);
             SetVisible(true);
             // BringToFront() is unreliable in this case as it takes into account only input-enabled elements.
             // Rather just force priority to max
@@ -102,6 +105,11 @@ void ToolTip::Update(float timeStep)
 void ToolTip::SetDelay(float delay)
 {
     delay_ = delay;
+}
+
+void ToolTip::SetOffset(const IntVector2& offset)
+{
+    offset_ = offset;
 }
 
 }

--- a/Source/Engine/UI/ToolTip.h
+++ b/Source/Engine/UI/ToolTip.h
@@ -46,15 +46,21 @@ public:
 
     /// Set the delay (milliseconds) until the tooltip shows once hovering.
     void SetDelay(float delay);
+    /// Set the offset of the tooltip from the parent element once shown.
+    void SetOffset(const IntVector2& offset);
 
     /// Return the delay until the tooltip shows once hovering.
     float GetDelay() const { return delay_; }
+    /// Get the offset from the parent position.
+    const IntVector2& GetOffset() const { return offset_; }
 
 private:
     /// The element that is being tracked for hovering. Normally the parent element.
     WeakPtr<UIElement> target_;
     /// Delay from hover start to displaying the tooltip.
     float delay_;
+    /// Offet from the parent position of where to display the tooltip.
+    IntVector2 offset_;
     /// Point at which the parent was hovered.
     bool parentHovered_;
     /// Point at which the tooltip was set visible.


### PR DESCRIPTION
Minor change that will allow you to specify the offset from the parent's screen position when displaying a tooltip.
