### PR TITLE
Added Asynchronous Resource Loading using WorkItems.

### DIFF
--- a/Source/Engine/Core/CoreEvents.h
+++ b/Source/Engine/Core/CoreEvents.h
@@ -63,4 +63,10 @@ EVENT(E_ENDFRAME, EndFrame)
 {
 }
 
+/// Work item completed event.
+EVENT(E_WORKITEMCOMPLETED, WorkItemCompleted)
+{
+    PARAM(P_ITEM, Item);                        // WorkItem ptr
+}
+
 }

--- a/Source/Engine/Core/WorkQueue.h
+++ b/Source/Engine/Core/WorkQueue.h
@@ -29,12 +29,6 @@
 namespace Urho3D
 {
 
-/// Work item completed event.
-EVENT(E_WORKITEMCOMPLETED, WorkItemCompleted)
-{
-    PARAM(P_ITEM, Item);                        // WorkItem ptr
-}
-
 class WorkerThread;
 
 /// Work queue item.

--- a/Source/Engine/Resource/ResourceEvents.h
+++ b/Source/Engine/Resource/ResourceEvents.h
@@ -42,4 +42,10 @@ EVENT(E_RELOADFAILED, ReloadFailed)
 {
 }
 
+/// Resource loaded asynchronously.
+EVENT(E_RESOURCELOADEDASYNC, ResourceLoadedAsync)
+{
+    PARAM(P_NAME, Name);            //Name of the resource as a String
+}
+
 }


### PR DESCRIPTION
Not the most elegant of solutions, but wanted to stick to using the WorkItem structure. Works along the following lines:

``` C++
loadingResources_.Push("Objects/LightFlash.xml");
loadingResources_.Push("Objects/Ninja.xml");
loadingResources_.Push("Objects/Potion.xml");
loadingResources_.Push("Objects/SnowBall.xml");
loadingResources_.Push("Objects/SnowCrate.xml");

SubscribeToEvent(E_RESOURCELOADEDASYNC, HANDLER(Urho3DPlayer, HandleResourceLoaded));
```

``` C++
ResourceCache* rc = GetSubsystem<ResourceCache>();

for (unsigned i = 0; i < loadingResources_.Size(); ++i)
{
    rc->LoadResourceAsync<XMLFile>(loadingResources_[i]);
}
```

``` C++
using namespace ResourceLoadedAsync;

loadingResources_.Remove(eventData[P_NAME].GetString());

if (!loadingResources_.Size())
{
    ...
}
```

It was done this way because firstly, there is no way to use the volatile bool from the WorkItem to track when a WorkItem has been completed because as soon as your copy is added to the WorkQueue its switched from your created WorkItem to one added to the Main Thread container. _This may just be from extreme lack of sleep in my testing, but I think thats the case._

Secondly since references and iterators for the container holding what resource to load can be invalidated at anytime by removing or adding there was no point passing them with the WorkItem.

I did toy with the idea of limiting the number of mutexs in general operation and adding all resources that have been completed to the resources groups at the start of the next frame and so not needing mutexs on the resource groups at all, but considering how much the ResourceCache will be used during actual game play, I don't think it will be an issue (please correct me here if you feel differently).
