### PR TITLE
Dynamic Types

### DIFF
--- a/Bin/Data/Scripts/Editor.as
+++ b/Bin/Data/Scripts/Editor.as
@@ -164,6 +164,7 @@ void LoadConfig()
     XMLElement resourcesElem = configElem.GetChild("resources");
     XMLElement consoleElem = configElem.GetChild("console");
     XMLElement varNamesElem = configElem.GetChild("varnames");
+    XMLElement soundTypesElem = configElem.GetChild("soundtypes");
 
     if (!cameraElem.isNull)
     {
@@ -272,6 +273,9 @@ void LoadConfig()
     
     if (!varNamesElem.isNull)
         globalVarNames = varNamesElem.GetVariantMap();
+        
+    if (!soundTypesElem.isNull)
+        LoadSoundTypes(soundTypesElem);
 }
 
 void SaveConfig()
@@ -288,6 +292,7 @@ void SaveConfig()
     XMLElement resourcesElem = configElem.CreateChild("resources");
     XMLElement consoleElem = configElem.CreateChild("console");
     XMLElement varNamesElem = configElem.CreateChild("varnames");
+    XMLElement soundTypesElem = configElem.CreateChild("soundtypes");
 
     cameraElem.SetFloat("nearclip", viewNearClip);
     cameraElem.SetFloat("farclip", viewFarClip);
@@ -358,6 +363,8 @@ void SaveConfig()
     consoleElem.SetAttribute("commandinterpreter", console.commandInterpreter);
 
     varNamesElem.SetVariantMap(globalVarNames);
+    
+    SaveSoundTypes(soundTypesElem);
 
     config.Save(File(configFileName, FILE_WRITE));
 }

--- a/Bin/Data/UI/EditorSoundTypeWindow.xml
+++ b/Bin/Data/UI/EditorSoundTypeWindow.xml
@@ -28,58 +28,6 @@
 		<element type="BorderImage" internal="true" style="none">
 			<element internal="true" style="none">
 				<element style="ListRow">
-					<attribute name="Name" value="Effect" />
-					<attribute name="Layout Spacing" value="10" />
-					<element type="Text">
-						<attribute name="Text" value="Effect" />
-					</element>
-					<element type="LineEdit">
-						<attribute name="Name" value="EffectValue" />
-						<attribute name="Min Size" value="100 0" />
-						<attribute name="Max Size" value="2147483647 20" />
-						<attribute name="Max Length" value="4" />
-					</element>
-				</element>
-				<element style="ListRow">
-					<attribute name="Name" value="Ambient" />
-					<attribute name="Layout Spacing" value="10" />
-					<element type="Text">
-						<attribute name="Text" value="Ambient" />
-					</element>
-					<element type="LineEdit">
-						<attribute name="Name" value="AmbientValue" />
-						<attribute name="Min Size" value="100 0" />
-						<attribute name="Max Size" value="2147483647 20" />
-						<attribute name="Max Length" value="4" />
-					</element>
-				</element>
-				<element style="ListRow">
-					<attribute name="Name" value="Voice" />
-					<attribute name="Layout Spacing" value="10" />
-					<element type="Text">
-						<attribute name="Text" value="Voice" />
-					</element>
-					<element type="LineEdit">
-						<attribute name="Name" value="VoiceValue" />
-						<attribute name="Min Size" value="100 0" />
-						<attribute name="Max Size" value="2147483647 20" />
-						<attribute name="Max Length" value="4" />
-					</element>
-				</element>
-				<element style="ListRow">
-					<attribute name="Name" value="Music" />
-					<attribute name="Layout Spacing" value="10" />
-					<element type="Text">
-						<attribute name="Text" value="Music" />
-					</element>
-					<element type="LineEdit">
-						<attribute name="Name" value="MusicValue" />
-						<attribute name="Min Size" value="100 0" />
-						<attribute name="Max Size" value="2147483647 20" />
-						<attribute name="Max Length" value="4" />
-					</element>
-				</element>
-				<element style="ListRow">
 					<attribute name="Name" value="Master" />
 					<attribute name="Layout Spacing" value="10" />
 					<element type="Text">

--- a/Docs/Reference.dox
+++ b/Docs/Reference.dox
@@ -1509,14 +1509,9 @@ To hear pseudo-3D positional sounds, a SoundListener component must exist in a s
 
 The output is software mixed for an unlimited amount of simultaneous sounds. Ogg Vorbis sounds are decoded on the fly, and decoding them can be memory- and CPU-intensive, so WAV files are recommended when a large number of short sound effects need to be played.
 
