### PR TITLE
AreaAllocator wouldnt increase size if next size was exactly max

### DIFF
--- a/Source/Engine/Math/AreaAllocator.cpp
+++ b/Source/Engine/Math/AreaAllocator.cpp
@@ -92,7 +92,7 @@ bool AreaAllocator::Allocate(int width, int height, int& x, int& y)
         
         if (best == freeAreas_.End())
         {
-            if (doubleWidth_ && size_.x_ < maxSize_.x_)
+            if (doubleWidth_ && size_.x_ <= maxSize_.x_)
             {
                 int oldWidth = size_.x_;
                 size_.x_ <<= 1;
@@ -106,7 +106,7 @@ bool AreaAllocator::Allocate(int width, int height, int& x, int& y)
                     freeAreas_.Push(newArea);
                 }
             }
-            else if (!doubleWidth_ && size_.y_ < maxSize_.y_)
+            else if (!doubleWidth_ && size_.y_ <= maxSize_.y_)
             {
                 int oldHeight = size_.y_;
                 size_.y_ <<= 1;


### PR DESCRIPTION
I set the area allocators max texture size to 2048 and added Data/Textures/Jack_face.jpg a 1024x1024 + 1px padding so 1025x1025 to the area allocator and it would not allocate up to 2048.  This patch fixed it on my end. 
