### PR TITLE
Support MinGW 4.7 ABIs on Clang.

### DIFF
--- a/Source/ThirdParty/AngelScript/source/as_callfunc_x86.cpp
+++ b/Source/ThirdParty/AngelScript/source/as_callfunc_x86.cpp
@@ -1287,7 +1287,7 @@ endcopy:
 		"subl  $4, %%ecx       \n"
 		"jne   copyloop3       \n"
 		"endcopy3:             \n"
-#if defined(__MINGW32__) && ((__GNUC__ == 4 && __GNUC_MINOR__ >= 7) || __GNUC__ > 4)
+#ifdef AS_MINGW47_WORKAROUND
         // MinGW made some strange choices with 4.7, and the thiscall calling convention
         // when returning an object in memory is completely different from when not returning
         // in memory

--- a/Source/ThirdParty/AngelScript/source/as_config.h
+++ b/Source/ThirdParty/AngelScript/source/as_config.h
@@ -772,8 +772,17 @@
 			#undef AS_NO_THISCALL_FUNCTOR_METHOD
 
 			// As of version 4.7 MinGW changed the ABI, presumably
+
 			// to be better aligned with how MSVC works
 			#if (__GNUC__ == 4 && __GNUC_MINOR__ >= 7) || __GNUC__ > 4
+			    #define AS_MINGW47_WORKAROUND
+			#endif
+
+			#if (__clang_major__ == 3 && __clang_minor__ > 4)
+			    #define AS_MINGW47_WORKAROUND
+			#endif
+
+			#ifdef AS_MINGW47_WORKAROUND
 				#undef  CALLEE_POPS_HIDDEN_RETURN_POINTER
 				#define THISCALL_CALLEE_POPS_ARGUMENTS
 			#else


### PR DESCRIPTION
Fix for  #708.  Adds a secondary check for recent Clang versions in addition to mingw, so AngelScript won't cause explosions.