### PR TITLE
Fix for vegetation vertex shader variable naming typo (GLSL)

### DIFF
--- a/Bin/CoreData/Shaders/GLSL/Vegetation.glsl
+++ b/Bin/CoreData/Shaders/GLSL/Vegetation.glsl
@@ -30,7 +30,7 @@ varying vec2 vTexCoord;
         varying vec3 vCubeMaskVec;
     #endif
 #else
-    varying vec4 vglslexLight;
+    varying vec4 vVertexLight;
     varying vec3 vNormal;
     #ifdef NORMALMAP
         varying vec3 vTangent;
@@ -109,12 +109,12 @@ void VS()
             #endif
         #endif
     #else
-        // Ambient & per-glslex lighting
-        vglslexLight = vec4(GetAmbient(GetZonePos(worldPos)), GetDepth(gl_Position));
-
-        #ifdef NUMglslEXLIGHTS
-            for (int i = 0; i < NUMglslEXLIGHTS; ++i)
-                vglslexLight.rgb += GetglslexLight(i, worldPos, vNormal) * cglslexLights[i * 3].rgb;
+        // Ambient & per-vertex lighting
+        vVertexLight = vec4(GetAmbient(GetZonePos(worldPos)), GetDepth(gl_Position));
+        
+        #ifdef NUMVERTEXLIGHTS
+            for (int i = 0; i < NUMVERTEXLIGHTS; ++i)
+                vVertexLight.rgb += GetVertexLight(i, worldPos, vNormal) * cVertexLights[i * 3].rgb;
         #endif
         
         vScreenPos = GetScreenPos(gl_Position);


### PR DESCRIPTION
Discovered that the vegetation shader (swaying in the wind vertex shader) had a wrong variable name in it that was probably forgotten in the shader refactoring project. This version is working (for me at least).

Before:
![before](https://f.cloud.github.com/assets/143604/2181078/f7df813e-9741-11e3-9fe5-6e8cca533897.png)

After:
![after](https://f.cloud.github.com/assets/143604/2181080/00cbb4e8-9742-11e3-9cec-202b269060ae.png)

Note that the same problem might exist in the HLSL shaders - I have not looked at those.
