### PR TITLE
ScriptObject can be stored in Variant. 

### DIFF
--- a/Source/Engine/Script/CoreAPI.cpp
+++ b/Source/Engine/Script/CoreAPI.cpp
@@ -253,6 +253,15 @@ static void ConstructVariantPtr(RefCounted* value, Variant* ptr)
     new(ptr) Variant(value);
 }
 
+static void ConstructVariantScriptObject(asIScriptObject* value, Variant* ptr)
+{
+    asIObjectType* scriptObjectInterface = value->GetEngine()->GetObjectTypeByName("ScriptObject");
+    if (!value->GetObjectType()->Implements(scriptObjectInterface))
+        new(ptr) Variant();
+
+    new(ptr) Variant(value);
+}
+
 static void ConstructVariantMatrix3(const Matrix3& value, Variant* ptr)
 {
     new(ptr) Variant(value);
@@ -301,6 +310,19 @@ static bool VariantEqualsVariantVector(CScriptArray* value, Variant* ptr)
 static CScriptArray* VariantGetVariantVector(Variant* ptr)
 {
     return VectorToArray<Variant>(ptr->GetVariantVector(), "Array<Variant>");
+}
+
+static asIScriptObject* VariantGetScriptObject(Variant* ptr)
+{
+    asIScriptObject* object = static_cast<asIScriptObject*>(ptr->GetVoidPtr());
+    if (object == NULL)
+        return NULL;
+
+    asIObjectType* scriptObjectInterface = object->GetEngine()->GetObjectTypeByName("ScriptObject");
+    if (!object->GetObjectType()->Implements(scriptObjectInterface))
+        return NULL;
+
+    return object;
 }
 
 static void ConstructVariantMap(VariantMap* ptr)
@@ -430,6 +452,7 @@ static void RegisterVariant(asIScriptEngine* engine)
     engine->RegisterObjectBehaviour("Variant", asBEHAVE_CONSTRUCT, "void f(const IntRect&in)", asFUNCTION(ConstructVariantIntRect), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectBehaviour("Variant", asBEHAVE_CONSTRUCT, "void f(const IntVector2&in)", asFUNCTION(ConstructVariantIntVector2), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectBehaviour("Variant", asBEHAVE_CONSTRUCT, "void f(RefCounted@+)", asFUNCTION(ConstructVariantPtr), asCALL_CDECL_OBJLAST);
+    engine->RegisterObjectBehaviour("Variant", asBEHAVE_CONSTRUCT, "void f(ScriptObject@+)", asFUNCTION(ConstructVariantScriptObject), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectBehaviour("Variant", asBEHAVE_CONSTRUCT, "void f(const Matrix3&in)", asFUNCTION(ConstructVariantMatrix3), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectBehaviour("Variant", asBEHAVE_CONSTRUCT, "void f(const Matrix3x4&in)", asFUNCTION(ConstructVariantMatrix3x4), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectBehaviour("Variant", asBEHAVE_CONSTRUCT, "void f(const Matrix4&in)", asFUNCTION(ConstructVariantMatrix4), asCALL_CDECL_OBJLAST);
@@ -456,6 +479,7 @@ static void RegisterVariant(asIScriptEngine* engine)
     engine->RegisterObjectMethod("Variant", "Variant& opAssign(const IntRect&in)", asMETHODPR(Variant, operator =, (const IntRect&), Variant&), asCALL_THISCALL);
     engine->RegisterObjectMethod("Variant", "Variant& opAssign(const IntVector2&in)", asMETHODPR(Variant, operator =, (const IntVector2&), Variant&), asCALL_THISCALL);
     engine->RegisterObjectMethod("Variant", "Variant& opAssign(RefCounted@+)", asMETHODPR(Variant, operator =, (RefCounted*), Variant&), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Variant", "Variant& opAssign(ScriptObject@+)", asMETHODPR(Variant, operator =, (void*), Variant&), asCALL_THISCALL);
     engine->RegisterObjectMethod("Variant", "Variant& opAssign(const Matrix3&in)", asMETHODPR(Variant, operator =, (const Matrix3&), Variant&), asCALL_THISCALL);
     engine->RegisterObjectMethod("Variant", "Variant& opAssign(const Matrix3x4&in)", asMETHODPR(Variant, operator =, (const Matrix3x4&), Variant&), asCALL_THISCALL);
     engine->RegisterObjectMethod("Variant", "Variant& opAssign(const Matrix4&in)", asMETHODPR(Variant, operator =, (const Matrix4&), Variant&), asCALL_THISCALL);
@@ -478,6 +502,7 @@ static void RegisterVariant(asIScriptEngine* engine)
     engine->RegisterObjectMethod("Variant", "bool opEquals(const IntRect&in) const", asMETHODPR(Variant, operator ==, (const IntRect&) const, bool), asCALL_THISCALL);
     engine->RegisterObjectMethod("Variant", "bool opEquals(const IntVector2&in) const", asMETHODPR(Variant, operator ==, (const IntVector2&) const, bool), asCALL_THISCALL);
     engine->RegisterObjectMethod("Variant", "bool opEquals(RefCounted@+) const", asMETHODPR(Variant, operator ==, (RefCounted*) const, bool), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Variant", "bool opEquals(ScriptObject@+) const", asMETHODPR(Variant, operator ==, (void*) const, bool), asCALL_THISCALL);
     engine->RegisterObjectMethod("Variant", "bool opEquals(const Matrix3&in) const", asMETHODPR(Variant, operator ==, (const Matrix3&) const, bool), asCALL_THISCALL);
     engine->RegisterObjectMethod("Variant", "bool opEquals(const Matrix3x4&in) const", asMETHODPR(Variant, operator ==, (const Matrix3x4&) const, bool), asCALL_THISCALL);
     engine->RegisterObjectMethod("Variant", "bool opEquals(const Matrix4&in) const", asMETHODPR(Variant, operator ==, (const Matrix4&) const, bool), asCALL_THISCALL);
@@ -499,6 +524,7 @@ static void RegisterVariant(asIScriptEngine* engine)
     engine->RegisterObjectMethod("Variant", "const IntRect& GetIntRect() const", asMETHOD(Variant, GetIntRect), asCALL_THISCALL);
     engine->RegisterObjectMethod("Variant", "const IntVector2& GetIntVector2() const", asMETHOD(Variant, GetIntVector2), asCALL_THISCALL);
     engine->RegisterObjectMethod("Variant", "RefCounted@+ GetPtr() const", asMETHOD(Variant, GetPtr), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Variant", "ScriptObject@+ GetScriptObject() const", asFUNCTION(VariantGetScriptObject), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod("Variant", "const Matrix3& GetMatrix3() const", asMETHOD(Variant, GetMatrix3), asCALL_THISCALL);
     engine->RegisterObjectMethod("Variant", "const Matrix3x4& GetMatrix3x4() const", asMETHOD(Variant, GetMatrix3x4), asCALL_THISCALL);
     engine->RegisterObjectMethod("Variant", "const Matrix4& GetMatrix4() const", asMETHOD(Variant, GetMatrix4), asCALL_THISCALL);

--- a/Source/Engine/Script/Script.cpp
+++ b/Source/Engine/Script/Script.cpp
@@ -70,6 +70,7 @@ Script::Script(Context* context) :
     RegisterArray(scriptEngine_);
     RegisterString(scriptEngine_);
     RegisterDictionary(scriptEngine_);
+    RegisterScriptInterfaceAPI(scriptEngine_);
 
     // Register the rest of the script API
     RegisterMathAPI(scriptEngine_);

--- a/Source/Engine/Script/ScriptAPI.cpp
+++ b/Source/Engine/Script/ScriptAPI.cpp
@@ -254,7 +254,6 @@ static void SelfRemove()
 
 static void RegisterScriptInstance(asIScriptEngine* engine)
 {
-    engine->RegisterInterface("ScriptObject");
     engine->RegisterObjectMethod("Node", "ScriptObject@+ CreateScriptObject(ScriptFile@+, const String&in, CreateMode mode = REPLICATED)", asFUNCTION(NodeCreateScriptObjectWithFile), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod("Node", "ScriptObject@+ CreateScriptObject(const String&in, const String&in, CreateMode mode = REPLICATED)", asFUNCTION(NodeCreateScriptObject), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod("Node", "ScriptObject@+ GetScriptObject() const", asFUNCTION(NodeGetScriptObject), asCALL_CDECL_OBJLAST);
@@ -310,6 +309,16 @@ static void RegisterScript(asIScriptEngine* engine)
     engine->RegisterObjectMethod("Script", "void set_executeConsoleCommands(bool)", asMETHOD(Script, SetExecuteConsoleCommands), asCALL_THISCALL);
     engine->RegisterObjectMethod("Script", "bool get_executeConsoleCommands() const", asMETHOD(Script, GetExecuteConsoleCommands), asCALL_THISCALL);
     engine->RegisterGlobalFunction("Script@+ get_script()", asFUNCTION(GetScript), asCALL_CDECL);
+}
+
+static void RegisterScriptObject(asIScriptEngine* engine)
+{
+    engine->RegisterInterface("ScriptObject");
+}
+
+void RegisterScriptInterfaceAPI(asIScriptEngine* engine)
+{
+    RegisterScriptObject(engine);
 }
 
 void RegisterScriptAPI(asIScriptEngine* engine)

--- a/Source/Engine/Script/ScriptAPI.h
+++ b/Source/Engine/Script/ScriptAPI.h
@@ -59,6 +59,8 @@ void RegisterNavigationAPI(asIScriptEngine* engine);
 #endif
 /// Register the Urho2D library to script.
 void RegisterUrho2DAPI(asIScriptEngine* engine);
+/// Register the Script interfaces to script.
+void RegisterScriptInterfaceAPI(asIScriptEngine* engine);
 /// Register the Script library to script.
 void RegisterScriptAPI(asIScriptEngine* engine);
 /// Register the Engine library to script.


### PR DESCRIPTION
There is a risk to this as the reference is not increased when storing it so if the original handle isn't stored correctly in the script it can be null when getting.

```
class Test : ScriptObject
{
    String msg;

    Test()
    {
    }

    Test(const String& msg)
    {
        this.msg = msg;
    }
}

    Test@ test1 = Test("I'm a Test");
    Variant var = Variant(@test1);

    Test@ test2 = cast<Test>(var.GetScriptObject());
    if (@test2 !is null)
        Print(test2.msg);
    else
        Print("Null");
```
