### PR TITLE
Use color Clang diagnostics when using Ninja build system

### DIFF
--- a/Source/CMake/Modules/Urho3D-CMake-magic.cmake
+++ b/Source/CMake/Modules/Urho3D-CMake-magic.cmake
@@ -241,6 +241,10 @@ else ()
         set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DDEBUG -D_DEBUG")
         set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG -D_DEBUG")
     endif ()
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_GENERATOR STREQUAL "Ninja")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fcolor-diagnostics")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcolor-diagnostics")
+    endif()
 endif ()
 
 # Include CMake builtin module for building shared library support


### PR DESCRIPTION
I was testing the Ninja build system and noticed that the Clang diagnostics were monochrome.  This patch forces Clang to use color diagnostics when used with Ninja.
