### PR TITLE
Fix PCH build with Clang

### DIFF
--- a/CMake/Modules/Urho3D-CMake-common.cmake
+++ b/CMake/Modules/Urho3D-CMake-common.cmake
@@ -661,7 +661,7 @@ macro (enable_pch HEADER_PATHNAME)
                 if (FILE MATCHES \\.cpp$)
                     get_property (NO_PCH SOURCE ${FILE} PROPERTY NO_PCH)
                     if (NOT NO_PCH)
-                        set_property (SOURCE ${FILE} APPEND_STRING PROPERTY COMPILE_FLAGS " -include ${HEADER_FILENAME}")
+                        set_property (SOURCE ${FILE} APPEND_STRING PROPERTY COMPILE_FLAGS " -include ${CMAKE_CURRENT_BINARY_DIR}/${HEADER_FILENAME}")
                     endif ()
                 endif ()
             endforeach ()
@@ -680,14 +680,6 @@ macro (enable_pch HEADER_PATHNAME)
                 set (TRIGGERS ${HEADER_FILENAME}.${CMAKE_BUILD_TYPE}.pch.trigger)
             endif ()
             list (APPEND SOURCE_FILES ${TRIGGERS})
-            # Ninja-build specific
-            if (CMAKE_GENERATOR STREQUAL Ninja)
-                # The precompiled header is always generated in the current binary dir,
-                # but Ninja project is not able to find it without adding the binary dir to the include search path
-                # FIXME: below quick fix may have negatively impacted ccache from perfoming correctly in Ninja
-                #        ccache increases the 'preprocessor error' stat count and fallbacks to perform the actual compilation which slows down the build unnecessarily
-                list (APPEND INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR})
-            endif ()
         endif ()
     endif ()
 endmacro ()


### PR DESCRIPTION
Clang doesn't use include path (-I) when looking for PCH files.  Use full path to header instead.  Tested on Ninja and Make builds using GCC and Clang.