### PR TITLE
Removal of hdrRendering variable caused compilation error when using the OpenGL renderer

### DIFF
--- a/Source/Urho3D/Graphics/View.cpp
+++ b/Source/Urho3D/Graphics/View.cpp
@@ -1938,7 +1938,7 @@ void View::AllocateScreenBuffers()
     }
     
     #ifdef URHO3D_OPENGL
-    if (deferred_ && !hdrRendering)
+    if (deferred_ && !renderer_->GetHDRRendering())
         format = Graphics::GetRGBAFormat();
     #endif
     


### PR DESCRIPTION
Fixed a minor compilation error when using the OpenGL renderer.