### PR TITLE
Fix Connection not sending delta update if only user variables have been modified

### DIFF
--- a/Source/Engine/Network/Connection.cpp
+++ b/Source/Engine/Network/Connection.cpp
@@ -1143,7 +1143,7 @@ void Connection::ProcessExistingNode(Node* node, NodeReplicationState& nodeState
     }
     
     // Check if attributes have changed
-    if (nodeState.dirtyAttributes_.Count())
+    if (nodeState.dirtyAttributes_.Count() || nodeState.dirtyVars_.Size())
     {
         const Vector<AttributeInfo>* attributes = node->GetNetworkAttributes();
         unsigned numAttributes = attributes->Size();


### PR DESCRIPTION
Is it intentional that Connection does not send delta update if only user variables have been modified? If not, this should fix it.

I'm not actually using the Connection class, but rather my own implementation using Connection as a reference implementation. Because of that, I ended up with the same bug in my own implementation. 8)
