### PR TITLE
Fix Variant:SetBuffer and VariantMap:SetBuffer in Lua

### DIFF
--- a/Source/Engine/LuaScript/pkgs/Core/Variant.pkg
+++ b/Source/Engine/LuaScript/pkgs/Core/Variant.pkg
@@ -261,7 +261,7 @@ static void VariantSetString(Variant* variant, const String value)
 
 static void VariantSetBuffer(Variant* variant, const VectorBuffer& value)
 {
-    *variant = value.GetData();
+    variant->SetBuffer(value.GetData(), value.GetBuffer().Size());
 }
 
 static void VariantSetResourceRef(Variant* variant, const ResourceRef& value)
@@ -361,7 +361,7 @@ static void VariantMapSetString(VariantMap* vmap, const String& key, const Strin
 
 static void VariantMapSetBuffer(VariantMap* vmap, const String& key, const VectorBuffer& value)
 {
-    (*vmap)[StringHash(key)] = value.GetData();
+    (*vmap)[StringHash(key)].SetBuffer(value.GetData(), value.GetBuffer().Size());
 }
 
 static void VariantMapSetResourceRef(VariantMap* vmap, const String& key, const ResourceRef& value)


### PR DESCRIPTION
Without this fix, any data starting with 0 will be copied as being zero length, and I guess it might segfault if there are no null bytes in the data.
