### PR TITLE
Editor Hierarchy Debug Rendering

### DIFF
--- a/Bin/Data/Scripts/Editor/EditorView.as
+++ b/Bin/Data/Scripts/Editor/EditorView.as
@@ -1307,19 +1307,7 @@ void HandlePostRenderUpdate()
 
     // Visualize the currently selected nodes as their local axes + the first drawable component
     for (uint i = 0; i < selectedNodes.length; ++i)
-    {
-        Node@ node = selectedNodes[i];
-        debug.AddNode(node, 1.0, false);
-        for (uint j = 0; j < node.numComponents; ++j)
-        {
-            Drawable@ drawable = cast<Drawable>(node.components[j]);
-            if (drawable !is null)
-            {
-                drawable.DrawDebugGeometry(debug, false);
-                break;
-            }
-        }
-    }
+        DrawNodeDebug(selectedNodes[i], debug);
 
     // Visualize the currently selected components
     for (uint i = 0; i < selectedComponents.length; ++i)
@@ -1344,6 +1332,16 @@ void HandlePostRenderUpdate()
     }
 
     ViewRaycast(false);
+}
+
+void DrawNodeDebug(Node@ node, DebugRenderer@ debug)
+{
+    debug.AddNode(node, 1.0, false);
+    for (uint j = 0; j < node.numComponents; ++j)
+        node.components[j].DrawDebugGeometry(debug, false);
+    
+    for (uint k = 0; k < node.numChildren; ++k)
+        DrawNodeDebug(node.children[k], debug);
 }
 
 void ViewMouseMove()


### PR DESCRIPTION
Slight change the editor will now draw the entire hierarchy's debug geometry for the selected node. I believe its more useful and brings the editor inline with other engine's editors, feel free to disagree.
