### PR TITLE
Fix C4512 ("'class' : assignment operator could not be generated", MSVC warning level 4) compiler warnings that leak into applications using Urho.

### DIFF
--- a/Source/Engine/Container/HashMap.h
+++ b/Source/Engine/Container/HashMap.h
@@ -62,6 +62,10 @@ public:
         const T first_;
         /// Value.
         U second_;
+
+    private:
+        KeyValue(KeyValue &); // noncopyable
+        KeyValue &operator =(KeyValue &); // noncopyable
     };
     
     /// Hash map node.

--- a/Source/Engine/Core/Mutex.h
+++ b/Source/Engine/Core/Mutex.h
@@ -56,6 +56,8 @@ public:
     ~MutexLock();
     
 private:
+    MutexLock(MutexLock &); // noncopyable
+    MutexLock &operator =(MutexLock &); // noncopyable
     /// Mutex reference.
     Mutex& mutex_;
 };

--- a/Source/Engine/Graphics/OctreeQuery.h
+++ b/Source/Engine/Graphics/OctreeQuery.h
@@ -62,6 +62,10 @@ public:
     unsigned char drawableFlags_;
     /// Drawable layers to include.
     unsigned viewMask_;
+
+private:
+    OctreeQuery(const OctreeQuery &); // noncopyable
+    OctreeQuery& operator =(const OctreeQuery &); // noncopyable
 };
 
 /// Point octree query.
@@ -230,6 +234,10 @@ public:
     float maxDistance_;
     /// Raycast detail level.
     RayQueryLevel level_;
+
+private:
+    RayOctreeQuery(const RayOctreeQuery &); // noncopyable
+    RayOctreeQuery& operator =(const RayOctreeQuery &); // noncopyable
 };
 
 }

--- a/Source/Engine/IO/FileSystem.cpp
+++ b/Source/Engine/IO/FileSystem.cpp
@@ -250,6 +250,9 @@ public:
     }
     
 private:
+    AsyncSystemRun(const AsyncSystemRun &); // noncopyable
+    AsyncSystemRun &operator =(const AsyncSystemRun &); // noncopyable
+
     /// File to run.
     String fileName_;
     /// Command line split in arguments.

--- a/Source/Engine/Physics/PhysicsWorld.cpp
+++ b/Source/Engine/Physics/PhysicsWorld.cpp
@@ -109,6 +109,10 @@ struct PhysicsQueryCallback : public btCollisionWorld::ContactResultCallback
     PODVector<RigidBody*>& result_;
     /// Collision mask for the query.
     unsigned collisionMask_;
+
+private:
+    PhysicsQueryCallback(const PhysicsQueryCallback &); // noncopyable
+    PhysicsQueryCallback &operator =(const PhysicsQueryCallback &); // noncopyable
 };
 
 PhysicsWorld::PhysicsWorld(Context* context) :

--- a/Source/Engine/Resource/XMLFile.cpp
+++ b/Source/Engine/Resource/XMLFile.cpp
@@ -60,6 +60,10 @@ public:
     Serializer& dest_;
     /// Success flag.
     bool success_;
+
+private:
+    XMLWriter(const XMLWriter &); // noncopyable
+    XMLWriter &operator =(const XMLWriter &); // noncopyable
 };
 
 XMLFile::XMLFile(Context* context) :

--- a/Source/Engine/Script/ScriptFile.cpp
+++ b/Source/Engine/Script/ScriptFile.cpp
@@ -63,6 +63,8 @@ public:
     }
     
 private:
+    ByteCodeSerializer(const ByteCodeSerializer &); // noncopyable
+    ByteCodeSerializer &operator =(const ByteCodeSerializer &); // noncopyable
     /// Destination stream.
     Serializer& dest_;
 };
@@ -89,6 +91,8 @@ public:
     }
     
 private:
+    ByteCodeDeserializer(const ByteCodeDeserializer &); // noncopyable
+    ByteCodeDeserializer &operator =(const ByteCodeDeserializer &); // noncopyable
     /// Source stream.
     MemoryBuffer& source_;
 };
@@ -157,7 +161,7 @@ bool ScriptFile::EndLoad()
     if (loadByteCode_)
     {
         MemoryBuffer buffer(loadByteCode_.Get(), loadByteCodeSize_);
-        ByteCodeDeserializer deserializer = ByteCodeDeserializer(buffer);
+        ByteCodeDeserializer deserializer(buffer);
 
         if (scriptModule_->LoadByteCode(&deserializer) >= 0)
         {
@@ -436,7 +440,7 @@ bool ScriptFile::SaveByteCode(Serializer& dest)
     if (compiled_)
     {
         dest.WriteFileID("ASBC");
-        ByteCodeSerializer serializer = ByteCodeSerializer(dest);
+        ByteCodeSerializer serializer(dest);
         return scriptModule_->SaveByteCode(&serializer, true) >= 0;
     }
     else

--- a/Source/Engine/Urho2D/PhysicsWorld2D.cpp
+++ b/Source/Engine/Urho2D/PhysicsWorld2D.cpp
@@ -390,6 +390,9 @@ public:
     }
 
 protected:
+    RayCastCallback(const RayCastCallback &); // noncopyable
+    RayCastCallback &operator =(const RayCastCallback &); // noncopyable
+
     // Physics raycast results.
     PODVector<PhysicsRaycastResult2D>& results_;
     // Start point.
@@ -444,6 +447,9 @@ public:
     }
 
 private:
+    SingleRayCastCallback(const SingleRayCastCallback &); // noncopyable
+    SingleRayCastCallback &operator =(const SingleRayCastCallback &); // noncopyable
+
     // Physics raycast result.
     PhysicsRaycastResult2D& result_;
     // Start point.
@@ -561,6 +567,8 @@ public:
     }
 
 private:
+    AabbQueryCallback(const AabbQueryCallback &); // noncopyable
+    AabbQueryCallback &operator =(const AabbQueryCallback &); // noncopyable
     // Results.
     PODVector<RigidBody2D*>& results_;
     // Collision mask.


### PR DESCRIPTION
Fix C4512 ("'class' : assignment operator could not be generated", MSVC warning level 4) compiler warnings that leak into applications using Urho.

I would recommend moving to using level 4 instead of the level 3 that CMake uses by default as the default warning level on MSVC in order to catch many quite useful warnings (there will be lots of warnings...).
