### PR TITLE
User-configurable indentation for XML and JSON files

### DIFF
--- a/Source/ThirdParty/rapidjson/include/rapidjson/prettywriter.h
+++ b/Source/ThirdParty/rapidjson/include/rapidjson/prettywriter.h
@@ -31,7 +31,8 @@ public:
 		\note The default indentation is 4 spaces.
 	*/
 	PrettyWriter& SetIndent(Ch indentChar, unsigned indentCharCount) {
-		RAPIDJSON_ASSERT(indentChar == ' ' || indentChar == '\t' || indentChar == '\n' || indentChar == '\r');
+		// Urho3D: in order to be consistent witht the XMLFile API, allow any character.
+		// RAPIDJSON_ASSERT(indentChar == ' ' || indentChar == '\t' || indentChar == '\n' || indentChar == '\r');
 		indentChar_ = indentChar;
 		indentCharCount_ = indentCharCount;
 		return *this;

--- a/Source/Urho3D/LuaScript/pkgs/Resource/JSONFile.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Resource/JSONFile.pkg
@@ -9,6 +9,8 @@ class JSONFile : Resource
 
     JSONValue CreateRoot(JSONValueType valueType = JSON_OBJECT);
     JSONValue GetRoot(JSONValueType valueType = JSON_ANY);
+
+    tolua_outside bool JSONFileSave @ Save(const String fileName, const String indentation = "\t") const;
 };
 
 ${
@@ -22,5 +24,16 @@ static int tolua_ResourceLuaAPI_JSONFile_new00(lua_State* tolua_S)
 static int tolua_ResourceLuaAPI_JSONFile_new00_local(lua_State* tolua_S)
 {
     return ToluaNewObjectGC<JSONFile>(tolua_S);
+}
+$}
+
+${
+static bool JSONFileSave(const JSONFile* resource, const String& fileName, const String& indentation)
+{
+    if (!resource)
+        return false;
+
+    File file(resource->GetContext());
+    return file.Open(fileName, FILE_WRITE) && resource->Save(file, indentation);
 }
 $}

--- a/Source/Urho3D/LuaScript/pkgs/Resource/XMLFile.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Resource/XMLFile.pkg
@@ -8,10 +8,12 @@ class XMLFile : public Resource
     bool FromString(const String source);
     XMLElement CreateRoot(const String name = String::EMPTY);
     XMLElement GetRoot(const String name = String::EMPTY);
-    String ToString() const;
+    String ToString(const String indentation = "\t") const;
 
     void Patch(XMLFile* patchFile);
     void Patch(XMLElement patchElement);
+
+    tolua_outside bool XMLFileSave @ Save(const String fileName, const String indentation = "\t") const;
 };
 
 ${
@@ -25,5 +27,16 @@ static int tolua_ResourceLuaAPI_XMLFile_new00(lua_State* tolua_S)
 static int tolua_ResourceLuaAPI_XMLFile_new00_local(lua_State* tolua_S)
 {
     return ToluaNewObjectGC<XMLFile>(tolua_S);
+}
+$}
+
+${
+static bool XMLFileSave(const XMLFile* resource, const String& fileName, const String& indentation)
+{
+    if (!resource)
+        return false;
+
+    File file(resource->GetContext());
+    return file.Open(fileName, FILE_WRITE) && resource->Save(file, indentation);
 }
 $}

--- a/Source/Urho3D/Resource/JSONFile.cpp
+++ b/Source/Urho3D/Resource/JSONFile.cpp
@@ -84,9 +84,14 @@ bool JSONFile::BeginLoad(Deserializer& source)
 
 bool JSONFile::Save(Serializer& dest) const
 {
+    return Save(dest, "\t");
+}
+
+bool JSONFile::Save(Serializer& dest, const String &indendation) const
+{
     StringBuffer buffer;
     PrettyWriter<StringBuffer> writer(buffer, &(document_->GetAllocator()));
-    writer.SetIndent('\t', 1);
+    writer.SetIndent(!indendation.Empty() ?  indendation.Front() : '\0', indendation.Length());
 
     document_->Accept(writer);
     dest.Write(buffer.GetString(), buffer.GetSize());

--- a/Source/Urho3D/Resource/JSONFile.h
+++ b/Source/Urho3D/Resource/JSONFile.h
@@ -49,8 +49,10 @@ public:
 
     /// Load resource from stream. May be called from a worker thread. Return true if successful.
     virtual bool BeginLoad(Deserializer& source);
-    /// Save resource. Return true if successful. Only supports saving to a File.
+    /// Save resource with default indentation (one tab). Return true if successful. Only supports saving to a File.
     virtual bool Save(Serializer& dest) const;
+    /// Save resource with user-defined indentation, only the first character (if any) of the string is used and the length of the string defines the character count. Return true if successful. Only supports saving to a File.
+    bool Save(Serializer& dest, const String &indendation) const;
 
     /// Clear the document and create a root value, default is object type.
     JSONValue CreateRoot(JSONValueType valueType = JSON_OBJECT);

--- a/Source/Urho3D/Resource/XMLFile.cpp
+++ b/Source/Urho3D/Resource/XMLFile.cpp
@@ -134,8 +134,13 @@ bool XMLFile::BeginLoad(Deserializer& source)
 
 bool XMLFile::Save(Serializer& dest) const
 {
+    return Save(dest, "\t");
+}
+
+bool XMLFile::Save(Serializer& dest, const String &indendation) const
+{
     XMLWriter writer(dest);
-    document_->save(writer);
+    document_->save(writer, indendation.CString());
     return writer.success_;
 }
 
@@ -167,11 +172,11 @@ XMLElement XMLFile::GetRoot(const String& name)
         return XMLElement(this, root.internal_object());
 }
 
