### PR TITLE
Fixed shader error: '*' does not operate on 'int' and 'vec2' in PostProcess.glsl

### DIFF
--- a/Bin/CoreData/Shaders/GLSL/PostProcess.glsl
+++ b/Bin/CoreData/Shaders/GLSL/PostProcess.glsl
@@ -29,8 +29,8 @@ vec4 GaussianBlur(int blurKernelSize, vec2 blurDir, vec2 blurRadius, float sigma
 
     for (int i = 1; i <= blurKernelSizeHalfSize; i++)
     {
-        avgValue += texture2D(texSampler, texCoord - i * blurVec) * gaussCoeff.x;
-        avgValue += texture2D(texSampler, texCoord + i * blurVec) * gaussCoeff.x;
+        avgValue += texture2D(texSampler, texCoord - float(i) * blurVec) * gaussCoeff.x;
+        avgValue += texture2D(texSampler, texCoord + float(i) * blurVec) * gaussCoeff.x;
 
         gaussCoeffSum += 2.0 * gaussCoeff.x;
         gaussCoeff.xy *= gaussCoeff.yz;


### PR DESCRIPTION
Tested on Mac OS X 10.8.5 (AMD Radeon HD 6630M).
