### PR TITLE
Fixed usage of deprecated GLSL function texture2DLod.

### DIFF
--- a/bin/CoreData/Shaders/GLSL/FXAA3.glsl
+++ b/bin/CoreData/Shaders/GLSL/FXAA3.glsl
@@ -314,13 +314,13 @@ float CalcLuma(vec3 rgb)
 
 /*--------------------------------------------------------------------------*/
 
-#define FxaaTexTop(t, p) vec4(texture2DLod(t, p, 0.0).rgb, 1.0)
+#define FxaaTexTop(t, p) vec4(textureLod(t, p, 0.0).rgb, 1.0)
 
-#define LumaTop(t, p) CalcLuma(texture2DLod(t, p, 0.0).rgb)
+#define LumaTop(t, p) CalcLuma(textureLod(t, p, 0.0).rgb)
 #if (FXAA_FAST_PIXEL_OFFSET == 1)
-    #define LumaOff(t, p, o, r) CalcLuma(texture2DLodOffset(t, p, 0.0, o).rgb)
+    #define LumaOff(t, p, o, r) CalcLuma(textureLodOffset(t, p, 0.0, o).rgb)
 #else
-    #define LumaOff(t, p, o, r) CalcLuma(texture2DLod(t, p + (o * r), 0.0).rgb)
+    #define LumaOff(t, p, o, r) CalcLuma(textureLod(t, p + (o * r), 0.0).rgb)
 #endif
 
 /*============================================================================


### PR DESCRIPTION
It is now textureLod and textureLodOffset. Error message was: (0(857) : error C7616: global function texture2DLod is removed after version 140)