### PR TITLE
Added Pool for WorkQueue WorkItems

### DIFF
--- a/Source/Engine/Core/WorkQueue.h
+++ b/Source/Engine/Core/WorkQueue.h
@@ -79,6 +79,8 @@ public:
     
     /// Create worker threads. Can only be called once.
     void CreateThreads(unsigned numThreads);
+    /// Get next free WorkItem Ptr.
+    SharedPtr<WorkItem> GetFreeItem();
     /// Add a work item and resume worker threads.
     void AddWorkItem(SharedPtr<WorkItem> item);
     /// Pause worker threads.
@@ -98,11 +100,15 @@ private:
     void ProcessItems(unsigned threadIndex);
     /// Purge completed work items and send completion events as necessary.
     void PurgeCompleted();
+    /// Purge the pool to reduce allocation where its unneeded.
+    void PurgePool();
     /// Handle frame start event. Purge completed work from the main thread queue, and perform work if no threads at all.
     void HandleBeginFrame(StringHash eventType, VariantMap& eventData);
     
     /// Worker threads.
     Vector<SharedPtr<WorkerThread> > threads_;
+    /// Work item pool for reuse to cut down on allocation. The bool is a flag for item pooling and whether it is available or not.
+    HashMap<SharedPtr<WorkItem>, bool> itemPool_;
     /// Work item collection. Accessed only by the main thread.
     List<SharedPtr<WorkItem> > workItems_;
     /// Work item prioritized queue for worker threads. Pointers are guaranteed to be valid (point to workItems.)

--- a/Source/Engine/Graphics/Octree.cpp
+++ b/Source/Engine/Graphics/Octree.cpp
@@ -410,7 +410,7 @@ void Octree::Update(const FrameInfo& frame)
         // Create a work item for each thread
         for (int i = 0; i < numWorkItems; ++i)
         {
-            SharedPtr<WorkItem> item(new WorkItem());
+            SharedPtr<WorkItem> item = queue->GetFreeItem();
             item->workFunction_ = UpdateDrawablesWork;
             item->aux_ = const_cast<FrameInfo*>(&frame);
 
@@ -529,7 +529,7 @@ void Octree::Raycast(RayOctreeQuery& query) const
             PODVector<Drawable*>::Iterator start = rayQueryDrawables_.Begin();
             while (start != rayQueryDrawables_.End())
             {
-                SharedPtr<WorkItem> item(new WorkItem());
+                SharedPtr<WorkItem> item = queue->GetFreeItem();
                 item->workFunction_ = RaycastDrawablesWork;
                 item->aux_ = const_cast<Octree*>(this);
 

--- a/Source/Engine/Graphics/View.cpp
+++ b/Source/Engine/Graphics/View.cpp
@@ -691,7 +691,7 @@ void View::GetDrawables()
         // Create a work item for each thread
         for (int i = 0; i < numWorkItems; ++i)
         {
-            SharedPtr<WorkItem> item(new WorkItem());
+            SharedPtr<WorkItem> item = queue->GetFreeItem();
             item->workFunction_ = CheckVisibilityWork;
             item->aux_ = this;
 
@@ -764,7 +764,7 @@ void View::GetBatches()
         
         for (unsigned i = 0; i < lightQueryResults_.Size(); ++i)
         {
-            SharedPtr<WorkItem> item(new WorkItem());
+            SharedPtr<WorkItem> item = queue->GetFreeItem();
             item->workFunction_ = ProcessLightWork;
             item->aux_ = this;
 
@@ -1059,7 +1059,7 @@ void View::UpdateGeometries()
             {
                 BatchQueue* passQueue = &batchQueues_[command.pass_];
                 
-                SharedPtr<WorkItem> item(new WorkItem());
+                SharedPtr<WorkItem> item = queue->GetFreeItem();
                 item->workFunction_ = command.sortMode_ == SORT_FRONTTOBACK ? SortBatchQueueFrontToBackWork : SortBatchQueueBackToFrontWork;
                 item->start_ = &batchQueues_[command.pass_];
                 queue->AddWorkItem(item);
@@ -1068,14 +1068,14 @@ void View::UpdateGeometries()
         
         for (Vector<LightBatchQueue>::Iterator i = lightQueues_.Begin(); i != lightQueues_.End(); ++i)
         {
-            SharedPtr<WorkItem> lightItem(new WorkItem());
+            SharedPtr<WorkItem> lightItem = queue->GetFreeItem();
             lightItem->workFunction_ = SortLightQueueWork;
             lightItem->start_ = &(*i);
             queue->AddWorkItem(lightItem);
 
             if (i->shadowSplits_.Size())
             {
-                SharedPtr<WorkItem> shadowItem(new WorkItem());
+                SharedPtr<WorkItem> shadowItem = queue->GetFreeItem();
                 shadowItem->workFunction_ = SortShadowQueueWork;
                 shadowItem->start_ = &(*i);
                 queue->AddWorkItem(shadowItem);
@@ -1117,7 +1117,7 @@ void View::UpdateGeometries()
                 if (i < numWorkItems - 1 && end - start > drawablesPerItem)
                     end = start + drawablesPerItem;
                 
-                SharedPtr<WorkItem> item(new WorkItem());
+                SharedPtr<WorkItem> item = queue->GetFreeItem();
                 item->workFunction_ = UpdateDrawableGeometriesWork;
                 item->aux_ = const_cast<FrameInfo*>(&frame_);
                 item->start_ = &(*start);


### PR DESCRIPTION
This is an optional construct to allow the user to create their own pools or not use the pool if they so desire.

To use the pooled allocation it works like so:

``` C++
SharedPtr<WorkItem> item = WorkQueue::GetFreeItem();
// Set Item Variables.
WorkQueue::AddWorkItem(item);
```
