### PR TITLE
Escape cancels ui dragging

### DIFF
--- a/Source/Engine/UI/UI.cpp
+++ b/Source/Engine/UI/UI.cpp
@@ -1282,6 +1282,14 @@ void UI::HandleKeyDown(StringHash eventType, VariantMap& eventData)
     qualifiers_ = eventData[P_QUALIFIERS].GetInt();
     int key = eventData[P_KEY].GetInt();
 
+    // Cancel UI Dragging
+    if (key == KEY_ESC && dragElement_)
+    {
+        dragElement_.Reset();
+        dragBeginPending_ = false;
+        return;
+    }
+
     // Dismiss modal element if any when ESC key is pressed
     if (key == KEY_ESC && HasModalElement())
     {


### PR DESCRIPTION
If you press escape while dragging it cancels the ui element dragging.
