### PR TITLE
added fallback for non-drawable components when orbiting

### DIFF
--- a/Bin/Data/Scripts/Editor/EditorView.as
+++ b/Bin/Data/Scripts/Editor/EditorView.as
@@ -706,11 +706,11 @@ Vector3 SelectedNodesCenterPoint()
     for (uint i = 0; i < selectedComponents.length; ++i)
     {
         Drawable@ drawable = cast<Drawable>(selectedComponents[i]);
+        count++;
         if (drawable !is null)
-        {
             centerPoint += drawable.node.LocalToWorld(drawable.boundingBox.center);
-            count++;
-        }
+        else
+            centerPoint += selectedComponents[i].node.worldPosition;
     }
 
     if (count > 0)


### PR DESCRIPTION
added the node position for components that aren't drawable. sorry about not handle that circumstance.
