### PR TITLE
Provide accessor method on Scene to get the Camera component that has been specified as Default

### DIFF
--- a/Source/Engine/Scene/Scene.cpp
+++ b/Source/Engine/Scene/Scene.cpp
@@ -21,6 +21,7 @@
 //
 
 #include "Precompiled.h"
+#include "Camera.h"
 #include "Component.h"
 #include "Context.h"
 #include "CoreEvents.h"
@@ -1215,6 +1216,22 @@ void Scene::PreloadResourcesXML(const XMLElement& element)
         PreloadResourcesXML(childElem);
         childElem = childElem.GetNext("node");
     }
+}
+
+void Scene::SetDefaultCamera(Camera* camera)
+{
+    if (camera)
+    {
+        defaultCamera_ = camera;
+    }
+}
+
+Camera* Scene::GetDefaultCamera() const
+{
+    if (defaultCamera_)
+        return defaultCamera_.Get();
+
+    return NULL;
 }
 
 void RegisterSceneLibrary(Context* context)

--- a/Source/Engine/Scene/Scene.h
+++ b/Source/Engine/Scene/Scene.h
@@ -25,6 +25,7 @@
 #include "HashSet.h"
 #include "Mutex.h"
 #include "Node.h"
+#include "Ptr.h"
 #include "SceneResolver.h"
 #include "XMLElement.h"
 
@@ -33,6 +34,7 @@ namespace Urho3D
 
 class File;
 class PackageFile;
+class Camera;
 
 static const unsigned FIRST_REPLICATED_ID = 0x1;
 static const unsigned LAST_REPLICATED_ID = 0xffffff;
@@ -130,6 +132,8 @@ public:
     void SetSnapThreshold(float threshold);
     /// Set maximum milliseconds per frame to spend on async scene loading.
     void SetAsyncLoadingMs(int ms);
+    /// Set default camera. This has no impact on functionality but provides a helper method for accessing it.
+    void SetDefaultCamera(Camera* camera);
     /// Add a required package file for networking. To be called on the server.
     void AddRequiredPackageFile(PackageFile* package);
     /// Clear required package files.
@@ -167,6 +171,8 @@ public:
     float GetSnapThreshold() const { return snapThreshold_; }
     /// Return maximum milliseconds per frame to spend on async loading.
     int GetAsyncLoadingMs() const { return asyncLoadingMs_; }
+    /// Return the default camera associated with this scene.
+    Camera* GetDefaultCamera() const;
     /// Return required package files.
     const Vector<SharedPtr<PackageFile> >& GetRequiredPackageFiles() const { return requiredPackageFiles_; }
     /// Return a node user variable name, or empty if not registered.
@@ -281,6 +287,8 @@ private:
     bool asyncLoading_;
     /// Threaded update flag.
     bool threadedUpdate_;
+    /// Default Camera.
+    WeakPtr<Camera> defaultCamera_;
 };
 
 /// Register Scene library objects.

--- a/Source/Engine/Script/GraphicsAPI.cpp
+++ b/Source/Engine/Script/GraphicsAPI.cpp
@@ -120,6 +120,8 @@ static void RegisterCamera(asIScriptEngine* engine)
     engine->RegisterObjectMethod("Camera", "Frustum get_viewSpaceFrustum() const", asMETHOD(Camera, GetViewSpaceFrustum), asCALL_THISCALL);
     engine->RegisterObjectMethod("Camera", "float get_halfViewSize() const", asMETHOD(Camera, GetHalfViewSize), asCALL_THISCALL);
     engine->RegisterObjectMethod("Camera", "Matrix3x4 get_effectiveWorldTransform() const", asMETHOD(Camera, GetEffectiveWorldTransform), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Scene", "void set_defaultCamera(Camera@+)", asMETHOD(Scene, SetDefaultCamera), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Scene", "Camera@+ get_defaultCamera() const", asMETHOD(Scene, GetDefaultCamera), asCALL_THISCALL);
 }
 
 static Node* BoneGetNode(Bone* ptr)


### PR DESCRIPTION
Provides an accessor method to get a "Default Camera" doesn't provide any functional impact but reduces the requirements to pass around or search for the Camera similar to the way scene is registered with Script for lookups.

Angelscript bindings included, lua not as I have no idea if the forward decl works with lua and can't register in a different order like you can in angelscript.
