### PR TITLE
Add support for SDL2 GameControllers

### DIFF
--- a/Source/Engine/Graphics/Direct3D9/D3D9Graphics.cpp
+++ b/Source/Engine/Graphics/Direct3D9/D3D9Graphics.cpp
@@ -204,7 +204,7 @@ Graphics::Graphics(Context* context) :
     SetTextureUnitMappings();
     
     // Initialize SDL now. Graphics should be the first SDL-using subsystem to be created
-    SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK | SDL_INIT_NOPARACHUTE);
+    SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER | SDL_INIT_NOPARACHUTE);
     
     // Register Graphics library object factories
     RegisterGraphicsLibrary(context_);

--- a/Source/Engine/Graphics/OpenGL/OGLGraphics.cpp
+++ b/Source/Engine/Graphics/OpenGL/OGLGraphics.cpp
@@ -189,7 +189,7 @@ Graphics::Graphics(Context* context_) :
     ResetCachedState();
     
     // Initialize SDL now. Graphics should be the first SDL-using subsystem to be created
-    SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK | SDL_INIT_NOPARACHUTE);
+    SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER | SDL_INIT_NOPARACHUTE);
     
     // Register Graphics library object factories
     RegisterGraphicsLibrary(context_);

--- a/Source/Engine/Input/Input.h
+++ b/Source/Engine/Input/Input.h
@@ -52,7 +52,7 @@ struct JoystickState
 {
     /// Construct with defaults.
     JoystickState() :
-        joystick_(0)
+        joystick_(0), controller_(0)
     {
     }
     
@@ -101,6 +101,8 @@ struct JoystickState
     
     /// SDL joystick.
     SDL_Joystick* joystick_;
+    /// SDL game controller
+    SDL_GameController* controller_;
     /// Joystick name.
     String name_;
     /// Button up/down state.

--- a/Source/Engine/Input/InputEvents.h
+++ b/Source/Engine/Input/InputEvents.h
@@ -25,6 +25,7 @@
 #include "Object.h"
 
 #include <SDL_joystick.h>
+#include <SDL_gamecontroller.h>
 #include <SDL_keycode.h>
 
 namespace Urho3D
@@ -148,6 +149,28 @@ EVENT(E_JOYSTICKHATMOVE, JoystickHatMove)
     PARAM(P_POSITION, Position);            // int
 }
 
