### PR TITLE
Iterate through updating the tilecache

### DIFF
--- a/Source/Urho3D/Navigation/DynamicNavigationMesh.cpp
+++ b/Source/Urho3D/Navigation/DynamicNavigationMesh.cpp
@@ -896,7 +896,9 @@ void DynamicNavigationMesh::AddObstacle(Obstacle* obstacle, bool silent)
         rcVcopy(pos, &obsPos.x_);
         dtObstacleRef refHolder;
 
-        if (tileCache_->isObstacleQueueFull())
+        // Because dtTileCache doesn't process obstacle requests while updating tiles 
+        // it's necessary update until sufficient request space is available
+        while (tileCache_->isObstacleQueueFull())
             tileCache_->update(1, navMesh_);
 
         if (dtStatusFailed(tileCache_->addObstacle(pos, obstacle->GetRadius(), obstacle->GetHeight(), &refHolder)))
@@ -906,7 +908,6 @@ void DynamicNavigationMesh::AddObstacle(Obstacle* obstacle, bool silent)
         }
         obstacle->obstacleId_ = refHolder;
         assert(refHolder > 0);
-        tileCache_->update(1, navMesh_);
 
         if (!silent)
         {
@@ -935,7 +936,9 @@ void DynamicNavigationMesh::RemoveObstacle(Obstacle* obstacle, bool silent)
 {
     if (tileCache_ && obstacle->obstacleId_ > 0)
     {
-        if (tileCache_->isObstacleQueueFull())
+        // Because dtTileCache doesn't process obstacle requests while updating tiles 
+        // it's necessary update until sufficient request space is available
+        while (tileCache_->isObstacleQueueFull())
             tileCache_->update(1, navMesh_);
 
         if (dtStatusFailed(tileCache_->removeObstacle(obstacle->obstacleId_)))


### PR DESCRIPTION
until open request space is available during obstacle addition/removal.
Pending tile updates may interfere with processing requests.