### PR TITLE
Don't cache geometry with dynamic vertex buffers.

### DIFF
--- a/Source/Engine/Physics/CollisionShape.cpp
+++ b/Source/Engine/Physics/CollisionShape.cpp
@@ -36,6 +36,7 @@
 #include "RigidBody.h"
 #include "Scene.h"
 #include "Terrain.h"
+#include "VertexBuffer.h"
 
 #include <BulletCollision/CollisionDispatch/btInternalEdgeUtility.h>
 #include <BulletCollision/CollisionShapes/btBoxShape.h>
@@ -888,7 +889,29 @@ void CollisionShape::UpdateShape()
                 else
                 {
                     geometry_ = new TriangleMeshData(model_, lodLevel_);
-                    cache[id] = geometry_;
+                    // Check if any geometry has a dynamic vertex buffer
+                    bool dynamic = false;
+                    unsigned numGeometries = model_->GetNumGeometries();
+                    for (unsigned i = 0; i < numGeometries; ++i)
+                    {
+                        Geometry* geometry = model_->GetGeometry(i, lodLevel_);
+                        if (!geometry)
+                            continue;
+                        unsigned numVertexBuffers = geometry->GetNumVertexBuffers();
+                        for(unsigned j = 0; j < numVertexBuffers; ++j)
+                        {
+                            VertexBuffer* buffer = geometry->GetVertexBuffer(j);
+                            if(!buffer)
+                                continue;
+                            if(buffer->IsDynamic())
+                                dynamic = true;
+                        }
+                    }
+                    // Don't cache geometry with dynamic vertex buffers
+                    if(!dynamic)
+                    {
+                        cache[id] = geometry_;
+                    }
                 }
                 
                 TriangleMeshData* triMesh = static_cast<TriangleMeshData*>(geometry_.Get());
@@ -925,7 +948,29 @@ void CollisionShape::UpdateShape()
                 else
                 {
                     geometry_ = new ConvexData(model_, lodLevel_);
-                    cache[id] = geometry_;
+                    // Check if any geometry has a dynamic vertex buffer
+                    bool dynamic = false;
+                    unsigned numGeometries = model_->GetNumGeometries();
+                    for (unsigned i = 0; i < numGeometries; ++i)
+                    {
+                        Geometry* geometry = model_->GetGeometry(i, lodLevel_);
+                        if (!geometry)
+                            continue;
+                        unsigned numVertexBuffers = geometry->GetNumVertexBuffers();
+                        for(unsigned j = 0; j < numVertexBuffers; ++j)
+                        {
+                            VertexBuffer* buffer = geometry->GetVertexBuffer(j);
+                            if(!buffer)
+                                continue;
+                            if(buffer->IsDynamic())
+                                dynamic = true;
+                        }
+                    }
+                    // Don't cache geometry with dynamic vertex buffers
+                    if(!dynamic)
+                    {
+                        cache[id] = geometry_;
+                    }
                 }
                 
                 ConvexData* convex = static_cast<ConvexData*>(geometry_.Get());


### PR DESCRIPTION
CollisionShape's for Triangle and Convex meshes are cached.  Vertex buffers marked as Dynamic will change frequently so arguably shouldn't be cached anyway; this patch prevents caching of dynamic geometry.
