### PR TITLE
Fixed input lag

### DIFF
--- a/Source/Urho3D/Input/Input.cpp
+++ b/Source/Urho3D/Input/Input.cpp
@@ -159,9 +159,8 @@ void Input::Update()
     }
 
     // Check and handle SDL events
-    SDL_PumpEvents();
     SDL_Event evt;
-    while (SDL_PeepEvents(&evt, 1, SDL_GETEVENT, SDL_FIRSTEVENT, SDL_LASTEVENT) > 0)
+    while (SDL_PollEvent(&evt))
         HandleSDLEvent(&evt);
 
     if (mouseVisible_ && mouseMode_ == MM_WRAP)


### PR DESCRIPTION
Fixed an input lag that was especially noticable with vsync by switching from SDL_PeepEvents to SDL_PollEvent. Using OpenGL the lag is completely gone and with DirectX it's greatly reduced (and can be almost gone by setting max fps = refresh rate).

Note that the OpenGL version uses SDL_GL_SetSwapInterval while the DirectX version uses D3DPRESENT_INTERVAL_ONE to enable VSync. I haven't looked into it but it could be that SDL_GL_SetSwapInterval does some internal stuff that fix the lag with the input polling when using VSync, unlike the DirectX version.

Also the only sagnificant difference between SDL_PeepEvents and SDL_PollEvent is that SDL_PeepEvents is thread safe, tho it shouldn't matter because the event polling isn't threaded.