-For purposes of volume control, each SoundSource is classified into one of four categories:
+For purposes of volume control, each SoundSource can be classified into a user defined group which is multiplied with a master category and the individual SoundSource gain set using \ref SoundSource::SetGain "SetGain()" for the final volume level.
 
-- %Sound effects
-- Ambient
-- Music
-- Voice
-
-A master gain category also exists that affects the final output level. To control the category volumes, use \ref Audio::SetMasterGain "SetMasterGain()".
+To control the category volumes, use \ref Audio::SetMasterGain "SetMasterGain()", which defines the category if it didn't already exist.
 
 The SoundSource components support automatic removal from the node they belong to, once playback is finished. To use, call \ref SoundSource::SetAutoRemove "SetAutoRemove()" on them. This may be useful when a game object plays several "fire and forget" sound effects.
 
@@ -1752,6 +1747,79 @@ For FreeType fonts, it is possible to adjust the positioning of the font glyphs.
 Sprites are a special kind of %UI element that allow subpixel (float) positioning and scaling, as well as rotation, while the other elements use integer positioning for pixel-perfect display. Sprites can be used to implement rotating HUD elements such as minimaps or speedometer needles.
 
 Due to the free transformability, sprites can not be reliably queried with \ref UI::GetElementAt "GetElementAt()". Also, only other sprites should be parented to sprites, as the other elements do not support scaling and rotation.
+
+\section UI_Cursor_Shapes Cursor Shapes
+
+Urho3D supports custom Cursor Shapes defined from an \ref Image.
+
+The Shape can be an OS default from the \ref CursorShape "CursorShape" enum, which are automatically switched to and from by the \ref UI "UI" subsystem, but can be manually switched to using \ref Cursor::SetShape "Cursor::SetShape(CursorShape)".
+
+Alternatively they can be defined using a name in String format to identify it, which can only be manually switched to and from using \ref Cursor::SetShape "Cursor::SetShape(const String&)".
+
+There are a number of reserved names that are used for the OS defaults:
+    - Normal
+    - IBeam
+    - Cross
+    - ResizeVertical
+    - ResizeDiagonalTopRight
+    - ResizeHorizontal
+    - ResizeDiagonalTopLeft
+    - ResizeAll
+    - AcceptDrop
+    - RejectDrop
+    - Busy
+    - BusyArrow
+	
+Cursor Shapes can be define in a number of different ways:
+
+XML:
+\code
+	<element type="Cursor">
+		<attribute name="Shapes">
+			<variant type="VariantVector" >
+				<variant type="String" value="Normal" />
+				<variant type="ResourceRef" value="Image;Textures/UI.png" />
+				<variant type="IntRect" value="0 0 12 24" />
+				<variant type="IntVector2" value="0 0" />
+			</variant>  
+			<variant type="VariantVector" >
+				<variant type="String" value="Custom" />
+				<variant type="ResourceRef" value="Image;Textures/UI.png" />
+				<variant type="IntRect" value="12 0 12 36" />
+				<variant type="IntVector2" value="0 0" />
+			</variant>  
+		</atrribute>
+	</element>
+\endcode
+
+C++:
+\code
+    UI* ui = GetSubsystem<UI>();
+    ResourceCache* rc = GetSubsystem<ResourceCache>();
+
+    Cursor* cursor = new Cursor(context_);
+    Image* image = rc->GetResource<Image>("Textures/UI.png");
+    if (image)
+	{
+        cursor->DefineShape(CS_NORMAL, image, IntRect(0, 0, 12, 24), IntVector2(0, 0));
+		cursor->DefineShape("Custom", image, IntRect(12, 0, 12, 36), IntVector2(0, 0));
+	}
+
+    ui->SetCursor(cursor);
+\endcode
+
+Angelcode:
+\code
+	Cursor@ cursor = new Cursor();
+	Image@ image = cache.GetResource("Image", "Textures/UI.png");
+	if (image !is null)
+	{
+		cursor.DefineShape(CS_NORMAL, image, IntRect(0, 0, 12, 24), IntVector2(0, 0));
+		cursor.DefineShape("Custom", image, IntRect(12, 0, 12, 36), IntVector2(0, 0));
+	}
+		
+	ui.SetCursor(cursor);
+\endcode
 
 \page Urho2D Urho2D
 In order to make 2D games in Urho3D, the Urho2D sublibrary is provided. Urho2D includes 2D graphics and 2D physics.

