### PR TITLE
Completely remove Gather4 from GLSL shader, fix conflicting tags

### DIFF
--- a/Bin/CoreData/Shaders/GLSL/FXAA3.glsl
+++ b/Bin/CoreData/Shaders/GLSL/FXAA3.glsl
@@ -58,7 +58,6 @@ varying vec2 vScreenPos;
 /*--------------------------------------------------------------------------*/
 
 #define FXAA_FAST_PIXEL_OFFSET 0
-#define FXAA_GATHER4 0
 
 /*============================================================================
                         FXAA QUALITY - TUNING KNOBS
@@ -385,25 +384,12 @@ vec4 FxaaPixelShader(
     posM.x = pos.x;
     posM.y = pos.y;
     
-    #if (FXAA_GATHER4 == 1)
-        vec4 rgbyM = FxaaTexTop(tex, posM);
-        vec4 luma4A = FxaaTex4(tex, posM);
-        vec4 luma4B = FxaaTexOff4(tex, posM, vec2(-1, -1));
-        #define lumaM rgbyM.w
-        #define lumaE luma4A.z
-        #define lumaS luma4A.x
-        #define lumaSE luma4A.y
-        #define lumaNW luma4B.w
-        #define lumaN luma4B.z
-        #define lumaW luma4B.x
-    #else
-        vec4 rgbyM = FxaaTexTop(tex, posM);
-        #define lumaM rgbyM.y
-        float lumaS = FxaaLuma(FxaaTexOff(tex, posM, vec2( 0, 1), fxaaQualityRcpFrame.xy));
-        float lumaE = FxaaLuma(FxaaTexOff(tex, posM, vec2( 1, 0), fxaaQualityRcpFrame.xy));
-        float lumaN = FxaaLuma(FxaaTexOff(tex, posM, vec2( 0,-1), fxaaQualityRcpFrame.xy));
-        float lumaW = FxaaLuma(FxaaTexOff(tex, posM, vec2(-1, 0), fxaaQualityRcpFrame.xy));
-    #endif
+    vec4 rgbyM = FxaaTexTop(tex, posM);
+    #define lumaM rgbyM.y
+    float lumaS = FxaaLuma(FxaaTexOff(tex, posM, vec2( 0, 1), fxaaQualityRcpFrame.xy));
+    float lumaE = FxaaLuma(FxaaTexOff(tex, posM, vec2( 1, 0), fxaaQualityRcpFrame.xy));
+    float lumaN = FxaaLuma(FxaaTexOff(tex, posM, vec2( 0,-1), fxaaQualityRcpFrame.xy));
+    float lumaW = FxaaLuma(FxaaTexOff(tex, posM, vec2(-1, 0), fxaaQualityRcpFrame.xy));
 /*--------------------------------------------------------------------------*/
     float maxSM = max(lumaS, lumaM);
     float minSM = min(lumaS, lumaM);
@@ -421,15 +407,10 @@ vec4 FxaaPixelShader(
     if(earlyExit)
         return FxaaTexTop(tex, pos);
 /*--------------------------------------------------------------------------*/
-    #if (FXAA_GATHER4 == 0)
-        float lumaNW = FxaaLuma(FxaaTexOff(tex, posM, vec2(-1,-1), fxaaQualityRcpFrame.xy));
-        float lumaSE = FxaaLuma(FxaaTexOff(tex, posM, vec2( 1, 1), fxaaQualityRcpFrame.xy));
-        float lumaNE = FxaaLuma(FxaaTexOff(tex, posM, vec2( 1,-1), fxaaQualityRcpFrame.xy));
-        float lumaSW = FxaaLuma(FxaaTexOff(tex, posM, vec2(-1, 1), fxaaQualityRcpFrame.xy));
-    #else
-        float lumaNE = FxaaLuma(FxaaTexOff(tex, posM, vec2(1, -1), fxaaQualityRcpFrame.xy));
-        float lumaSW = FxaaLuma(FxaaTexOff(tex, posM, vec2(-1, 1), fxaaQualityRcpFrame.xy));
-    #endif
+    float lumaNW = FxaaLuma(FxaaTexOff(tex, posM, vec2(-1,-1), fxaaQualityRcpFrame.xy));
+    float lumaSE = FxaaLuma(FxaaTexOff(tex, posM, vec2( 1, 1), fxaaQualityRcpFrame.xy));
+    float lumaNE = FxaaLuma(FxaaTexOff(tex, posM, vec2( 1,-1), fxaaQualityRcpFrame.xy));
+    float lumaSW = FxaaLuma(FxaaTexOff(tex, posM, vec2(-1, 1), fxaaQualityRcpFrame.xy));
 /*--------------------------------------------------------------------------*/
     float lumaNS = lumaN + lumaS;
     float lumaWE = lumaW + lumaE;

--- a/Bin/Data/PostProcess/FXAA2.xml
+++ b/Bin/Data/PostProcess/FXAA2.xml
@@ -1,5 +1,5 @@
 <renderpath>
-    <command type="quad" tag="FXAA" vs="FXAA2" ps="FXAA2" output="viewport">
+    <command type="quad" tag="FXAA2" vs="FXAA2" ps="FXAA2" output="viewport">
         <texture unit="diffuse" name="viewport" />
         <parameter name="FXAAParams" value="0.4 0.5 0.75" />
     </command>

--- a/Bin/Data/PostProcess/FXAA3.xml
+++ b/Bin/Data/PostProcess/FXAA3.xml
@@ -1,5 +1,5 @@
 <renderpath>
-    <command type="quad" tag="FXAA" vs="FXAA3" ps="FXAA3" psdefines="FXAA_QUALITY_PRESET=12" output="viewport">
+    <command type="quad" tag="FXAA3" vs="FXAA3" ps="FXAA3" psdefines="FXAA_QUALITY_PRESET=12" output="viewport">
         <texture unit="diffuse" name="viewport" />
     </command>
 </renderpath>


### PR DESCRIPTION
Gather4: Since the actual functions have been removed, it will not work if it is enabled, so it can be completely removed.

Tags: In case someone wants to activate one or the other (I immediately ran into that problem :P).
