### PR TITLE
Fix incorrect use of PODVector in ValueAnimation, maybe related to #361

### DIFF
--- a/Source/Engine/Scene/ValueAnimation.h
+++ b/Source/Engine/Scene/ValueAnimation.h
@@ -141,13 +141,13 @@ protected:
     /// End time.
     float endTime_;
     /// Key frames.
-    PODVector<VAnimKeyFrame> keyFrames_;
+    Vector<VAnimKeyFrame> keyFrames_;
     /// Spline tangents.
     VariantVector splineTangents_;
     /// Spline tangents dirty.
     bool splineTangentsDirty_;
     /// Event frames.
-    PODVector<VAnimEventFrame> eventFrames_;
+    Vector<VAnimEventFrame> eventFrames_;
 };
 
 }


### PR DESCRIPTION
Indeed VAnimKeyFrame and VAnimEventFrame structures contains objects of types Variant and VariantMap, which may need to call constructors and destructors for memory allocation, so PODVector cannot be used here.
With this fix applied I no longer have any of the segfaults I previously randomly had while using animations.
