### PR TITLE
Refactor WorkItem to use a SharedPtr implementation

### DIFF
--- a/Source/Engine/Core/WorkQueue.h
+++ b/Source/Engine/Core/WorkQueue.h
@@ -38,7 +38,7 @@ EVENT(E_WORKITEMCOMPLETED, WorkItemCompleted)
 class WorkerThread;
 
 /// Work queue item.
-struct WorkItem
+struct WorkItem : public RefCounted
 {
     // Construct
     WorkItem() :
@@ -80,7 +80,7 @@ public:
     /// Create worker threads. Can only be called once.
     void CreateThreads(unsigned numThreads);
     /// Add a work item and resume worker threads.
-    void AddWorkItem(const WorkItem& item);
+    void AddWorkItem(SharedPtr<WorkItem> item);
     /// Pause worker threads.
     void Pause();
     /// Resume worker threads.
@@ -104,7 +104,7 @@ private:
     /// Worker threads.
     Vector<SharedPtr<WorkerThread> > threads_;
     /// Work item collection. Accessed only by the main thread.
-    List<WorkItem> workItems_;
+    List<SharedPtr<WorkItem> > workItems_;
     /// Work item prioritized queue for worker threads. Pointers are guaranteed to be valid (point to workItems.)
     List<WorkItem*> queue_;
     /// Worker queue mutex.

--- a/Source/Engine/Graphics/Octree.cpp
+++ b/Source/Engine/Graphics/Octree.cpp
@@ -406,20 +406,20 @@ void Octree::Update(const FrameInfo& frame)
         int numWorkItems = queue->GetNumThreads() + 1; // Worker threads + main thread
         int drawablesPerItem = drawableUpdates_.Size() / numWorkItems;
         
-        WorkItem item;
-        item.workFunction_ = UpdateDrawablesWork;
-        item.aux_ = const_cast<FrameInfo*>(&frame);
-
         PODVector<Drawable*>::Iterator start = drawableUpdates_.Begin();
         // Create a work item for each thread
         for (int i = 0; i < numWorkItems; ++i)
         {
+            SharedPtr<WorkItem> item(new WorkItem());
+            item->workFunction_ = UpdateDrawablesWork;
+            item->aux_ = const_cast<FrameInfo*>(&frame);
+
             PODVector<Drawable*>::Iterator end = drawableUpdates_.End();
             if (i < numWorkItems - 1 && end - start > drawablesPerItem)
                 end = start + drawablesPerItem;
 
-            item.start_ = &(*start);
-            item.end_ = &(*end);
+            item->start_ = &(*start);
+            item->end_ = &(*end);
             queue->AddWorkItem(item);
 
             start = end;
@@ -526,19 +526,19 @@ void Octree::Raycast(RayOctreeQuery& query) const
             for (unsigned i = 0; i < rayQueryResults_.Size(); ++i)
                 rayQueryResults_[i].Clear();
 
-            WorkItem item;
-            item.workFunction_ = RaycastDrawablesWork;
-            item.aux_ = const_cast<Octree*>(this);
-
             PODVector<Drawable*>::Iterator start = rayQueryDrawables_.Begin();
             while (start != rayQueryDrawables_.End())
             {
+                SharedPtr<WorkItem> item(new WorkItem());
+                item->workFunction_ = RaycastDrawablesWork;
+                item->aux_ = const_cast<Octree*>(this);
+
                 PODVector<Drawable*>::Iterator end = rayQueryDrawables_.End();
                 if (end - start > RAYCASTS_PER_WORK_ITEM)
                     end = start + RAYCASTS_PER_WORK_ITEM;
 
-                item.start_ = &(*start);
-                item.end_ = &(*end);
+                item->start_ = &(*start);
+                item->end_ = &(*end);
                 queue->AddWorkItem(item);
 
                 start = end;


### PR DESCRIPTION
WorkItems now take in a SharedPtr to allow tracking and usage of the complete volatile boolean, e.g:

``` c++
                SharedPtr<WorkItem> item(new WorkItem());
                item->workFunction_ = UpdateDrawableGeometriesWork;
                item->aux_ = const_cast<FrameInfo*>(&frame_);
                item->start_ = &(*start);
                item->end_ = &(*end);
                queue->AddWorkItem(item);
```
