### PR TITLE
Added KDevelop and GCC PCH files to the .gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ Docs/minimal-*
 Source/.*project
 Source/.settings
 
+# KDevelop project settings
+*.kdev?
+
 # Qt Creator project settings
 Source/CMakeLists.txt.user
 
@@ -57,6 +60,9 @@ CMakeScripts/
 Makefile
 cmake_install.cmake
 install_manifest.txt
+
+# GCC PCH files that are some-how ending up in the Source tree instead of the Build directory
+*.gch
 
 # Misc.
 configure*


### PR DESCRIPTION
Yes GCC pch files have a gch extension.  The CMake setting that is causing the issue of it appearing in the Source directory when enabled should probably be looked in to sometime.  I verified these do not match anything that they should not.