-String XMLFile::ToString() const
+String XMLFile::ToString(const String &indendation) const
 {
     VectorBuffer dest;
     XMLWriter writer(dest);
-    document_->save(writer);
+    document_->save(writer, indendation.CString());
     return String((const char*)dest.GetData(), dest.GetSize());
 }
 

--- a/Source/Urho3D/Resource/XMLFile.h
+++ b/Source/Urho3D/Resource/XMLFile.h
@@ -50,9 +50,11 @@ public:
     
     /// Load resource from stream. May be called from a worker thread. Return true if successful.
     virtual bool BeginLoad(Deserializer& source);
-    /// Save resource. Return true if successful. Only supports saving to a File.
+    /// Save resource with default indentation (one tab). Return true if successful. Only supports saving to a File.
     virtual bool Save(Serializer& dest) const;
-    
+    /// Save resource with user-defined indentation. Return true if successful. Only supports saving to a File.
+    bool Save(Serializer& dest, const String &indendation) const;
+
     /// Deserialize from a string. Return true if successful.
     bool FromString(const String& source);
     /// Clear the document and create a root element.
@@ -63,7 +65,7 @@ public:
     /// Return the pugixml document.
     pugi::xml_document* GetDocument() const { return document_; }
     /// Serialize the XML content to a string.
-    String ToString() const;
+    String ToString(const String &indendation = "\t") const;
 
     /// Patch the XMLFile with another XMLFile. Based on RFC 5261.
     void Patch(XMLFile* patchFile);

--- a/Source/Urho3D/Script/ResourceAPI.cpp
+++ b/Source/Urho3D/Script/ResourceAPI.cpp
@@ -332,11 +332,17 @@ static void RegisterJSONValue(asIScriptEngine* engine)
     engine->RegisterObjectMethod("JSONValue", "Variant GetVariantValue(uint, VariantType type) const", asMETHODPR(JSONValue, GetVariantValue, (unsigned, VariantType) const, Variant), asCALL_THISCALL);
 }
 
+static bool JSONFileSave(File* file, const String &indendation, JSONFile* ptr)
+{
+    return file && ptr->Save(*file, indendation);
+}
+
 static void RegisterJSONFile(asIScriptEngine* engine)
 {
     RegisterResource<JSONFile>(engine, "JSONFile");
     engine->RegisterObjectMethod("JSONFile", "JSONValue CreateRoot(JSONValueType valueType = JSON_ANY)", asMETHOD(JSONFile, CreateRoot), asCALL_THISCALL);
     engine->RegisterObjectMethod("JSONFile", "JSONValue GetRoot(JSONValueType valueType = JSON_ANY)", asMETHOD(JSONFile, GetRoot), asCALL_THISCALL);
+    engine->RegisterObjectMethod("JSONFile", "bool Save(File@+, const String&in) const", asFUNCTION(JSONFileSave), asCALL_CDECL_OBJLAST);
 }
 
 static void ConstructXMLElement(XMLElement* ptr)
@@ -517,12 +523,18 @@ static XMLElement XMLFileGetRootDefault(XMLFile* ptr)
     return ptr->GetRoot();
 }
 
+static bool XMLFileSave(File* file, const String &indendation, XMLFile* ptr)
+{
+    return file && ptr->Save(*file, indendation);
+}
+
 static void RegisterXMLFile(asIScriptEngine* engine)
 {
     engine->RegisterObjectMethod("XMLFile", "bool FromString(const String&in)", asMETHOD(XMLFile, FromString), asCALL_THISCALL);
     engine->RegisterObjectMethod("XMLFile", "XMLElement CreateRoot(const String&in)", asMETHOD(XMLFile, CreateRoot), asCALL_THISCALL);
     engine->RegisterObjectMethod("XMLFile", "XMLElement GetRoot(const String&in name = String())", asMETHOD(XMLFile, GetRoot), asCALL_THISCALL);
-    engine->RegisterObjectMethod("XMLFile", "String ToString() const", asMETHOD(XMLFile, ToString), asCALL_THISCALL);
+    engine->RegisterObjectMethod("XMLFile", "bool Save(File@+, const String&in) const", asFUNCTION(XMLFileSave), asCALL_CDECL_OBJLAST);
+    engine->RegisterObjectMethod("XMLFile", "String ToString(const String&in = String(\"\t\")) const", asMETHOD(XMLFile, ToString), asCALL_THISCALL);
     engine->RegisterObjectMethod("XMLFile", "XMLElement get_root()", asFUNCTION(XMLFileGetRootDefault), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod("XMLFile", "void Patch(XMLFile@+)", asMETHODPR(XMLFile, Patch, (XMLFile*), void), asCALL_THISCALL);
     engine->RegisterObjectMethod("XMLFile", "void Patch(XMLElement)", asMETHODPR(XMLFile, Patch, (XMLElement), void), asCALL_THISCALL);


### PR DESCRIPTION
User-configurable indentation for XML and JSON files (AS and Lua bindings included). Closes #591