### PR TITLE
Set editor script to windowed/scalable by default if no parameters specified

### DIFF
--- a/Bin/Editor.bat
+++ b/Bin/Editor.bat
@@ -1,1 +1,9 @@
-Urho3DPlayer.exe Scripts/Editor.as %*
+@ECHO OFF
+
+IF [%1] == [] (
+        Urho3DPlayer.exe Scripts/Editor.as -w -s
+        )
+
+IF NOT [%1] == [] (
+        Urho3DPlayer.exe Scripts/Editor.as %*
+        )

--- a/Bin/Editor.sh
+++ b/Bin/Editor.sh
@@ -1,1 +1,6 @@
-$( dirname $0 )/Urho3DPlayer Scripts/Editor.as $@
+if [ $# -eq 0 ]
+then
+    $( dirname $0 )/Urho3DPlayer Scripts/Editor.as -w -s
+else
+    $( dirname $0 )/Urho3DPlayer Scripts/Editor.as $@
+fi


### PR DESCRIPTION
Its kind of opinionated but if a new comer doesn't know about the command line args or if you are launching via double click or something you get fullscreen when you probably want windowed with re-sizable.  I don't like adding the extra wierdness to the script which may confuse people.  I think this might be the lesser of 2 evils.  Like all my ideas don't feel afraid to shoot em down!