+/// Controller button pressed
+EVENT(E_CONTROLLERBUTTONDOWN, ControllerButtonDown)
+{
+    PARAM(P_JOYSTICK, Joystick);            // int
+    PARAM(P_BUTTON, Button);                // int
+}
+
+/// Controller button released.
+EVENT(E_CONTROLLERBUTTONUP, ControllerButtonUp)
+{
+    PARAM(P_JOYSTICK, Joystick);            // int
+    PARAM(P_BUTTON, Button);                // int
+}
+
+/// Controller axis moved.
+EVENT(E_CONTROLLERAXISMOVE, ControllerAxisMove)
+{
+    PARAM(P_JOYSTICK, Joystick);            // int
+    PARAM(P_AXIS, Button);                  // int
+    PARAM(P_POSITION, Position);            // float
+}
+
 /// A file was drag-dropped into the application window.
 EVENT(E_DROPFILE, DropFile)
 {
@@ -261,5 +284,28 @@ static const int HAT_UP = SDL_HAT_UP;
 static const int HAT_RIGHT = SDL_HAT_RIGHT;
 static const int HAT_DOWN = SDL_HAT_DOWN;
 static const int HAT_LEFT = SDL_HAT_LEFT;
+
+static const int CONTROLLER_BUTTON_A = SDL_CONTROLLER_BUTTON_A;
+static const int CONTROLLER_BUTTON_B = SDL_CONTROLLER_BUTTON_B;
+static const int CONTROLLER_BUTTON_X = SDL_CONTROLLER_BUTTON_X;
+static const int CONTROLLER_BUTTON_Y = SDL_CONTROLLER_BUTTON_Y;
+static const int CONTROLLER_BUTTON_BACK = SDL_CONTROLLER_BUTTON_BACK;
+static const int CONTROLLER_BUTTON_GUIDE = SDL_CONTROLLER_BUTTON_GUIDE;
+static const int CONTROLLER_BUTTON_START = SDL_CONTROLLER_BUTTON_START;
+static const int CONTROLLER_BUTTON_LEFTSTICK = SDL_CONTROLLER_BUTTON_LEFTSTICK;
+static const int CONTROLLER_BUTTON_RIGHTSTICK = SDL_CONTROLLER_BUTTON_RIGHTSTICK;
+static const int CONTROLLER_BUTTON_LEFTSHOULDER = SDL_CONTROLLER_BUTTON_LEFTSHOULDER;
+static const int CONTROLLER_BUTTON_RIGHTSHOULDER = SDL_CONTROLLER_BUTTON_RIGHTSHOULDER;
+static const int CONTROLLER_BUTTON_DPAD_UP = SDL_CONTROLLER_BUTTON_DPAD_UP;
+static const int CONTROLLER_BUTTON_DPAD_DOWN = SDL_CONTROLLER_BUTTON_DPAD_DOWN;
+static const int CONTROLLER_BUTTON_DPAD_LEFT = SDL_CONTROLLER_BUTTON_DPAD_LEFT;
+static const int CONTROLLER_BUTTON_DPAD_RIGHT = SDL_CONTROLLER_BUTTON_DPAD_RIGHT;
+
+static const int CONTROLLER_AXIS_LEFTX = SDL_CONTROLLER_AXIS_LEFTX;
+static const int CONTROLLER_AXIS_LEFTY = SDL_CONTROLLER_AXIS_LEFTY;
+static const int CONTROLLER_AXIS_RIGHTX = SDL_CONTROLLER_AXIS_RIGHTX;
+static const int CONTROLLER_AXIS_RIGHTY = SDL_CONTROLLER_AXIS_RIGHTY;
+static const int CONTROLLER_AXIS_TRIGGERLEFT = SDL_CONTROLLER_AXIS_TRIGGERLEFT;
+static const int CONTROLLER_AXIS_TRIGGERRIGHT = SDL_CONTROLLER_AXIS_TRIGGERRIGHT;
 
 }


### PR DESCRIPTION
This is mostly the same as the current joystick code.  However, the SDL game controller code maps buttons to a predefined interface, which is more convenient.

E_CONTROLLERBUTTONDOWN, E_CONTROLLERBUTTONUP, and E_CONTROLLERAXISMOVE are the new events added.

Button returned can be determined by the following variables:
CONTROLLER_BUTTON_A
CONTROLLER_BUTTON_B
CONTROLLER_BUTTON_X
CONTROLLER_BUTTON_Y
CONTROLLER_BUTTON_BACK
CONTROLLER_BUTTON_GUIDE
CONTROLLER_BUTTON_START
CONTROLLER_BUTTON_LEFTSTICK
CONTROLLER_BUTTON_RIGHTSTICK
CONTROLLER_BUTTON_LEFTSHOULDER
CONTROLLER_BUTTON_RIGHTSHOULDER
CONTROLLER_BUTTON_DPAD_UP
CONTROLLER_BUTTON_DPAD_DOWN
CONTROLLER_BUTTON_DPAD_LEFT
CONTROLLER_BUTTON_DPAD_RIGHT

Axis returned can be determined by the following variables:
CONTROLLER_AXIS_LEFTX
CONTROLLER_AXIS_LEFTY
CONTROLLER_AXIS_RIGHTX
CONTROLLER_AXIS_RIGHTY
CONTROLLER_AXIS_TRIGGERLEFT
CONTROLLER_AXIS_TRIGGERRIGHT

Tested on an Xbox 360 controller and it worked correctly.

Feature request here: https://github.com/urho3d/Urho3D/issues/21
