### PR TITLE
Expose Image constructor to LuaScript

### DIFF
--- a/Source/Engine/LuaScript/pkgs/Resource/Image.pkg
+++ b/Source/Engine/LuaScript/pkgs/Resource/Image.pkg
@@ -15,6 +15,8 @@ enum CompressedFormat
 
 class Image : public Resource
 {
+    Image();
+    ~Image();
     void FlipVertical();
     bool SaveBMP(const String fileName);
     bool SavePNG(const String fileName);
@@ -36,3 +38,17 @@ class Image : public Resource
     tolua_readonly tolua_property__get_set CompressedFormat compressedFormat;
     tolua_readonly tolua_property__get_set unsigned numCompressedLevels;
 };
+
+${
+#define TOLUA_DISABLE_tolua_ResourceLuaAPI_Image_new00
+static int tolua_ResourceLuaAPI_Image_new00(lua_State* tolua_S)
+{
+    return ToluaNewObject<Image>(tolua_S);
+}
+
+#define TOLUA_DISABLE_tolua_ResourceLuaAPI_Image_new00_local
+static int tolua_ResourceLuaAPI_Image_new00_local(lua_State* tolua_S)
+{
+    return ToluaNewObjectGC<Image>(tolua_S);
+}
+$}


### PR DESCRIPTION
In order to take a screenshot from Lua, expose the constructor for Image so that an image may be created to be passed to TakeScreenShot().