--- a/Source/Engine/Audio/Audio.cpp
+++ b/Source/Engine/Audio/Audio.cpp
@@ -53,8 +53,8 @@ Audio::Audio(Context* context) :
     sampleSize_(0),
     playing_(false)
 {
-    for (unsigned i = 0; i < MAX_SOUND_TYPES; ++i)
-        masterGain_[soundTypeHashes[i]] = 1.0f;
+    // Set the master to the default value
+    masterGain_[SOUND_MASTER] = 1.0f;
     
     // Register Audio library object factories
     RegisterAudioLibrary(context_);
@@ -149,15 +149,7 @@ void Audio::Stop()
     playing_ = false;
 }
 
-void Audio::SetMasterGain(SoundType type, float gain)
-{
-    if (type >= MAX_SOUND_TYPES)
-        return;
-
-    SetMasterGain(soundTypeHashes[type], gain);
-}
-
-void Audio::SetMasterGain(const StringHash& type, float gain)
+void Audio::SetMasterGain(const String& type, float gain)
 {
     masterGain_[type] = Clamp(gain, 0.0f, 1.0f);
 }
@@ -176,19 +168,9 @@ void Audio::StopSound(Sound* soundClip)
     }
 }
 
-
-float Audio::GetMasterGain(SoundType type) const
+float Audio::GetMasterGain(const String& type) const
 {
-    if (type >= MAX_SOUND_TYPES)
-        return 0.0f;
-
-    return GetMasterGain(soundTypeHashes[type]);
-}
-
-
-float Audio::GetMasterGain(const StringHash& type) const
-{
-    VariantMap::ConstIterator findIt = masterGain_.Find(type);
+    HashMap<String, Variant>::ConstIterator findIt = masterGain_.Find(type);
     if (findIt == masterGain_.End())
         return 0.0f;
 
@@ -216,18 +198,14 @@ void Audio::RemoveSoundSource(SoundSource* channel)
     }
 }
 
-float Audio::GetSoundSourceMasterGain(SoundType type) const
+float Audio::GetSoundSourceMasterGain(const String& type) const
 {
-    if (type >= MAX_SOUND_TYPES)
-        return 0.0f;
-    
-    return GetSoundSourceMasterGain(soundTypeHashes[type]);
-}
+    HashMap<String, Variant>::ConstIterator masterIt = masterGain_.Find(SOUND_MASTER);
 
