### PR TITLE
Add `luaL_loadfile` support, with CMake option to prefer this strategy

### DIFF
--- a/CMake/Modules/Urho3D-CMake-common.cmake
+++ b/CMake/Modules/Urho3D-CMake-common.cmake
@@ -93,6 +93,20 @@ cmake_dependent_option (URHO3D_SSE "Enable SSE instruction set" ${URHO3D_DEFAULT
 if (CMAKE_PROJECT_NAME STREQUAL Urho3D)
     cmake_dependent_option (URHO3D_LUAJIT_AMALG "Enable LuaJIT amalgamated build (LuaJIT only)" FALSE "URHO3D_LUAJIT" FALSE)
     cmake_dependent_option (URHO3D_SAFE_LUA "Enable Lua C++ wrapper safety checks (Lua/LuaJIT only)" FALSE "URHO3D_LUA OR URHO3D_LUAJIT" FALSE)
+
+    set(LUA_RAW_DESC "Prefer loading raw script files from the file system before falling back on Urho3D resource cache. Useful for debugging (e.g. breakpoints), but less performant (Lua/LuaJIT only)")
+    if (CMAKE_BUILD_TYPE STREQUAL "Release")
+        cmake_dependent_option (
+            URHO3D_LUA_RAW_SCRIPT_LOADER
+            ${LUA_RAW_DESC} OFF "URHO3D_LUA OR URHO3D_LUAJIT" OFF
+        )    
+    else ()
+        cmake_dependent_option (
+            URHO3D_LUA_RAW_SCRIPT_LOADER
+            ${LUA_RAW_DESC} ON "URHO3D_LUA OR URHO3D_LUAJIT" OFF
+        )     
+    endif ()
+    
     option (URHO3D_SAMPLES "Build sample applications")
     cmake_dependent_option (URHO3D_TOOLS "Build tools (native and RPI only)" TRUE "NOT IOS AND NOT ANDROID AND NOT EMSCRIPTEN" FALSE)
     cmake_dependent_option (URHO3D_EXTRAS "Build extras (native and RPI only)" FALSE "NOT IOS AND NOT ANDROID AND NOT EMSCRIPTEN" FALSE)
@@ -319,6 +333,9 @@ if (URHO3D_LUA)
     if (NOT URHO3D_SAFE_LUA)
         add_definitions (-DTOLUA_RELEASE)
     endif ()
+endif ()
+if (URHO3D_LUA_RAW_SCRIPT_LOADER)
+    add_definitions (-DURHO3D_LUA_RAW_SCRIPT_LOADER)
 endif ()
 
 # Add definition for Navigation

--- a/CMake/Modules/Urho3D-CMake-common.cmake
+++ b/CMake/Modules/Urho3D-CMake-common.cmake
@@ -94,19 +94,13 @@ if (CMAKE_PROJECT_NAME STREQUAL Urho3D)
     cmake_dependent_option (URHO3D_LUAJIT_AMALG "Enable LuaJIT amalgamated build (LuaJIT only)" FALSE "URHO3D_LUAJIT" FALSE)
     cmake_dependent_option (URHO3D_SAFE_LUA "Enable Lua C++ wrapper safety checks (Lua/LuaJIT only)" FALSE "URHO3D_LUA OR URHO3D_LUAJIT" FALSE)
 
-    set(LUA_RAW_DESC "Prefer loading raw script files from the file system before falling back on Urho3D resource cache. Useful for debugging (e.g. breakpoints), but less performant (Lua/LuaJIT only)")
-    if (CMAKE_BUILD_TYPE STREQUAL "Release")
-        cmake_dependent_option (
-            URHO3D_LUA_RAW_SCRIPT_LOADER
-            ${LUA_RAW_DESC} OFF "URHO3D_LUA OR URHO3D_LUAJIT" OFF
-        )    
+    if (CMAKE_BUILD_TYPE STREQUAL Release OR CMAKE_CONFIGURATION_TYPES)
+        set (URHO3D_DEFAULT_LUA_RAW FALSE)
     else ()
-        cmake_dependent_option (
-            URHO3D_LUA_RAW_SCRIPT_LOADER
-            ${LUA_RAW_DESC} ON "URHO3D_LUA OR URHO3D_LUAJIT" OFF
-        )     
+        set (URHO3D_DEFAULT_LUA_RAW TRUE)
     endif ()
-    
+    cmake_dependent_option (URHO3D_LUA_RAW_SCRIPT_LOADER "Prefer loading raw script files from the file system before falling back on Urho3D resource cache. Useful for debugging (e.g. breakpoints), but less performant (Lua/LuaJIT only)" ${URHO3D_DEFAULT_LUA_RAW} "URHO3D_LUA OR URHO3D_LUAJIT" FALSE)
+ 
     option (URHO3D_SAMPLES "Build sample applications")
     cmake_dependent_option (URHO3D_TOOLS "Build tools (native and RPI only)" TRUE "NOT IOS AND NOT ANDROID AND NOT EMSCRIPTEN" FALSE)
     cmake_dependent_option (URHO3D_EXTRAS "Build extras (native and RPI only)" FALSE "NOT IOS AND NOT ANDROID AND NOT EMSCRIPTEN" FALSE)

--- a/Docs/GettingStarted.dox
+++ b/Docs/GettingStarted.dox
@@ -77,6 +77,7 @@ A number of build options can be defined when invoking the build scripts or when
 |URHO3D_LUAJIT        |0|Enable Lua scripting support using LuaJIT (check LuaJIT's CMakeLists.txt for more options)|
 |URHO3D_LUAJIT_AMALG  |0|Enable LuaJIT amalgamated build (LuaJIT only)|
 |URHO3D_SAFE_LUA      |0|Enable Lua C++ wrapper safety checks (Lua/LuaJIT only)|
+|URHO3D_LUA_RAW_SCRIPT_LOADER  |0|Prefer loading raw script files from the file system before falling back on Urho3D resource cache. Useful for debugging (e.g. breakpoints), but less performant (Lua/LuaJIT only)|
 |URHO3D_NETWORK       |1|Enable Networking support|
 |URHO3D_PHYSICS       |1|Enable Physics support|
 |URHO3D_NAVIGATION    |1|Enable Navigation support|

--- a/Docs/Reference.dox
+++ b/Docs/Reference.dox
@@ -607,6 +607,18 @@ In contrast to AngelScript modules, which exist as separate entities and do not 
 
 After that, the functions in the script file are available for calling. Use \ref LuaScript::GetFunction "GetFunction()" to get a Lua function by name. This returns a LuaFunction object, on which you should call \ref LuaFunction::BeginCall "BeginCall()" first, followed by pushing the function parameters if any, and finally execute the function with \ref LuaFunction::EndCall "EndCall()".
 
+\subsection LuaScripting_Debugging Debugging script files
+
+Debugging Lua scripts embedded in an application can be done by attaching to a remote debugger, after first injecting a client into the application (for example, see <a href="https://wiki.eclipse.org/LDT/User_Area/User_Guides/User_Guide_1.2#Attach_session">eclipse LDT's remote debugger</a>). 
+
+However, Lua script files in Urho3D are loaded into the interpreter via Urho3D's resource cache, which loads the script file into a memory buffer before passing that buffer to the interpreter. This is good for performance and cross platform compatibility, but means that the source file is not available to debuggers and so, for example, breakpoints may not work and the code cannot be meaningfully stepped through.
+
+For a single script that you wish to step through, you can use \ref LuaScript::ExecuteRawFile "ExecuteRawFile()", which will load the script from the file system directly into the Lua interpreter, making the source available to debuggers that rely on it. There are a couple of caveats with this: 
+- The file has has to be on the file system, within a resource directory, and not packaged.
+- If the script uses `require()` to import a second script, then that second script will not be available for the debugger in the same way, since internally the second script is passed to Lua via the resource cache.
+
+To get around the second caveat, and avoid changing method calls, use the CMake flag `URHO3D_LUA_RAW_SCRIPT_LOADER`.  This will force Urho3D to attempt to load scripts from the file system by default, before falling back on the resource cache.  You can then use \ref LuaScript::ExecuteFile "ExecuteFile()", as above, and disable the CMake option for production if required.
+
 \section LuaScripting_ScriptObjects Script objects
 
 By using the LuaScriptInstance component, Lua script objects can be added to scene nodes. After the component has been created, there are two ways to specify the object to instantiate: either specifying both the script file name and the object class name, in which case the script file is loaded and executed first, or specifying only the class name, in which case the Lua code containing the class definition must already have been executed. An example of creating a script object in C++ from the LuaIntegration sample, where a class called Rotator is instantiated from the script file Rotator.lua:

--- a/Source/Urho3D/LuaScript/LuaScript.cpp
+++ b/Source/Urho3D/LuaScript/LuaScript.cpp
@@ -224,7 +224,7 @@ bool LuaScript::ExecuteFile(const String& fileName)
 
 #ifdef URHO3D_LUA_RAW_SCRIPT_LOADER
     if (ExecuteRawFile(fileName))
-    	return true;
+        return true;
 #endif
 
     ResourceCache* cache = GetSubsystem<ResourceCache>();
@@ -261,7 +261,7 @@ bool LuaScript::LoadRawFile(const String& fileName)
     if (filePath.Empty())
     {
         LOGINFO("Lua file not found: " + fileName);
-    	return false;
+        return false;
     }
 
     filePath = GetNativePath(filePath);
@@ -287,10 +287,10 @@ bool LuaScript::ExecuteRawFile(const String& fileName)
 {
     PROFILE(ExecuteRawFile);
 
-	int top = lua_gettop(luaState_);
+    int top = lua_gettop(luaState_);
 
     if (!LoadRawFile(fileName))
-		return false;
+        return false;
 
     if (lua_pcall(luaState_, 0, 0, 0))
     {
@@ -349,17 +349,17 @@ int LuaScript::AtPanic(lua_State* L)
 
 int LuaScript::Loader(lua_State* L)
 {
-	LuaScript* lua = ::GetContext(L)->GetSubsystem<LuaScript>();
+    LuaScript* lua = ::GetContext(L)->GetSubsystem<LuaScript>();
     // Get module name
-	String fileName(luaL_checkstring(L, 1));
+    String fileName(luaL_checkstring(L, 1));
 
 #ifdef URHO3D_LUA_RAW_SCRIPT_LOADER
     // First attempt to load lua script file from the file system.
-	// Attempt to load .luc file first, then fall back to .lua.
-	if (
-		lua->LoadRawFile(fileName + ".luc")
-		|| lua->LoadRawFile(fileName + ".lua")
-	) return 1;
+    // Attempt to load .luc file first, then fall back to .lua.
+    if (
+        lua->LoadRawFile(fileName + ".luc")
+        || lua->LoadRawFile(fileName + ".lua")
+    ) return 1;
 #endif
 
     ResourceCache* cache = ::GetContext(L)->GetSubsystem<ResourceCache>();

--- a/Source/Urho3D/LuaScript/LuaScript.cpp
+++ b/Source/Urho3D/LuaScript/LuaScript.cpp
@@ -23,6 +23,7 @@
 #include "../Core/CoreEvents.h"
 #include "../Engine/EngineEvents.h"
 #include "../IO/File.h"
+#include "../IO/FileSystem.h"
 #include "../IO/Log.h"
 #include "../LuaScript/LuaFile.h"
 #include "../LuaScript/LuaFunction.h"
@@ -221,6 +222,11 @@ bool LuaScript::ExecuteFile(const String& fileName)
 {
     PROFILE(ExecuteFile);
 
+#ifdef URHO3D_LUA_RAW_SCRIPT_LOADER
+    if (ExecuteRawFile(fileName))
+    	return true;
+#endif
+
     ResourceCache* cache = GetSubsystem<ResourceCache>();
     LuaFile* luaFile = cache->GetResource<LuaFile>(fileName);
     return luaFile && luaFile->LoadAndExecute(luaState_);
@@ -236,6 +242,60 @@ bool LuaScript::ExecuteString(const String& string)
     {
         const char* message = lua_tostring(luaState_, -1);
         LOGERROR("Execute Lua string failed: " + String(message));
+        lua_settop(luaState_, top);
+        return false;
+    }
+
+    return true;
+}
+
+bool LuaScript::LoadRawFile(const String& fileName)
+{
+    PROFILE(LoadRawFile);
+
+    LOGINFO("Finding Lua file on file system: " + fileName);
+
+    ResourceCache* cache = GetSubsystem<ResourceCache>();
+    String filePath = cache->GetResourceFileName(fileName);
+
+    if (filePath.Empty())
+    {
+        LOGINFO("Lua file not found: " + fileName);
+    	return false;
+    }
+
+    filePath = GetNativePath(filePath);
+
+    LOGINFO("Loading Lua file from file system: " + filePath);
+
+    int top = lua_gettop(luaState_);
+
+    if (luaL_loadfile (luaState_, filePath.CString()))
+    {
+        const char* message = lua_tostring(luaState_, -1);
+        LOGERROR("Load Lua file failed: " + String(message));
+        lua_settop(luaState_, top);
+        return false;
+    }
+
+    LOGINFO("Lua file loaded: " + filePath);
+
+    return true;
+}
+
+bool LuaScript::ExecuteRawFile(const String& fileName)
+{
+    PROFILE(ExecuteRawFile);
+
+	int top = lua_gettop(luaState_);
+
+    if (!LoadRawFile(fileName))
+		return false;
+
+    if (lua_pcall(luaState_, 0, 0, 0))
+    {
+        const char* message = lua_tostring(luaState_, -1);
+        LOGERROR("Execute Lua file failed: " + String(message));
         lua_settop(luaState_, top);
         return false;
     }
@@ -289,20 +349,29 @@ int LuaScript::AtPanic(lua_State* L)
 
 int LuaScript::Loader(lua_State* L)
 {
+	LuaScript* lua = ::GetContext(L)->GetSubsystem<LuaScript>();
+    // Get module name
+	String fileName(luaL_checkstring(L, 1));
+
+#ifdef URHO3D_LUA_RAW_SCRIPT_LOADER
+    // First attempt to load lua script file from the file system.
+	// Attempt to load .luc file first, then fall back to .lua.
+	if (
+		lua->LoadRawFile(fileName + ".luc")
+		|| lua->LoadRawFile(fileName + ".lua")
+	) return 1;
+#endif
+
     ResourceCache* cache = ::GetContext(L)->GetSubsystem<ResourceCache>();
 
-    // Get module name
-    const char* name = luaL_checkstring(L, 1);
-
     // Attempt to get .luc file first.
-    String lucFileName = String(name) + ".luc";
-    LuaFile* lucFile = cache->GetResource<LuaFile>(lucFileName, false);
+    LuaFile* lucFile = cache->GetResource<LuaFile>(fileName + ".luc", false);
     if (lucFile)
         return lucFile->LoadChunk(L) ? 1 : 0;
 
-    // Then try to get .lua file. If this also fails, error is logged and resource not found event is sent
-    String luaFileName = String(name) + ".lua";
-    LuaFile* luaFile = cache->GetResource<LuaFile>(luaFileName);
+    // Then try to get .lua file. If this also fails, error is logged and
+    // resource not found event is sent
+    LuaFile* luaFile = cache->GetResource<LuaFile>(fileName + ".lua");
     if (luaFile)
         return luaFile->LoadChunk(L) ? 1 : 0;
 

--- a/Source/Urho3D/LuaScript/LuaScript.h
+++ b/Source/Urho3D/LuaScript/LuaScript.h
@@ -71,6 +71,12 @@ public:
     bool ExecuteFile(const String& fileName);
     /// Execute script string. Return true if successful.
     bool ExecuteString(const String& string);
+    /// Load script file on file system (i.e. not from resource cache).
+    /// Return true if successful.
+    bool LoadRawFile(const String& fileName);
+    /// Load and execute script file on file system (i.e. not from resource cache).
+    /// Return true if successful.
+    bool ExecuteRawFile(const String& fileName);
     /// Execute script function.
     bool ExecuteFunction(const String& functionName);
     /// Send event.

--- a/Source/Urho3D/LuaScript/LuaScript.h
+++ b/Source/Urho3D/LuaScript/LuaScript.h
@@ -71,11 +71,9 @@ public:
     bool ExecuteFile(const String& fileName);
     /// Execute script string. Return true if successful.
     bool ExecuteString(const String& string);
-    /// Load script file on file system (i.e. not from resource cache).
-    /// Return true if successful.
+    /// Load script file on file system (i.e. not from resource cache). Return true if successful.
     bool LoadRawFile(const String& fileName);
-    /// Load and execute script file on file system (i.e. not from resource cache).
-    /// Return true if successful.
+    /// Load and execute script file on file system (i.e. not from resource cache). Return true if successful.
     bool ExecuteRawFile(const String& fileName);
     /// Execute script function.
     bool ExecuteFunction(const String& functionName);


### PR DESCRIPTION
* Added `LuaScript::LoadRawFile` and `LuaScript::ExecuteRawFile` to load
files using `luaL_loadfile` rather than via the resource cache
(`luaL_loadbuffer`).  This strategy makes the source available to Lua
debuggers (e.g. eclipse LDT) for setting breakpoints, etc.
* Added a CMake option `URHO3D_LUA_RAW_SCRIPT_LOADER` to make
`luaL_loadfile` the default script loading strategy.
  - `LuaScript::ExecuteFile` will thus prefer the `luaL_loadfile`
strategy, aiding in debugging as above, but without needing to change
method calls.
  -  `LuaScript::Loader` will also prefer the `luaL_loadfile` strategy,
so that scripts `require`d in the main script are also amenable to
debugging.
  - If a script file cannot be loaded from the file system, then it will
fall back on the default resource cache `luaL_loadbuffer` strategy (e.g.
for packaged scripts).