### PR TITLE
Add the ability to allow pure script objects that are not created through a ScriptInstance to handle events

### DIFF
--- a/Source/Engine/Script/ScriptEventListener.cpp
+++ b/Source/Engine/Script/ScriptEventListener.cpp
@@ -1,0 +1,65 @@
+//
+// Copyright (c) 2008-2013 the Urho3D project.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include "Precompiled.h"
+#include "ScriptEventListener.h"
+
+#include <angelscript.h>
+
+namespace Urho3D
+{
+
+ScriptEventData::ScriptEventData(asIScriptFunction* function, asIScriptObject* object) :
+    sharedbool_(0),
+    function_(function),
+    object_(object)
+{
+    if (object_)
+    {
+        sharedbool_ = object_->GetEngine()->GetWeakRefFlagOfScriptObject(object_, object_->GetObjectType());
+        if (sharedbool_)
+            sharedbool_->AddRef();
+    }
+}
+
+ScriptEventData::~ScriptEventData()
+{
+    if (sharedbool_)
+        sharedbool_->Release();
+
+    sharedbool_ = 0;
+    function_ = 0;
+    object_ = 0;
+}
+
+bool ScriptEventData::IsObjectAlive() const
+{
+    if (sharedbool_)
+    {
+        // Return inverse as Get returns true when an asIScriptObject is dead.
+        return !sharedbool_->Get();
+    }
+
+    return true;
+}
+
+}

--- a/Source/Engine/Script/ScriptEventListener.h
+++ b/Source/Engine/Script/ScriptEventListener.h
@@ -24,13 +24,17 @@
 
 #include "Object.h"
 
+class asILockableSharedBool;
+class asIScriptFunction;
+class asIScriptObject;
+
 namespace Urho3D
 {
 
 /// Delay-executed function or method call.
 struct DelayedCall
 {
-   /// Period for repeating calls.
+    /// Period for repeating calls.
     float period_;
     /// Delay time remaining until execution.
     float delay_;
@@ -48,10 +52,34 @@ class URHO3D_API ScriptEventListener
 public:
     /// Destruct
     virtual ~ScriptEventListener() {};
+
     /// Add a scripted event handler. Called by script exposed version of SubscribeToEvent().
     virtual void AddEventHandler(StringHash eventType, const String& handlerName) = 0;
     /// Add a scripted event handler for a specific sender. Called by script exposed version of SubscribeToEvent().
     virtual void AddEventHandler(Object* sender, StringHash eventType, const String& handlerName) = 0;
+};
+
+/// Holds the data required to send events to scripts.
+class URHO3D_API ScriptEventData : public RefCounted
+{
+public:
+    /// Constructor, will create the asILockableSharedBool if a ScriptObject is passed in.
+    ScriptEventData(asIScriptFunction* function, asIScriptObject* object = 0);
+    /// Destructor, release the ref it we still hold it.
+    ~ScriptEventData();
+
+    /// Get the asIScriptFunction to call.
+    asIScriptFunction* GetFunction() const { return function_; }
+    /// Get the asIScriptObject to call the method on, can be null.
+    asIScriptObject* GetObject() const { return object_; }
+
+    /// Returns whether a ScriptObject is still alive. Will return true if there is no reference and object.
+    bool IsObjectAlive() const;
+
+private:
+    asILockableSharedBool* sharedbool_;
+    asIScriptFunction* function_;
+    asIScriptObject* object_;
 };
 
 }

--- a/Source/Engine/Script/ScriptFile.h
+++ b/Source/Engine/Script/ScriptFile.h
@@ -55,6 +55,7 @@ public:
     
     /// Load resource. Return true if successful.
     virtual bool Load(Deserializer& source);
+
     /// Add an event handler. Called by script exposed version of SubscribeToEvent().
     virtual void AddEventHandler(StringHash eventType, const String& handlerName);
     /// Add an event handler for a specific sender. Called by script exposed version of SubscribeToEvent().
@@ -116,6 +117,8 @@ private:
     HashMap<asIObjectType*, HashMap<String, asIScriptFunction*> > methods_;
     /// Delayed function calls.
     Vector<DelayedCall> delayedCalls_;
+    /// ScriptEventData objects that this ScriptFile is subscribed with.
+    Vector< SharedPtr<ScriptEventData> > scriptEventData_;
 };
 
 /// Get currently executing script file.

--- a/Source/Engine/Script/ScriptInstance.cpp
+++ b/Source/Engine/Script/ScriptInstance.cpp
@@ -860,12 +860,12 @@ Scene* GetScriptContextScene()
 
 ScriptEventListener* GetScriptContextEventListener()
 {
-    // If context's this pointer is non-null, try to get the script instance. Else get the script file for procedural
-    // event handling
+    // If the context has an object and that object has user data set, try and get the ScriptInstance, otherwise try and get a ScriptFile.
     asIScriptContext* context = asGetActiveContext();
     if (context)
     {
-        if (context->GetThisPointer())
+        asIScriptObject* object = static_cast<asIScriptObject*>(context->GetThisPointer());
+        if (object && object->GetUserData())
             return GetScriptContextInstance();
         else
             return GetScriptContextFile();

--- a/Source/Engine/Script/ScriptInstance.h
+++ b/Source/Engine/Script/ScriptInstance.h
@@ -76,6 +76,7 @@ public:
     virtual void ApplyAttributes();
     /// Handle enabled/disabled state change.
     virtual void OnSetEnabled();
+
     /// Add an event handler. Called by script exposed version of SubscribeToEvent().
     virtual void AddEventHandler(StringHash eventType, const String& handlerName);
     /// Add an event handler for a specific sender. Called by script exposed version of SubscribeToEvent().


### PR DESCRIPTION
This works like it currently does using:

```
SubscribeToEvent("Foo","FooHandler");
```

Where if called inside a procedural function the ScriptFile will handle it, if called inside an object if that object was created through a ScriptInstance that ScriptInstance will handle the event, otherwise the ScriptFile associated with the current script module will handle it.

There is one caveat with this, you can't have multiple objects have the same event with no sender specified ie:

```
class Foo()
{
     ...
    Foo()
    {
        SubscribeToEvent("Update","FooUpdateHandler");
    }
    ...
}

class Bar()
{
    ...
    Bar()
    {
        SubscribeToEvent("Update","BarUpdateHandler");
    }
    ...
}

Foo@ foo;
Bar@ bar;

void Start()
{
    @foo = Foo();
    @bar = Bar();
}
```

Only Bar's event hanlder would be called as Foo's handler would be erased.

This also make starting directly in objects when using a ScriptFile easier, as that main object can handle all necessary events like Update and pass them down the chain instead of requiring a procedural function to do so meaning no global object declarations are necessary. 

```
scriptFile_ = GetSubsystem<ResourceCache>()->GetResource<ScriptFile>("Scripts/Editor.as");

if (scriptFile_)
    scriptObject_ = scriptFile_->CreateObject("Editor");

// If script loading is successful, proceed to main loop
if (scriptObject_ && scriptFile_->Execute(scriptObject_, "void Start()"))
```

~~(No hints as what's in the process of being re-written with this change)~~