-float Audio::GetSoundSourceMasterGain(const StringHash& type) const
-{
-    VariantMap::ConstIterator masterIt = masterGain_.Find(soundTypeHashes[SOUND_MASTER]);
-    VariantMap::ConstIterator typeIt = masterGain_.Find(type);
+    if (type == String::EMPTY)
+        return masterIt->second_.GetFloat();
+
+    HashMap<String, Variant>::ConstIterator typeIt = masterGain_.Find(type);
 
     if (typeIt == masterGain_.End() || typeIt == masterIt)
         return masterIt->second_.GetFloat();

--- a/Source/Engine/Audio/Audio.h
+++ b/Source/Engine/Audio/Audio.h
@@ -54,10 +54,8 @@ public:
     bool Play();
     /// Suspend sound output.
     void Stop();
-    /// Set master gain on a specific sound type such as sound effecs, music or voice using the enum for backwards compatibility.
-    void SetMasterGain(SoundType type, float gain);
     /// Set master gain on a specific sound type such as sound effects, music or voice.
-    void SetMasterGain(const StringHash& type, float gain);
+    void SetMasterGain(const String& type, float gain);
     /// Set active sound listener for 3D sounds.
     void SetListener(SoundListener* listener);
     /// Stop any sound source playing a certain sound clip.
@@ -75,17 +73,15 @@ public:
     bool IsPlaying() const { return playing_; }
     /// Return whether an audio stream has been reserved.
     bool IsInitialized() const { return deviceID_ != 0; }
-    /// Return master gain for a specific sound source type by enum.
-    float GetMasterGain(SoundType type) const;
     /// Return master gain for a specific sound source type.
-    float GetMasterGain(const StringHash& type) const;
+    float GetMasterGain(const String& type) const;
     /// Return active sound listener.
     SoundListener* GetListener() const;
     /// Return all sound sources.
     const PODVector<SoundSource*>& GetSoundSources() const { return soundSources_; }
 
     /// Return whether the specified master gain has been defined.
-    bool IsMasterGain(const StringHash& type) const { return masterGain_.Contains(type); }
+    bool IsMasterGain(const String& type) const { return masterGain_.Contains(type); }
 
     /// Add a sound source to keep track of. Called by SoundSource.
     void AddSoundSource(SoundSource* soundSource);
@@ -94,9 +90,7 @@ public:
     /// Return audio thread mutex.
     Mutex& GetMutex() { return audioMutex_; }
     /// Return sound type specific gain multiplied by master gain.
-    float GetSoundSourceMasterGain(SoundType type) const;
-    /// Return sound type specific gain multiplied by master gain.
-    float GetSoundSourceMasterGain(const StringHash& type) const;
+    float GetSoundSourceMasterGain(const String& type) const;
 
     /// Mix sound sources into the buffer.
     void MixOutput(void *dest, unsigned samples);
@@ -125,7 +119,7 @@ private:
     /// Playing flag.
     bool playing_;
     /// Master gain by sound source type.
-    VariantMap masterGain_;
+    HashMap<String, Variant> masterGain_;
     /// Sound sources.
     PODVector<SoundSource*> soundSources_;
     /// Sound listener.

--- a/Source/Engine/Audio/AudioDefs.h
+++ b/Source/Engine/Audio/AudioDefs.h
@@ -22,30 +22,10 @@
 
 #pragma once
 
-#include "StringHash.h"
-
 namespace Urho3D
 {
 
-/// SoundSource type enumeration for master gain control.
-enum SoundType
-{
-    SOUND_EFFECT = 0,
-    SOUND_AMBIENT,
-    SOUND_VOICE,
-    SOUND_MUSIC,
-    SOUND_MASTER,
-    MAX_SOUND_TYPES
-};
-
-static const StringHash soundTypeHashes[MAX_SOUND_TYPES] =
-{
-    "Effect",
-    "Ambient",
-    "Voice",
-    "Music",
-    "Master"
-};
-
+/// SoundSource type defaults
+static const String SOUND_MASTER = "Master";
 
 }

--- a/Source/Engine/Audio/SoundSource.h
+++ b/Source/Engine/Audio/SoundSource.h
@@ -60,10 +60,8 @@ public:
     void Play(SoundStream* stream);
     /// Stop playback.
     void Stop();
-    /// Set sound type, determines the master gain group by enum.
-    void SetSoundType(SoundType type);   
     /// Set sound type, determines the master gain group.
-    void SetSoundType(const StringHash& type);
+    void SetSoundType(const String& type);
     /// Set frequency.
     void SetFrequency(float frequency);
     /// Set gain. 0.0 is silence, 1.0 is full volume.
@@ -82,7 +80,7 @@ public:
     /// Return playback position.
     volatile signed char* GetPlayPosition() const { return position_; }
     /// Return sound type, determines the master gain group.
-    StringHash GetSoundType() const { return soundType_; }
+    String GetSoundType() const { return soundType_; }
     /// Return playback time position.
     float GetTimePosition() const { return timePosition_; }
     /// Return frequency.
@@ -113,16 +111,12 @@ public:
     void SetPlayingAttr(bool value);
     /// Return sound position attribute.
     int GetPositionAttr() const;
-    /// Set sound type attribute for backwards compatibility.
-    void SetSoundTypeAttr(SoundType type);
-    /// Return sound type attribute for backwards compatibility.
-    SoundType GetSoundTypeAttr() const;
     
 protected:
     /// Audio subsystem.
     WeakPtr<Audio> audio_;
     /// SoundSource type, determines the master gain group.
-    StringHash soundType_;
+    String soundType_;
     /// Frequency.
     float frequency_;
     /// Gain.

--- a/Source/Engine/Core/Attribute.h
+++ b/Source/Engine/Core/Attribute.h
@@ -46,8 +46,6 @@ static const unsigned AM_NODEID = 0x10;
 static const unsigned AM_COMPONENTID = 0x20;
 /// Attribute is a node ID vector where first element is the amount of nodes.
 static const unsigned AM_NODEIDVECTOR = 0x40;
-/// Attribute is only read not written, mainly used for backwards compatibility with serialization.
-static const unsigned AM_READ = 0x80;
 
 class Serializable;
 

--- a/Source/Engine/LuaScript/pkgs/Audio/Audio.pkg
+++ b/Source/Engine/LuaScript/pkgs/Audio/Audio.pkg
@@ -1,22 +1,13 @@
 $#include "Audio.h"
 
-enum SoundType
-{
-    SOUND_EFFECT,
-    SOUND_AMBIENT,
-    SOUND_VOICE,
-    SOUND_MUSIC,
-    SOUND_MASTER,
-    MAX_SOUND_TYPES
-};
+static const String SOUND_MASTER;
 
 class Audio : public Object
 {
     bool SetMode(int bufferLengthMSec, int mixRate, bool stereo, bool interpolation = true);
     bool Play();
     void Stop();
-    void SetMasterGain(SoundType type, float gain);
-    void SetMasterGain(const StringHash& type, float gain);
+    void SetMasterGain(const String& type, float gain);
     void SetListener(SoundListener* listener);
     void StopSound(Sound* sound);
 
@@ -26,16 +17,15 @@ class Audio : public Object
     bool IsStereo() const;
     bool IsPlaying() const;
     bool IsInitialized() const;
-    bool IsMasterGain(const StringHash& type) const;
-    float GetMasterGain(SoundType type) const;
-    float GetMasterGain(const StringHash& type) const;
+    bool IsMasterGain(const String& type) const;
+    float GetMasterGain(const String& type) const;
     SoundListener* GetListener() const;
     const PODVector<SoundSource*>& GetSoundSources() const;
 
     void AddSoundSource(SoundSource* soundSource);
     void RemoveSoundSource(SoundSource* soundSource);
-    float GetSoundSourceMasterGain(SoundType type) const;
-    float GetSoundSourceMasterGain(const StringHash& type) const;
+    float GetSoundSourceMasterGain(const String& type) const;
+	
     void MixOutput(void *dest, unsigned samples);
 
     tolua_readonly tolua_property__get_set unsigned sampleSize;

--- a/Source/Engine/LuaScript/pkgs/Audio/SoundSource.pkg
+++ b/Source/Engine/LuaScript/pkgs/Audio/SoundSource.pkg
@@ -9,8 +9,7 @@ class SoundSource : public Component
     void Play(Sound* sound, float frequency, float gain);
     void Play(Sound* sound, float frequency, float gain, float panning);
     void Stop();
-    void SetSoundType(SoundType type);
-    void SetSoundType(const StringHash& type);
+    void SetSoundType(const String& type);
     void SetFrequency(float frequency);
     void SetGain(float gain);
     void SetAttenuation(float attenuation);
@@ -18,7 +17,7 @@ class SoundSource : public Component
     void SetAutoRemove(bool enable);
 
     Sound* GetSound() const;
-    StringHash GetSoundType() const;
+    String GetSoundType() const;
     float GetTimePosition() const;
     float GetFrequency() const;
     float GetGain() const;
@@ -28,7 +27,7 @@ class SoundSource : public Component
     bool IsPlaying() const;
     
     tolua_readonly tolua_property__get_set Sound* sound;
-    tolua_property__get_set StringHash soundType;
+    tolua_property__get_set String soundType;
     tolua_readonly tolua_property__get_set float timePosition;
     tolua_property__get_set float frequency;
     tolua_property__get_set float gain;

--- a/Source/Engine/LuaScript/pkgs/UI/Cursor.pkg
+++ b/Source/Engine/LuaScript/pkgs/UI/Cursor.pkg
@@ -26,12 +26,12 @@ class Cursor : public BorderImage
     void DefineShape(CursorShape shape, Image* image, const IntRect& imageRect, const IntVector2& hotSpot);
     
     void SetShape(CursorShape shape);
-    void SetShape(const StringHash& shape);
+    void SetShape(const String& shape);
     void SetUseSystemShapes(bool enable);
-    StringHash GetShape() const;
+    String GetShape() const;
     bool GetUseSystemShapes() const;
 
-    tolua_property__get_set StringHash shape;
+    tolua_property__get_set String shape;
     tolua_property__get_set bool useSystemShapes;
 };
 

--- a/Source/Engine/Scene/Serializable.cpp
+++ b/Source/Engine/Scene/Serializable.cpp
@@ -319,7 +319,7 @@ bool Serializable::LoadXML(const XMLElement& source, bool setInstanceDefault)
         while (attempts)
         {
             const AttributeInfo& attr = attributes->At(i);
-            if (((attr.mode_ & AM_FILE) || (attr.mode_ & AM_READ)) && !attr.name_.Compare(name, true))
+            if ((attr.mode_ & AM_FILE) && !attr.name_.Compare(name, true))
             {
                 Variant varValue;
 

--- a/Source/Engine/Script/APITemplates.h
+++ b/Source/Engine/Script/APITemplates.h
@@ -788,10 +788,8 @@ template <class T> void RegisterSoundSource(asIScriptEngine* engine, const char*
     engine->RegisterObjectMethod(className, "void Play(Sound@+, float, float)", asMETHODPR(T, Play, (Sound*, float, float), void), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "void Play(Sound@+, float, float, float)", asMETHODPR(T, Play, (Sound*, float, float, float), void), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "void Stop()", asMETHOD(T, Stop), asCALL_THISCALL);
-    engine->RegisterObjectMethod(className, "void SetSoundType(const StringHash&in)", asMETHODPR(T, SetSoundType, (const StringHash&), void), asCALL_THISCALL);
-    engine->RegisterObjectMethod(className, "void SetSoundType(SoundType)", asMETHODPR(T, SetSoundType, (SoundType), void), asCALL_THISCALL);
-    engine->RegisterObjectMethod(className, "void set_soundType(const StringHash&in)", asMETHODPR(T, SetSoundType, (const StringHash&), void), asCALL_THISCALL);
-    engine->RegisterObjectMethod(className, "StringHash get_soundType() const", asMETHOD(T, GetSoundType), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "void set_soundType(const String&in)", asMETHOD(T, SetSoundType), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "String get_soundType() const", asMETHOD(T, GetSoundType), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "void set_frequency(float)", asMETHOD(T, SetFrequency), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "float get_frequency() const", asMETHOD(T, GetFrequency), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "void set_gain(float)", asMETHOD(T, SetGain), asCALL_THISCALL);

--- a/Source/Engine/Script/AudioAPI.cpp
+++ b/Source/Engine/Script/AudioAPI.cpp
@@ -45,12 +45,7 @@ void RegisterSound(asIScriptEngine* engine)
 
 void RegisterSoundSources(asIScriptEngine* engine)
 {
-    engine->RegisterEnum("SoundType");
-    engine->RegisterEnumValue("SoundType", "SOUND_EFFECT", SOUND_EFFECT);
-    engine->RegisterEnumValue("SoundType", "SOUND_AMBIENT", SOUND_AMBIENT);
-    engine->RegisterEnumValue("SoundType", "SOUND_VOICE", SOUND_VOICE);
-    engine->RegisterEnumValue("SoundType", "SOUND_MUSIC", SOUND_MUSIC);
-    engine->RegisterEnumValue("SoundType", "SOUND_MASTER", SOUND_MASTER);
+    engine->RegisterGlobalProperty("const String SOUND_MASTER", (void*) &SOUND_MASTER);
     
     RegisterSoundSource<SoundSource>(engine, "SoundSource");
     RegisterSoundSource<SoundSource3D>(engine, "SoundSource3D");
@@ -80,34 +75,15 @@ static Audio* GetAudio()
     return GetScriptContext()->GetSubsystem<Audio>();
 }
 
-static float GetMasterGainFromEnum(SoundType type, Audio* audio)
-{
-    return audio->GetMasterGain(type);
-}
-
-static float GetMasterGainFromHash(const StringHash& type, Audio* audio)
-{
-    return audio->GetMasterGain(type);
-}
-
-static StringHash GetHashFromType(SoundType type)
-{
-    return soundTypeHashes[type];
-}
-
 void RegisterAudio(asIScriptEngine* engine)
 {
     RegisterObject<Audio>(engine, "Audio");
     engine->RegisterObjectMethod("Audio", "void SetMode(int, int, bool, bool interpolate = true)", asMETHOD(Audio, SetMode), asCALL_THISCALL);
     engine->RegisterObjectMethod("Audio", "bool Play()", asMETHOD(Audio, Play), asCALL_THISCALL);
     engine->RegisterObjectMethod("Audio", "void Stop()", asMETHOD(Audio, Stop), asCALL_THISCALL);
-    engine->RegisterObjectMethod("Audio", "void SetMasterGain(SoundType, float)", asMETHODPR(Audio, SetMasterGain, (SoundType, float), void), asCALL_THISCALL);
-    engine->RegisterObjectMethod("Audio", "float GetMasterGain(SoundType) const", asFUNCTION(GetMasterGainFromEnum), asCALL_CDECL_OBJLAST);
-    engine->RegisterObjectMethod("Audio", "void SetMasterGain(const StringHash&in, float)", asMETHODPR(Audio, SetMasterGain, (const StringHash&, float), void), asCALL_THISCALL);
-    engine->RegisterObjectMethod("Audio", "float GetMasterGain(const StringHash&in) const", asFUNCTION(GetMasterGainFromHash), asCALL_CDECL_OBJLAST);
-    engine->RegisterObjectMethod("Audio", "void set_masterGain(const StringHash&in, float)", asMETHODPR(Audio, SetMasterGain, (const StringHash&, float), void), asCALL_THISCALL);
-    engine->RegisterObjectMethod("Audio", "float get_masterGain(const StringHash&in) const", asFUNCTION(GetMasterGainFromHash), asCALL_CDECL_OBJLAST);
-    engine->RegisterObjectMethod("Audio", "bool IsMasterGain(const StringHash&in) const", asMETHOD(Audio, IsMasterGain), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Audio", "void set_masterGain(const String&in, float)", asMETHOD(Audio, SetMasterGain), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Audio", "float get_masterGain(const String&in) const", asMETHOD(Audio, GetMasterGain), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Audio", "bool IsMasterGain(const String&in) const", asMETHOD(Audio, IsMasterGain), asCALL_THISCALL);
     engine->RegisterObjectMethod("Audio", "void set_listener(SoundListener@+)", asMETHOD(Audio, SetListener), asCALL_THISCALL);
     engine->RegisterObjectMethod("Audio", "SoundListener@+ get_listener() const", asMETHOD(Audio, GetListener), asCALL_THISCALL);
     engine->RegisterObjectMethod("Audio", "uint get_sampleSize() const", asMETHOD(Audio, GetSampleSize), asCALL_THISCALL);
@@ -117,7 +93,6 @@ void RegisterAudio(asIScriptEngine* engine)
     engine->RegisterObjectMethod("Audio", "bool get_playing() const", asMETHOD(Audio, IsPlaying), asCALL_THISCALL);
     engine->RegisterObjectMethod("Audio", "bool get_initialized() const", asMETHOD(Audio, IsInitialized), asCALL_THISCALL);
     engine->RegisterGlobalFunction("Audio@+ get_audio()", asFUNCTION(GetAudio), asCALL_CDECL);
-    engine->RegisterGlobalFunction("StringHash GetHashFromSoundType(SoundType type)", asFUNCTION(GetHashFromType), asCALL_CDECL);
 }
 
 void RegisterAudioAPI(asIScriptEngine* engine)

--- a/Source/Engine/Script/SceneAPI.cpp
+++ b/Source/Engine/Script/SceneAPI.cpp
@@ -45,7 +45,6 @@ static void RegisterSerializable(asIScriptEngine* engine)
     engine->RegisterGlobalProperty("const uint AM_NODEID", (void*)&AM_NODEID);
     engine->RegisterGlobalProperty("const uint AM_COMPONENTID", (void*)&AM_COMPONENTID);
     engine->RegisterGlobalProperty("const uint AM_NODEIDVECTOR", (void*)&AM_NODEIDVECTOR);
-    engine->RegisterGlobalProperty("const uint AM_READ", (void*) &AM_READ);
 
     RegisterSerializable<Serializable>(engine, "Serializable");
 }

--- a/Source/Engine/Script/UIAPI.cpp
+++ b/Source/Engine/Script/UIAPI.cpp
@@ -169,10 +169,10 @@ static void RegisterCursor(asIScriptEngine* engine)
     RegisterBorderImage<Cursor>(engine, "Cursor");
     engine->RegisterObjectMethod("Cursor", "void DefineShape(const String&in, Texture@+, const IntRect&in, const IntVector2&in)", asMETHODPR(Cursor, DefineShape, (CursorShape, Image*, const IntRect&, const IntVector2&), void), asCALL_THISCALL);
     engine->RegisterObjectMethod("Cursor", "void DefineShape(CursorShape, Texture@+, const IntRect&in, const IntVector2&in)", asMETHODPR(Cursor, DefineShape, (const String&, Image*, const IntRect&, const IntVector2&), void), asCALL_THISCALL);
-    engine->RegisterObjectMethod("Cursor", "void SetShape(const StringHash&in)", asMETHODPR(Cursor, SetShape, (const StringHash&), void), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Cursor", "void SetShape(const String&in)", asMETHODPR(Cursor, SetShape, (const String&), void), asCALL_THISCALL);
     engine->RegisterObjectMethod("Cursor", "void SetShape(CursorShape)", asMETHODPR(Cursor, SetShape, (CursorShape), void), asCALL_THISCALL);
-    engine->RegisterObjectMethod("Cursor", "void set_shape(const StringHash&in)", asMETHODPR(Cursor, SetShape, (const StringHash&), void), asCALL_THISCALL);
-    engine->RegisterObjectMethod("Cursor", "StringHash get_shape() const", asMETHOD(Cursor, GetShape), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Cursor", "void set_shape(const String&in)", asMETHODPR(Cursor, SetShape, (const String&), void), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Cursor", "String get_shape() const", asMETHOD(Cursor, GetShape), asCALL_THISCALL);
     engine->RegisterObjectMethod("Cursor", "void set_useSystemShapes(bool)", asMETHOD(Cursor, SetUseSystemShapes), asCALL_THISCALL);
     engine->RegisterObjectMethod("Cursor", "bool get_useSystemShapes() const", asMETHOD(Cursor, GetUseSystemShapes), asCALL_THISCALL);
 }

--- a/Source/Engine/UI/Cursor.h
+++ b/Source/Engine/UI/Cursor.h
@@ -54,7 +54,6 @@ struct URHO3D_API CursorShapeInfo
 {
     /// Construct with defaults.
     CursorShapeInfo() :
-    name_(String::EMPTY),
         imageRect_(IntRect::ZERO),
         hotSpot_(IntVector2::ZERO),
         osCursor_(0),
@@ -63,20 +62,8 @@ struct URHO3D_API CursorShapeInfo
     {
     }
 
-    /// Construct with name.
-    CursorShapeInfo(const String& name) :
-        name_(name),
-        imageRect_(IntRect::ZERO),
-        hotSpot_(IntVector2::ZERO),
-        osCursor_(0),
-        systemDefined_(false),
-        systemCursor_(-1)
-    {
-    }
-
-    /// Construct with name.
-    CursorShapeInfo(const String& name, int systemCursor) :
-        name_(name),
+    /// Construct with system cursor.
+    CursorShapeInfo(int systemCursor) :
         imageRect_(IntRect::ZERO),
         hotSpot_(IntVector2::ZERO),
         osCursor_(0),
@@ -85,8 +72,6 @@ struct URHO3D_API CursorShapeInfo
     {
     }
 
-    /// Name.
-    String name_;
     /// Image.
     SharedPtr<Image> image_;
     /// Texture.
@@ -124,7 +109,7 @@ public:
     /// Define a shape.
     void DefineShape(CursorShape shape, Image* image, const IntRect& imageRect, const IntVector2& hotSpot);
     /// Set current shape.
-    void SetShape(const StringHash& shape);
+    void SetShape(const String& shape);
     /// Set current shape.
     void SetShape(CursorShape shape);
     /// Set whether to use system default shapes. Is only possible when the OS mouse cursor has been set visible from the Input subsystem.
@@ -146,9 +131,9 @@ protected:
     void HandleMouseVisibleChanged(StringHash eventType, VariantMap& eventData);
 
     /// Current shape index.
-    StringHash shape_;
+    String shape_;
     /// Shape definitions.
-    HashMap<StringHash, CursorShapeInfo> shapeInfos_;
+    HashMap<String, CursorShapeInfo> shapeInfos_;
     /// Use system default shapes flag.
     bool useSystemShapes_;
     /// OS cursor shape needs update flag.


### PR DESCRIPTION
Looking to address issues raised in #521, this allows a Sound Type to be defined via a StringHash or the old enum style and preserves loading the old enum style (but will not serialize it again in the future if the scene is exported).

Editor support added for managed Audio Master Gains. For user defined ones they ui element can be dragged onto a line edit to set the underlying string hash value into that field.

In addition to this allows Cursor Shapes to be defined in a similar manner while preserving the enum for UI, sdl and backwards compatibility (except in cases where GetShape is used as that no longer returns a CursorShape). However serialization has been refactored and is no longer backwards compatible, for example it now looks like:

```
            <variant type="VariantVector" >
                <variant type="String" value="Busy" />
                <variant type="ResourceRef" value="Image;Textures/UI.png" />
                <variant type="IntRect" value="128 64 148 85" />
                <variant type="IntVector2" value="9 9" />
            </variant>   
```

By no means a sure thing, only one way of doing this so feedback more than welcome.
