### PR TITLE
Fixed OgreImporter link problems on OS X

### DIFF
--- a/Source/Tools/OgreImporter/CMakeLists.txt
+++ b/Source/Tools/OgreImporter/CMakeLists.txt
@@ -28,6 +28,6 @@ define_source_files ()
 
 # Setup target
 if (APPLE)
-    set (CMAKE_EXE_LINKER_FLAGS "-framework Foundation -framework CoreServices")
+    setup_macosx_linker_flags (CMAKE_EXE_LINKER_FLAGS)
 endif ()
 setup_executable ()


### PR DESCRIPTION
OgreImporter fail to link on OS X because of missing frameworks. This pull request adds the correct frameworks by using the setup_macosx_linker_flags() macro.
