### PR TITLE
Allow ray queries to return UV texture coordinates of ray intersection

### DIFF
--- a/Source/Samples/08_Decals/Decals.cpp
+++ b/Source/Samples/08_Decals/Decals.cpp
@@ -24,7 +24,6 @@
 
 #include <Urho3D/Graphics/Camera.h>
 #include <Urho3D/Core/CoreEvents.h>
-#include <Urho3D/IO/Log.h>
 #include <Urho3D/UI/Cursor.h>
 #include <Urho3D/Graphics/DebugRenderer.h>
 #include <Urho3D/Graphics/DecalSet.h>
@@ -64,10 +63,10 @@ void Decals::Start()
 
     // Create the scene content
     CreateScene();
-    
+
     // Create the UI content
     CreateUI();
-    
+
     // Setup the viewport for displaying the scene
     SetupViewport();
 
@@ -78,21 +77,21 @@ void Decals::Start()
 void Decals::CreateScene()
 {
     ResourceCache* cache = GetSubsystem<ResourceCache>();
-    
+
     scene_ = new Scene(context_);
-    
+
     // Create octree, use default volume (-1000, -1000, -1000) to (1000, 1000, 1000)
     // Also create a DebugRenderer component so that we can draw debug geometry
     scene_->CreateComponent<Octree>();
     scene_->CreateComponent<DebugRenderer>();
-    
+
     // Create scene node & StaticModel component for showing a static plane
     Node* planeNode = scene_->CreateChild("Plane");
     planeNode->SetScale(Vector3(100.0f, 1.0f, 100.0f));
     StaticModel* planeObject = planeNode->CreateComponent<StaticModel>();
     planeObject->SetModel(cache->GetResource<Model>("Models/Plane.mdl"));
     planeObject->SetMaterial(cache->GetResource<Material>("Materials/StoneTiled.xml"));
-    
+
     // Create a Zone component for ambient lighting & fog control
     Node* zoneNode = scene_->CreateChild("Zone");
     Zone* zone = zoneNode->CreateComponent<Zone>();
@@ -101,7 +100,7 @@ void Decals::CreateScene()
     zone->SetFogColor(Color(0.5f, 0.5f, 0.7f));
     zone->SetFogStart(100.0f);
     zone->SetFogEnd(300.0f);
-    
+
     // Create a directional light to the world. Enable cascaded shadows on it
     Node* lightNode = scene_->CreateChild("DirectionalLight");
     lightNode->SetDirection(Vector3(0.6f, -1.0f, 0.8f));
@@ -125,7 +124,7 @@ void Decals::CreateScene()
         mushroomObject->SetMaterial(cache->GetResource<Material>("Materials/Mushroom.xml"));
         mushroomObject->SetCastShadows(true);
     }
-    
+
     // Create randomly sized boxes. If boxes are big enough, make them occluders. Occluders will be software rasterized before
     // rendering to a low-resolution depth-only buffer to test the objects in the view frustum for visibility
     const unsigned NUM_BOXES = 20;
@@ -142,12 +141,12 @@ void Decals::CreateScene()
         if (size >= 3.0f)
             boxObject->SetOccluder(true);
     }
-    
+
     // Create the camera. Limit far clip distance to match the fog
     cameraNode_ = scene_->CreateChild("Camera");
     Camera* camera = cameraNode_->CreateComponent<Camera>();
     camera->SetFarClip(300.0f);
-    
+
     // Set an initial position for the camera scene node above the plane
     cameraNode_->SetPosition(Vector3(0.0f, 5.0f, 0.0f));
 }
@@ -156,7 +155,7 @@ void Decals::CreateUI()
 {
     ResourceCache* cache = GetSubsystem<ResourceCache>();
     UI* ui = GetSubsystem<UI>();
-    
+
     // Create a Cursor UI element because we want to be able to hide and show it at will. When hidden, the mouse cursor will
     // control the camera, and when visible, it will point the raycast target
     XMLFile* style = cache->GetResource<XMLFile>("UI/DefaultStyle.xml");
@@ -166,7 +165,7 @@ void Decals::CreateUI()
     // Set starting position of the cursor at the rendering window center
     Graphics* graphics = GetSubsystem<Graphics>();
     cursor->SetPosition(graphics->GetWidth() / 2, graphics->GetHeight() / 2);
-    
+
     // Construct new Text object, set string to display and font to use
     Text* instructionText = ui->GetRoot()->CreateChild<Text>();
     instructionText->SetText(
@@ -178,7 +177,7 @@ void Decals::CreateUI()
     instructionText->SetFont(cache->GetResource<Font>("Fonts/Anonymous Pro.ttf"), 15);
     // The text has multiple rows. Center them in relation to each other
     instructionText->SetTextAlignment(HA_CENTER);
-    
+
     // Position the text relative to the screen center
     instructionText->SetHorizontalAlignment(HA_CENTER);
     instructionText->SetVerticalAlignment(VA_CENTER);
@@ -188,7 +187,7 @@ void Decals::CreateUI()
 void Decals::SetupViewport()
 {
     Renderer* renderer = GetSubsystem<Renderer>();
-    
+
     // Set up a viewport to the Renderer subsystem so that the 3D scene can be seen
     SharedPtr<Viewport> viewport(new Viewport(context_, scene_, cameraNode_->GetComponent<Camera>()));
     renderer->SetViewport(0, viewport);
@@ -198,7 +197,7 @@ void Decals::SubscribeToEvents()
 {
     // Subscribe HandleUpdate() function for processing update events
     SubscribeToEvent(E_UPDATE, HANDLER(Decals, HandleUpdate));
-    
+
     // Subscribe HandlePostRenderUpdate() function for processing the post-render update event, during which we request
     // debug geometry
     SubscribeToEvent(E_POSTRENDERUPDATE, HANDLER(Decals, HandlePostRenderUpdate));
@@ -210,16 +209,16 @@ void Decals::MoveCamera(float timeStep)
     UI* ui = GetSubsystem<UI>();
     Input* input = GetSubsystem<Input>();
     ui->GetCursor()->SetVisible(!input->GetMouseButtonDown(MOUSEB_RIGHT));
-    
+
     // Do not move if the UI has a focused element (the console)
     if (ui->GetFocusElement())
         return;
-    
+
     // Movement speed as world units per second
     const float MOVE_SPEED = 20.0f;
     // Mouse sensitivity as degrees per pixel
     const float MOUSE_SENSITIVITY = 0.1f;
-    
+
     // Use this frame's mouse motion to adjust camera node yaw and pitch. Clamp the pitch between -90 and 90 degrees
     // Only move the camera when the cursor is hidden
     if (!ui->GetCursor()->IsVisible())
@@ -228,11 +227,11 @@ void Decals::MoveCamera(float timeStep)
         yaw_ += MOUSE_SENSITIVITY * mouseMove.x_;
         pitch_ += MOUSE_SENSITIVITY * mouseMove.y_;
         pitch_ = Clamp(pitch_, -90.0f, 90.0f);
-        
+
         // Construct new orientation for the camera scene node from yaw and pitch. Roll is fixed to zero
         cameraNode_->SetRotation(Quaternion(pitch_, yaw_, 0.0f));
     }
-    
+
     // Read WASD keys and move the camera scene node to the corresponding direction if they are pressed
     if (input->GetKeyDown('W'))
         cameraNode_->Translate(Vector3::FORWARD * MOVE_SPEED * timeStep);
@@ -242,11 +241,11 @@ void Decals::MoveCamera(float timeStep)
         cameraNode_->Translate(Vector3::LEFT * MOVE_SPEED * timeStep);
     if (input->GetKeyDown('D'))
         cameraNode_->Translate(Vector3::RIGHT * MOVE_SPEED * timeStep);
-    
+
     // Toggle debug geometry with space
     if (input->GetKeyPress(KEY_SPACE))
         drawDebug_ = !drawDebug_;
-    
+
     // Paint decal with the left mousebutton; cursor must be visible
     if (ui->GetCursor()->IsVisible() && input->GetMouseButtonPress(MOUSEB_LEFT))
         PaintDecal();
@@ -256,7 +255,7 @@ void Decals::PaintDecal()
 {
     Vector3 hitPos;
     Drawable* hitDrawable;
-    
+
     if (Raycast(250.0f, hitPos, hitDrawable))
     {
         // Check if target scene node already has a DecalSet component. If not, create now
@@ -265,7 +264,7 @@ void Decals::PaintDecal()
         if (!decal)
         {
             ResourceCache* cache = GetSubsystem<ResourceCache>();
-            
+
             decal = targetNode->CreateComponent<DecalSet>();
             decal->SetMaterial(cache->GetResource<Material>("Materials/UrhoDecal.xml"));
         }
@@ -281,29 +280,28 @@ void Decals::PaintDecal()
 bool Decals::Raycast(float maxDistance, Vector3& hitPos, Drawable*& hitDrawable)
 {
     hitDrawable = 0;
-    
+
     UI* ui = GetSubsystem<UI>();
     IntVector2 pos = ui->GetCursorPosition();
     // Check the cursor is visible and there is no UI element in front of the cursor
     if (!ui->GetCursor()->IsVisible() || ui->GetElementAt(pos, true))
         return false;
-    
+
     Graphics* graphics = GetSubsystem<Graphics>();
     Camera* camera = cameraNode_->GetComponent<Camera>();
     Ray cameraRay = camera->GetScreenRay((float)pos.x_ / graphics->GetWidth(), (float)pos.y_ / graphics->GetHeight());
     // Pick only geometry objects, not eg. zones or lights, only get the first (closest) hit
     PODVector<RayQueryResult> results;
-    RayOctreeQuery query(results, cameraRay, RAY_TRIANGLE_UV, maxDistance, DRAWABLE_GEOMETRY);
+    RayOctreeQuery query(results, cameraRay, RAY_TRIANGLE, maxDistance, DRAWABLE_GEOMETRY);
     scene_->GetComponent<Octree>()->RaycastSingle(query);
     if (results.Size())
     {
         RayQueryResult& result = results[0];
         hitPos = result.position_;
         hitDrawable = result.drawable_;
-        LOGWARNINGF("hit UV %f,%f",result.texture_uv_.x_,result.texture_uv_.y_);
         return true;
     }
-    
+
     return false;
 }
 
@@ -313,7 +311,7 @@ void Decals::HandleUpdate(StringHash eventType, VariantMap& eventData)
 
     // Take the frame time step, which is stored as a float
     float timeStep = eventData[P_TIMESTEP].GetFloat();
-    
+
     // Move the camera, scale movement with time step
     MoveCamera(timeStep);
 }

--- a/Source/Samples/08_Decals/Decals.cpp
+++ b/Source/Samples/08_Decals/Decals.cpp
@@ -24,6 +24,7 @@
 
 #include <Urho3D/Graphics/Camera.h>
 #include <Urho3D/Core/CoreEvents.h>
+#include <Urho3D/IO/Log.h>
 #include <Urho3D/UI/Cursor.h>
 #include <Urho3D/Graphics/DebugRenderer.h>
 #include <Urho3D/Graphics/DecalSet.h>
@@ -292,13 +293,14 @@ bool Decals::Raycast(float maxDistance, Vector3& hitPos, Drawable*& hitDrawable)
     Ray cameraRay = camera->GetScreenRay((float)pos.x_ / graphics->GetWidth(), (float)pos.y_ / graphics->GetHeight());
     // Pick only geometry objects, not eg. zones or lights, only get the first (closest) hit
     PODVector<RayQueryResult> results;
-    RayOctreeQuery query(results, cameraRay, RAY_TRIANGLE, maxDistance, DRAWABLE_GEOMETRY);
+    RayOctreeQuery query(results, cameraRay, RAY_TRIANGLE_UV, maxDistance, DRAWABLE_GEOMETRY);
     scene_->GetComponent<Octree>()->RaycastSingle(query);
     if (results.Size())
     {
         RayQueryResult& result = results[0];
         hitPos = result.position_;
         hitDrawable = result.drawable_;
+        LOGWARNINGF("hit UV %f,%f",result.texture_uv_.x_,result.texture_uv_.y_);
         return true;
     }
     

--- a/Source/Urho3D/Graphics/Geometry.cpp
+++ b/Source/Urho3D/Graphics/Geometry.cpp
@@ -59,14 +59,14 @@ bool Geometry::SetNumVertexBuffers(unsigned num)
         LOGERROR("Too many vertex streams");
         return false;
     }
-    
+
     unsigned oldSize = vertexBuffers_.Size();
     vertexBuffers_.Resize(num);
     elementMasks_.Resize(num);
-    
+
     for (unsigned i = oldSize; i < num; ++i)
         elementMasks_[i] = MASK_NONE;
-    
+
     GetPositionBufferIndex();
     return true;
 }
@@ -78,9 +78,9 @@ bool Geometry::SetVertexBuffer(unsigned index, VertexBuffer* buffer, unsigned el
         LOGERROR("Stream index out of bounds");
         return false;
     }
-    
+
     vertexBuffers_[index] = buffer;
-    
+
     if (buffer)
     {
         if (elementMask == MASK_DEFAULT)
@@ -88,7 +88,7 @@ bool Geometry::SetVertexBuffer(unsigned index, VertexBuffer* buffer, unsigned el
         else
             elementMasks_[index] = elementMask;
     }
-    
+
     GetPositionBufferIndex();
     return true;
 }
@@ -111,17 +111,17 @@ bool Geometry::SetDrawRange(PrimitiveType type, unsigned indexStart, unsigned in
             String(indexBuffer_->GetIndexCount()) + " indices");
         return false;
     }
-    
+
     primitiveType_ = type;
     indexStart_ = indexStart;
     indexCount_ = indexCount;
-    
+
     // Get min.vertex index and num of vertices from index buffer. If it fails, use full range as fallback
     if (indexCount)
     {
         vertexStart_ = 0;
         vertexCount_ = vertexBuffers_[0] ? vertexBuffers_[0]->GetVertexCount() : 0;
-        
+
         if (getUsedVertexRange && indexBuffer_)
             indexBuffer_->GetUsedVertexRange(indexStart_, indexCount_, vertexStart_, vertexCount_);
     }
@@ -130,7 +130,7 @@ bool Geometry::SetDrawRange(PrimitiveType type, unsigned indexStart, unsigned in
         vertexStart_ = 0;
         vertexCount_ = 0;
     }
-    
+
     return true;
 }
 
@@ -151,13 +151,13 @@ bool Geometry::SetDrawRange(PrimitiveType type, unsigned indexStart, unsigned in
         indexStart = 0;
         indexCount = 0;
     }
-    
+
     primitiveType_ = type;
     indexStart_ = indexStart;
     indexCount_ = indexCount;
     vertexStart_ = minVertex;
     vertexCount_ = vertexCount;
-    
+
     return true;
 }
 
@@ -165,7 +165,7 @@ void Geometry::SetLodDistance(float distance)
 {
     if (distance < 0.0f)
         distance = 0.0f;
-    
+
     lodDistance_ = distance;
 }
 
@@ -210,16 +210,16 @@ unsigned Geometry::GetVertexElementMask(unsigned index) const
 unsigned short Geometry::GetBufferHash() const
 {
     unsigned short hash = 0;
-    
+
     for (unsigned i = 0; i < vertexBuffers_.Size(); ++i)
     {
         VertexBuffer* vBuf = vertexBuffers_[i];
         hash += *((unsigned short*)&vBuf);
     }
-    
+
     IndexBuffer* iBuf = indexBuffer_;
     hash += *((unsigned short*)&iBuf);
-    
+
     return hash;
 }
 
@@ -255,7 +255,7 @@ void Geometry::GetRawData(const unsigned char*& vertexData, unsigned& vertexSize
             elementMask = 0;
         }
     }
-    
+
     if (rawIndexData_)
     {
         indexData = rawIndexData_;
@@ -311,7 +311,7 @@ void Geometry::GetRawDataShared(SharedArrayPtr<unsigned char>& vertexData, unsig
             elementMask = 0;
         }
     }
-    
+
     if (rawIndexData_)
     {
         indexData = rawIndexData_;
@@ -344,8 +344,10 @@ float Geometry::GetHitDistance(const Ray& ray, Vector3* outNormal, Vector2 * out
     unsigned elementMask;
     unsigned uvOffset=0;
     GetRawData(vertexData, vertexSize, indexData, indexSize, elementMask);
-    if(outUV) {
-        if( 0 == (elementMask & MASK_TEXCOORD1) ) {
+    if (outUV)
+    {
+        if ( (elementMask & MASK_TEXCOORD1) == 0 )
+        {
             // requested UV output, but no texture data in vertex buffer
             LOGWARNING("Illegal GetHitDistance call: UV return requested on vertex buffer without UV coords");
             outUV = 0;
@@ -353,7 +355,8 @@ float Geometry::GetHitDistance(const Ray& ray, Vector3* outNormal, Vector2 * out
         else
             uvOffset = VertexBuffer::GetElementOffset(elementMask,ELEMENT_TEXCOORD1);
     }
-    if (vertexData) {
+    if (vertexData)
+    {
         if(indexData)
             return ray.HitDistance(vertexData, vertexSize, indexData, indexSize, indexStart_, indexCount_, outNormal,outUV,uvOffset);
         return ray.HitDistance(vertexData, vertexSize, vertexStart_, vertexCount_, outNormal,outUV,uvOffset);
@@ -368,9 +371,9 @@ bool Geometry::IsInside(const Ray& ray) const
     unsigned vertexSize;
     unsigned indexSize;
     unsigned elementMask;
-    
+
     GetRawData(vertexData, vertexSize, indexData, indexSize, elementMask);
-    
+
     if (vertexData && indexData)
         return ray.InsideGeometry(vertexData, vertexSize, indexData, indexSize, indexStart_, indexCount_);
     else if (vertexData)
@@ -389,7 +392,7 @@ void Geometry::GetPositionBufferIndex()
             return;
         }
     }
-    
+
     // No vertex buffer with positions
     positionBufferIndex_ = M_MAX_UNSIGNED;
 }

--- a/Source/Urho3D/Graphics/Geometry.cpp
+++ b/Source/Urho3D/Graphics/Geometry.cpp
@@ -348,10 +348,10 @@ float Geometry::GetHitDistance(const Ray& ray, Vector3* outNormal, Vector2 * out
         if( 0 == (elementMask & MASK_TEXCOORD1) ) {
             // requested UV output, but no texture data in vertex buffer
             LOGWARNING("Illegal GetHitDistance call: UV return requested on vertex buffer without UV coords");
-            outUV = nullptr;
+            outUV = 0;
         }
         else
-            uvOffset = VertexBuffer::GetElementOffset(elementMask,VertexElement::ELEMENT_TEXCOORD1);
+            uvOffset = VertexBuffer::GetElementOffset(elementMask,ELEMENT_TEXCOORD1);
     }
     if (vertexData) {
         if(indexData)

--- a/Source/Urho3D/Graphics/Geometry.h
+++ b/Source/Urho3D/Graphics/Geometry.h
@@ -95,7 +95,7 @@ public:
     /// Return raw vertex and index data for CPU operations, or null pointers if not available.
     void GetRawDataShared(SharedArrayPtr<unsigned char>& vertexData, unsigned& vertexSize, SharedArrayPtr<unsigned char>& indexData, unsigned& indexSize, unsigned& elementMask) const;
     /// Return ray hit distance or infinity if no hit. Requires raw data to be set. Optionally return hit normal.
-    float GetHitDistance(const Ray& ray, Vector3* outNormal = nullptr,Vector2* outUV = nullptr) const;
+    float GetHitDistance(const Ray& ray, Vector3* outNormal = 0,Vector2* outUV = 0) const;
     /// Return whether or not the ray is inside geometry.
     bool IsInside(const Ray& ray) const;
     /// Return whether has empty draw range.

--- a/Source/Urho3D/Graphics/Geometry.h
+++ b/Source/Urho3D/Graphics/Geometry.h
@@ -95,7 +95,7 @@ public:
     /// Return raw vertex and index data for CPU operations, or null pointers if not available.
     void GetRawDataShared(SharedArrayPtr<unsigned char>& vertexData, unsigned& vertexSize, SharedArrayPtr<unsigned char>& indexData, unsigned& indexSize, unsigned& elementMask) const;
     /// Return ray hit distance or infinity if no hit. Requires raw data to be set. Optionally return hit normal.
-    float GetHitDistance(const Ray& ray, Vector3* outNormal = 0) const;
+    float GetHitDistance(const Ray& ray, Vector3* outNormal = nullptr,Vector2* outUV = nullptr) const;
     /// Return whether or not the ray is inside geometry.
     bool IsInside(const Ray& ray) const;
     /// Return whether has empty draw range.

--- a/Source/Urho3D/Graphics/OctreeQuery.h
+++ b/Source/Urho3D/Graphics/OctreeQuery.h
@@ -197,7 +197,7 @@ struct URHO3D_API RayQueryResult
     {
         return position_ != rhs.position_ ||
                 normal_ != rhs.normal_ ||
-                texture_uv_ != rhs.texture_uv_ ||
+                textureUV_ != rhs.textureUV_ ||
                 distance_ != rhs.distance_ ||
                 drawable_ != rhs.drawable_ ||
                 node_ != rhs.node_ ||
@@ -209,7 +209,7 @@ struct URHO3D_API RayQueryResult
     /// Hit normal in world space. Negation of ray direction if per-triangle data not available.
     Vector3 normal_;
     /// Hit texture position
-    Vector2 texture_uv_;
+    Vector2 textureUV_;
     /// Distance from ray origin.
     float distance_;
     /// Drawable.

--- a/Source/Urho3D/Graphics/OctreeQuery.h
+++ b/Source/Urho3D/Graphics/OctreeQuery.h
@@ -45,24 +45,24 @@ public:
         viewMask_(viewMask)
     {
     }
-    
+
     /// Destruct.
     virtual ~OctreeQuery()
     {
     }
-    
+
     /// Intersection test for an octant.
     virtual Intersection TestOctant(const BoundingBox& box, bool inside) = 0;
     /// Intersection test for drawables.
     virtual void TestDrawables(Drawable** start, Drawable** end, bool inside) = 0;
-    
+
     /// Result vector reference.
     PODVector<Drawable*>& result_;
     /// Drawable flags to include.
     unsigned char drawableFlags_;
     /// Drawable layers to include.
     unsigned viewMask_;
-    
+
 private:
     /// Prevent copy construction.
     OctreeQuery(const OctreeQuery& rhs);
@@ -81,12 +81,12 @@ public:
         point_(point)
     {
     }
-    
+
     /// Intersection test for an octant.
     virtual Intersection TestOctant(const BoundingBox& box, bool inside);
     /// Intersection test for drawables.
     virtual void TestDrawables(Drawable** start, Drawable** end, bool inside);
-    
+
     /// Point.
     Vector3 point_;
 };
@@ -102,12 +102,12 @@ public:
         sphere_(sphere)
     {
     }
-    
+
     /// Intersection test for an octant.
     virtual Intersection TestOctant(const BoundingBox& box, bool inside);
     /// Intersection test for drawables.
     virtual void TestDrawables(Drawable** start, Drawable** end, bool inside);
-    
+
     /// Sphere.
     Sphere sphere_;
 };
@@ -123,12 +123,12 @@ public:
         box_(box)
     {
     }
-    
+
     /// Intersection test for an octant.
     virtual Intersection TestOctant(const BoundingBox& box, bool inside);
     /// Intersection test for drawables.
     virtual void TestDrawables(Drawable** start, Drawable** end, bool inside);
-    
+
     /// Bounding box.
     BoundingBox box_;
 };
@@ -144,12 +144,12 @@ public:
         frustum_(frustum)
     {
     }
-    
+
     /// Intersection test for an octant.
     virtual Intersection TestOctant(const BoundingBox& box, bool inside);
     /// Intersection test for drawables.
     virtual void TestDrawables(Drawable** start, Drawable** end, bool inside);
-    
+
     /// Frustum.
     Frustum frustum_;
 };
@@ -166,7 +166,7 @@ struct URHO3D_API OctreeQueryResult
 
     /// Test for inequality, added to prevent GCC from complaining.
     bool operator != (const OctreeQueryResult& rhs) const { return drawable_ != rhs.drawable_ || node_ != rhs.node_; }
-    
+
     /// Drawable.
     Drawable* drawable_;
     /// Scene node.
@@ -193,7 +193,8 @@ struct URHO3D_API RayQueryResult
     }
 
     /// Test for inequality, added to prevent GCC from complaining.
-    bool operator != (const RayQueryResult& rhs) const {
+    bool operator != (const RayQueryResult& rhs) const
+    {
         return position_ != rhs.position_ ||
                 normal_ != rhs.normal_ ||
                 texture_uv_ != rhs.texture_uv_ ||
@@ -202,7 +203,7 @@ struct URHO3D_API RayQueryResult
                 node_ != rhs.node_ ||
                 subObject_ != rhs.subObject_;
     }
-    
+
     /// Hit position in world space.
     Vector3 position_;
     /// Hit normal in world space. Negation of ray direction if per-triangle data not available.
@@ -234,7 +235,7 @@ public:
         level_(level)
     {
     }
-    
+
     /// Result vector reference.
     PODVector<RayQueryResult>& result_;
     /// Ray.
@@ -247,7 +248,7 @@ public:
     float maxDistance_;
     /// Raycast detail level.
     RayQueryLevel level_;
-    
+
 private:
     /// Prevent copy construction.
     RayOctreeQuery(const RayOctreeQuery& rhs);

--- a/Source/Urho3D/Graphics/OctreeQuery.h
+++ b/Source/Urho3D/Graphics/OctreeQuery.h
@@ -185,10 +185,18 @@ enum RayQueryLevel
 /// Raycast result.
 struct URHO3D_API RayQueryResult
 {
+    /// Construct with defaults.
+    RayQueryResult() :
+        drawable_(0),
+        node_(0)
+    {
+    }
+
     /// Test for inequality, added to prevent GCC from complaining.
     bool operator != (const RayQueryResult& rhs) const {
         return position_ != rhs.position_ ||
                 normal_ != rhs.normal_ ||
+                texture_uv_ != rhs.texture_uv_ ||
                 distance_ != rhs.distance_ ||
                 drawable_ != rhs.drawable_ ||
                 node_ != rhs.node_ ||
@@ -204,9 +212,9 @@ struct URHO3D_API RayQueryResult
     /// Distance from ray origin.
     float distance_;
     /// Drawable.
-    Drawable* drawable_ = nullptr;
+    Drawable* drawable_;
     /// Scene node.
-    Node* node_ = nullptr;
+    Node* node_;
     /// Drawable specific subobject if applicable.
     unsigned subObject_;
 };

--- a/Source/Urho3D/Graphics/OctreeQuery.h
+++ b/Source/Urho3D/Graphics/OctreeQuery.h
@@ -178,32 +178,35 @@ enum RayQueryLevel
 {
     RAY_AABB = 0,
     RAY_OBB,
-    RAY_TRIANGLE
+    RAY_TRIANGLE,
+    RAY_TRIANGLE_UV
 };
 
 /// Raycast result.
 struct URHO3D_API RayQueryResult
 {
-    /// Construct with defaults.
-    RayQueryResult() :
-        drawable_(0),
-        node_(0)
-    {
-    }
-
     /// Test for inequality, added to prevent GCC from complaining.
-    bool operator != (const RayQueryResult& rhs) const { return position_ != rhs.position_ || normal_ != rhs.normal_ || distance_ != rhs.distance_ || drawable_ != rhs.drawable_ || node_ != rhs.node_ || subObject_ != rhs.subObject_; }
+    bool operator != (const RayQueryResult& rhs) const {
+        return position_ != rhs.position_ ||
+                normal_ != rhs.normal_ ||
+                distance_ != rhs.distance_ ||
+                drawable_ != rhs.drawable_ ||
+                node_ != rhs.node_ ||
+                subObject_ != rhs.subObject_;
+    }
     
     /// Hit position in world space.
     Vector3 position_;
     /// Hit normal in world space. Negation of ray direction if per-triangle data not available.
     Vector3 normal_;
+    /// Hit texture position
+    Vector2 texture_uv_;
     /// Distance from ray origin.
     float distance_;
     /// Drawable.
-    Drawable* drawable_;
+    Drawable* drawable_ = nullptr;
     /// Scene node.
-    Node* node_;
+    Node* node_ = nullptr;
     /// Drawable specific subobject if applicable.
     unsigned subObject_;
 };

--- a/Source/Urho3D/Graphics/StaticModel.cpp
+++ b/Source/Urho3D/Graphics/StaticModel.cpp
@@ -124,7 +124,7 @@ void StaticModel::ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQuer
             result.drawable_ = this;
             result.node_ = node_;
             result.subObject_ = hitBatch;
-            result.texture_uv_ = geometryUV;
+            result.textureUV_ = geometryUV;
             results.Push(result);
         }
         break;

--- a/Source/Urho3D/Graphics/StaticModel.cpp
+++ b/Source/Urho3D/Graphics/StaticModel.cpp
@@ -82,13 +82,15 @@ void StaticModel::ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQuer
 
     case RAY_OBB:
     case RAY_TRIANGLE:
+    case RAY_TRIANGLE_UV:
         Matrix3x4 inverse(node_->GetWorldTransform().Inverse());
         Ray localRay = query.ray_.Transformed(inverse);
         float distance = localRay.HitDistance(boundingBox_);
         Vector3 normal = -query.ray_.direction_;
+        Vector2 geometryUV;
         unsigned hitBatch = M_MAX_UNSIGNED;
 
-        if (level == RAY_TRIANGLE && distance < query.maxDistance_)
+        if (level >= RAY_TRIANGLE && distance < query.maxDistance_)
         {
             distance = M_INFINITY;
 
@@ -98,7 +100,11 @@ void StaticModel::ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQuer
                 if (geometry)
                 {
                     Vector3 geometryNormal;
-                    float geometryDistance = geometry->GetHitDistance(localRay, &geometryNormal);
+                    float geometryDistance ;
+                    if(level>RAY_TRIANGLE_UV)
+                        geometryDistance = geometry->GetHitDistance(localRay, &geometryNormal);
+                    else
+                        geometryDistance = geometry->GetHitDistance(localRay, &geometryNormal,&geometryUV);
                     if (geometryDistance < query.maxDistance_ && geometryDistance < distance)
                     {
                         distance = geometryDistance;
@@ -118,7 +124,8 @@ void StaticModel::ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQuer
             result.drawable_ = this;
             result.node_ = node_;
             result.subObject_ = hitBatch;
-            results.Push(result);
+            result.texture_uv_ = geometryUV;
+            results.push_back(result);
         }
         break;
     }

--- a/Source/Urho3D/Graphics/StaticModel.cpp
+++ b/Source/Urho3D/Graphics/StaticModel.cpp
@@ -125,7 +125,7 @@ void StaticModel::ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQuer
             result.node_ = node_;
             result.subObject_ = hitBatch;
             result.texture_uv_ = geometryUV;
-            results.push_back(result);
+            results.Push(result);
         }
         break;
     }

--- a/Source/Urho3D/LuaScript/pkgs/Graphics/OctreeQuery.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Graphics/OctreeQuery.pkg
@@ -13,7 +13,8 @@ enum RayQueryLevel
 {
     RAY_AABB = 0,
     RAY_OBB,
-    RAY_TRIANGLE
+    RAY_TRIANGLE,
+    RAY_TRIANGLE_UV
 };
 
 struct RayQueryResult
@@ -23,6 +24,7 @@ struct RayQueryResult
     
     Vector3 position_ @ position;
     Vector3 normal_ @ normal;
+    Vector2 texture_uv_ @ texture_uv;
     float distance_ @ distance;
     Drawable* drawable_ @ drawable;
     Node* node_ @ node;

--- a/Source/Urho3D/LuaScript/pkgs/Graphics/OctreeQuery.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Graphics/OctreeQuery.pkg
@@ -24,7 +24,7 @@ struct RayQueryResult
     
     Vector3 position_ @ position;
     Vector3 normal_ @ normal;
-    Vector2 texture_uv_ @ texture_uv;
+    Vector2 textureUV_ @ textureUV;
     float distance_ @ distance;
     Drawable* drawable_ @ drawable;
     Node* node_ @ node;

--- a/Source/Urho3D/Math/Ray.cpp
+++ b/Source/Urho3D/Math/Ray.cpp
@@ -203,7 +203,7 @@ float Ray::HitDistance(const Sphere& sphere) const
 
 float Ray::HitDistance(const Vector3& v0, const Vector3& v1, const Vector3& v2) const
 {
-    return HitDistance(v0, v1, v2, nullptr,nullptr);
+    return HitDistance(v0, v1, v2, 0, 0);
 }
 
 float Ray::HitDistance(const Vector3& v0, const Vector3& v1, const Vector3& v2, Vector3* outNormal,Vector3 *outBary) const
@@ -285,7 +285,7 @@ float Ray::HitDistance(const void* vertexData, unsigned vertexStride, unsigned v
             const Vector3& v0 = *((const Vector3*)(&vertices[index * vertexStride]));
             const Vector3& v1 = *((const Vector3*)(&vertices[(index + 1) * vertexStride]));
             const Vector3& v2 = *((const Vector3*)(&vertices[(index + 2) * vertexStride]));
-            nearest = Min(nearest, HitDistance(v0, v1, v2, outNormal,nullptr));
+            nearest = Min(nearest, HitDistance(v0, v1, v2, outNormal,0));
             index += 3;
         }
     }
@@ -369,7 +369,7 @@ float Ray::HitDistance(const void* vertexData, unsigned vertexStride, const void
                 const Vector3& v0 = *((const Vector3*)(&vertices[indices[0] * vertexStride]));
                 const Vector3& v1 = *((const Vector3*)(&vertices[indices[1] * vertexStride]));
                 const Vector3& v2 = *((const Vector3*)(&vertices[indices[2] * vertexStride]));
-                nearest = Min(nearest, HitDistance(v0, v1, v2, outNormal,nullptr));
+                nearest = Min(nearest, HitDistance(v0, v1, v2, outNormal,0));
                 indices += 3;
             }
         }
@@ -384,7 +384,7 @@ float Ray::HitDistance(const void* vertexData, unsigned vertexStride, const void
                 const Vector3& v0 = *((const Vector3*)(&vertices[indices[0] * vertexStride]));
                 const Vector3& v1 = *((const Vector3*)(&vertices[indices[1] * vertexStride]));
                 const Vector3& v2 = *((const Vector3*)(&vertices[indices[2] * vertexStride]));
-                nearest = Min(nearest, HitDistance(v0, v1, v2, outNormal,nullptr));
+                nearest = Min(nearest, HitDistance(v0, v1, v2, outNormal,0));
                 indices += 3;
             }
         }

--- a/Source/Urho3D/Math/Ray.cpp
+++ b/Source/Urho3D/Math/Ray.cpp
@@ -35,19 +35,19 @@ Vector3 Ray::ClosestPoint(const Ray& ray) const
     Vector3 p13 = origin_ - ray.origin_;
     Vector3 p43 = ray.direction_;
     Vector3 p21 = direction_;
-    
+
     float d1343 = p13.DotProduct(p43);
     float d4321 = p43.DotProduct(p21);
     float d1321 = p13.DotProduct(p21);
     float d4343 = p43.DotProduct(p43);
     float d2121 = p21.DotProduct(p21);
-    
+
     float d = d2121 * d4343 - d4321 * d4321;
     if (Abs(d) < M_EPSILON)
         return origin_;
     float n = d1343 * d4321 - d1321 * d4343;
     float a = n / d;
-    
+
     return origin_ + a * direction_;
 }
 
@@ -71,13 +71,13 @@ float Ray::HitDistance(const BoundingBox& box) const
     // If undefined, no hit (infinite distance)
     if (!box.defined_)
         return M_INFINITY;
-    
+
     // Check for ray origin being inside the box
     if (box.IsInside(origin_))
         return 0.0f;
-    
+
     float dist = M_INFINITY;
-    
+
     // Check for intersecting in the X-direction
     if (origin_.x_ < box.min_.x_ && direction_.x_ > 0.0f)
     {
@@ -141,7 +141,7 @@ float Ray::HitDistance(const BoundingBox& box) const
                 dist = x;
         }
     }
-    
+
     return dist;
 }
 
@@ -150,12 +150,12 @@ float Ray::HitDistance(const Frustum& frustum, bool solidInside) const
     float maxOutside = 0.0f;
     float minInside = M_INFINITY;
     bool allInside = true;
-    
+
     for (unsigned i = 0; i < NUM_FRUSTUM_PLANES; ++i)
     {
         const Plane& plane = frustum.planes_[i];
         float distance = HitDistance(frustum.planes_[i]);
-        
+
         if (plane.Distance(origin_) < 0.0f)
         {
             maxOutside = Max(maxOutside, distance);
@@ -164,7 +164,7 @@ float Ray::HitDistance(const Frustum& frustum, bool solidInside) const
         else
             minInside = Min(minInside, distance);
     }
-    
+
     if (allInside)
         return solidInside ? 0.0f : minInside;
     else if (maxOutside <= minInside)
@@ -177,21 +177,21 @@ float Ray::HitDistance(const Sphere& sphere) const
 {
     Vector3 centeredOrigin = origin_ - sphere.center_;
     float squaredRadius = sphere.radius_ * sphere.radius_;
-    
+
     // Check if ray originates inside the sphere
     if (centeredOrigin.LengthSquared() <= squaredRadius)
         return 0.0f;
-    
+
     // Calculate intersection by quadratic equation
     float a = direction_.DotProduct(direction_);
     float b = 2.0f * centeredOrigin.DotProduct(direction_);
     float c = centeredOrigin.DotProduct(centeredOrigin) - squaredRadius;
     float d = b * b - 4.0f * a * c;
-    
+
     // No solution
     if (d < 0.0f)
         return M_INFINITY;
-    
+
     // Get the nearer solution
     float dSqrt = sqrtf(d);
     float dist = (-b - dSqrt) / (2.0f * a);
@@ -208,12 +208,12 @@ float Ray::HitDistance(const Vector3& v0, const Vector3& v1, const Vector3& v2) 
 
 float Ray::HitDistance(const Vector3& v0, const Vector3& v1, const Vector3& v2, Vector3* outNormal,Vector3 *outBary) const
 {
-    // Based on Fast, Minimum Storage Ray/Triangle Intersection by M�ller & Trumbore
+    // Based on Fast, Minimum Storage Ray/Triangle Intersection by Möller & Trumbore
     // http://www.graphics.cornell.edu/pubs/1997/MT97.pdf
     // Calculate edge vectors
     Vector3 edge1(v1 - v0);
     Vector3 edge2(v2 - v0);
-    
+
     // Calculate determinant & check backfacing
     Vector3 p(direction_.CrossProduct(edge2));
     float det = edge1.DotProduct(p);
@@ -235,15 +235,15 @@ float Ray::HitDistance(const Vector3& v0, const Vector3& v1, const Vector3& v2, 
                     // There is an intersection, so calculate distance & optional normal
                     if (outNormal)
                         *outNormal = edge1.CrossProduct(edge2);
-                    if (outBary) {
+                    if (outBary)
                         *outBary = Vector3(1-(u/det)-(v/det),u/det,v/det);
-                    }
+
                     return distance;
                 }
             }
         }
     }
-    
+
     return M_INFINITY;
 }
 
@@ -252,7 +252,8 @@ float Ray::HitDistance(const void* vertexData, unsigned vertexStride, unsigned v
     float nearest = M_INFINITY;
     const unsigned char* vertices = ((const unsigned char*)vertexData) + vertexStart * vertexStride;
     unsigned index = 0;
-    if(outUV1) {
+    if (outUV1)
+    {
         unsigned nearestIdx = -1;
         Vector3 barycentric;
         while (index + 2 < vertexCount)
@@ -267,7 +268,7 @@ float Ray::HitDistance(const void* vertexData, unsigned vertexStride, unsigned v
             }
             index += 3;
         }
-        if(nearestIdx!=-1) {
+        if (nearestIdx!=-1) {
             const Vector2& uv0 = *((const Vector2*)(&vertices[uvOffset + nearestIdx * vertexStride]));
             const Vector2& uv1 = *((const Vector2*)(&vertices[uvOffset + (nearestIdx + 1) * vertexStride]));
             const Vector2& uv2 = *((const Vector2*)(&vertices[uvOffset + (nearestIdx + 2) * vertexStride]));
@@ -279,7 +280,8 @@ float Ray::HitDistance(const void* vertexData, unsigned vertexStride, unsigned v
         }
 
     }
-    else {
+    else
+    {
         while (index + 2 < vertexCount)
         {
             const Vector3& v0 = *((const Vector3*)(&vertices[index * vertexStride]));
@@ -289,7 +291,7 @@ float Ray::HitDistance(const void* vertexData, unsigned vertexStride, unsigned v
             index += 3;
         }
     }
-    
+
     return nearest;
 }
 
@@ -298,8 +300,9 @@ float Ray::HitDistance(const void* vertexData, unsigned vertexStride, const void
 {
     float nearest = M_INFINITY;
     const unsigned char* vertices = (const unsigned char*)vertexData;
-    
-    if(outUV) {
+
+    if (outUV)
+    {
         int nearestIdx[3] = {-1,-1,-1};
         Vector3 barycentric;
         // 16-bit indices
@@ -314,7 +317,8 @@ float Ray::HitDistance(const void* vertexData, unsigned vertexStride, const void
                 const Vector3& v1 = *((const Vector3*)(&vertices[indices[1] * vertexStride]));
                 const Vector3& v2 = *((const Vector3*)(&vertices[indices[2] * vertexStride]));
                 float interesectDist = HitDistance(v0, v1, v2, outNormal,&barycentric);
-                if(interesectDist<nearest) {
+                if (interesectDist<nearest)
+                {
                     nearestIdx[0] = indices[0];
                     nearestIdx[1] = indices[1];
                     nearestIdx[2] = indices[2];
@@ -335,7 +339,8 @@ float Ray::HitDistance(const void* vertexData, unsigned vertexStride, const void
                 const Vector3& v1 = *((const Vector3*)(&vertices[indices[1] * vertexStride]));
                 const Vector3& v2 = *((const Vector3*)(&vertices[indices[2] * vertexStride]));
                 float interesectDist = HitDistance(v0, v1, v2, outNormal,&barycentric);
-                if(interesectDist<nearest) {
+                if (interesectDist<nearest)
+                {
                     nearestIdx[0] = indices[0];
                     nearestIdx[1] = indices[1];
                     nearestIdx[2] = indices[2];
@@ -345,7 +350,8 @@ float Ray::HitDistance(const void* vertexData, unsigned vertexStride, const void
             }
         }
 
-        if(nearestIdx[0]!=-1) {
+        if (nearestIdx[0]!=-1)
+        {
             const Vector2& uv0 = *((const Vector2*)(&vertices[uvOffset + nearestIdx[0] * vertexStride]));
             const Vector2& uv1 = *((const Vector2*)(&vertices[uvOffset + nearestIdx[1] * vertexStride]));
             const Vector2& uv2 = *((const Vector2*)(&vertices[uvOffset + nearestIdx[2] * vertexStride]));
@@ -357,7 +363,8 @@ float Ray::HitDistance(const void* vertexData, unsigned vertexStride, const void
         }
 
     }
-    else {
+    else
+    {
         // 16-bit indices
         if (indexSize == sizeof(unsigned short))
         {
@@ -398,7 +405,7 @@ bool Ray::InsideGeometry(const void* vertexData, unsigned vertexSize, unsigned v
     float currentBackFace = M_INFINITY;
     const unsigned char* vertices = ((const unsigned char*)vertexData) + vertexStart * vertexSize;
     unsigned index = 0;
-    
+
     while (index + 2 < vertexCount)
     {
         const Vector3& v0 = *((const Vector3*)(&vertices[index * vertexSize]));
@@ -412,13 +419,13 @@ bool Ray::InsideGeometry(const void* vertexData, unsigned vertexSize, unsigned v
         currentBackFace = Min(backFaceDistance > 0.0f ? backFaceDistance : M_INFINITY, currentBackFace);
         index += 3;
     }
-    
+
     // If the closest face is a backface, that means that the ray originates from the inside of the geometry
     // NOTE: there may be cases where both are equal, as in, no collision to either. This is prevented in the most likely case
     // (ray doesnt hit either) by this conditional
     if (currentFrontFace != M_INFINITY || currentBackFace != M_INFINITY)
         return currentBackFace < currentFrontFace;
-    
+
     // It is still possible for two triangles to be equally distant from the triangle, however, this is extremely unlikely.
     // As such, it is safe to assume they are not
     return false;
@@ -430,13 +437,13 @@ bool Ray::InsideGeometry(const void* vertexData, unsigned vertexSize, const void
     float currentFrontFace = M_INFINITY;
     float currentBackFace = M_INFINITY;
     const unsigned char* vertices = (const unsigned char*)vertexData;
-    
+
     // 16-bit indices
     if (indexSize == sizeof(unsigned short))
     {
         const unsigned short* indices = ((const unsigned short*)indexData) + indexStart;
         const unsigned short* indicesEnd = indices + indexCount;
-        
+
         while (indices < indicesEnd)
         {
             const Vector3& v0 = *((const Vector3*)(&vertices[indices[0] * vertexSize]));
@@ -456,7 +463,7 @@ bool Ray::InsideGeometry(const void* vertexData, unsigned vertexSize, const void
     {
         const unsigned* indices = ((const unsigned*)indexData) + indexStart;
         const unsigned* indicesEnd = indices + indexCount;
-        
+
         while (indices < indicesEnd)
         {
             const Vector3& v0 = *((const Vector3*)(&vertices[indices[0] * vertexSize]));
@@ -468,16 +475,16 @@ bool Ray::InsideGeometry(const void* vertexData, unsigned vertexSize, const void
             // A backwards face is just a regular one, with the vertices in the opposite order. This essentially checks backfaces by
             // checking reversed frontfaces
             currentBackFace = Min(backFaceDistance > 0.0f ? backFaceDistance : M_INFINITY, currentBackFace);
-            indices += 3; 
+            indices += 3;
         }
     }
-    
+
     // If the closest face is a backface, that means that the ray originates from the inside of the geometry
     // NOTE: there may be cases where both are equal, as in, no collision to either. This is prevented in the most likely case
     // (ray doesnt hit either) by this conditional
     if (currentFrontFace != M_INFINITY || currentBackFace != M_INFINITY)
         return currentBackFace < currentFrontFace;
-    
+
     // It is still possible for two triangles to be equally distant from the triangle, however, this is extremely unlikely.
     // As such, it is safe to assume they are not
     return false;

--- a/Source/Urho3D/Math/Ray.h
+++ b/Source/Urho3D/Math/Ray.h
@@ -102,11 +102,11 @@ public:
     /// Return hit distance to a triangle, or infinity if no hit.
     float HitDistance(const Vector3& v0, const Vector3& v1, const Vector3& v2) const;
     /// Return hit distance to a triangle and out normal, or infinity if no hit.
-    float HitDistance(const Vector3& v0, const Vector3& v1, const Vector3& v2, Vector3* outNormal) const;
-    /// Return hit distance to non-indexed geometry data, or infinity if no hit. Optionally return normal.
-    float HitDistance(const void* vertexData, unsigned vertexSize, unsigned vertexStart, unsigned vertexCount, Vector3* outNormal = 0) const;
+    float HitDistance(const Vector3& v0, const Vector3& v1, const Vector3& v2, Vector3* outNormal, Vector3 * outBary) const;
+    /// Return hit distance to non-indexed geometry data, or infinity if no hit. Optionally return normal, and uv coordinates at intersect point
+    float HitDistance(const void* vertexData, unsigned vertexStride, unsigned vertexStart, unsigned vertexCount, Vector3* outNormal = nullptr, Vector2* outUV1 = nullptr, unsigned uvOffset=0) const;
     /// Return hit distance to indexed geometry data, or infinity if no hit.
-    float HitDistance(const void* vertexData, unsigned vertexSize, const void* indexData, unsigned indexSize, unsigned indexStart, unsigned indexCount, Vector3* outNormal = 0) const;
+    float HitDistance(const void* vertexData, unsigned vertexStride, const void* indexData, unsigned indexSize, unsigned indexStart, unsigned indexCount, Vector3* outNormal = nullptr, Vector2* outUV1 = nullptr, unsigned uvOffset=0) const;
     /// Return whether ray is inside non-indexed geometry.
     bool InsideGeometry(const void* vertexData, unsigned vertexSize, unsigned vertexStart, unsigned vertexCount) const;
     /// Return whether ray is inside indexed geometry.

--- a/Source/Urho3D/Math/Ray.h
+++ b/Source/Urho3D/Math/Ray.h
@@ -104,9 +104,9 @@ public:
     /// Return hit distance to a triangle and out normal, or infinity if no hit.
     float HitDistance(const Vector3& v0, const Vector3& v1, const Vector3& v2, Vector3* outNormal, Vector3 * outBary) const;
     /// Return hit distance to non-indexed geometry data, or infinity if no hit. Optionally return normal, and uv coordinates at intersect point
-    float HitDistance(const void* vertexData, unsigned vertexStride, unsigned vertexStart, unsigned vertexCount, Vector3* outNormal = nullptr, Vector2* outUV1 = nullptr, unsigned uvOffset=0) const;
+    float HitDistance(const void* vertexData, unsigned vertexStride, unsigned vertexStart, unsigned vertexCount, Vector3* outNormal = 0, Vector2* outUV1 = 0, unsigned uvOffset=0) const;
     /// Return hit distance to indexed geometry data, or infinity if no hit.
-    float HitDistance(const void* vertexData, unsigned vertexStride, const void* indexData, unsigned indexSize, unsigned indexStart, unsigned indexCount, Vector3* outNormal = nullptr, Vector2* outUV1 = nullptr, unsigned uvOffset=0) const;
+    float HitDistance(const void* vertexData, unsigned vertexStride, const void* indexData, unsigned indexSize, unsigned indexStart, unsigned indexCount, Vector3* outNormal = 0, Vector2* outUV1 = 0, unsigned uvOffset=0) const;
     /// Return whether ray is inside non-indexed geometry.
     bool InsideGeometry(const void* vertexData, unsigned vertexSize, unsigned vertexStart, unsigned vertexCount) const;
     /// Return whether ray is inside indexed geometry.

--- a/Source/Urho3D/Script/GraphicsAPI.cpp
+++ b/Source/Urho3D/Script/GraphicsAPI.cpp
@@ -68,12 +68,12 @@ static void RegisterCamera(asIScriptEngine* engine)
     engine->RegisterGlobalProperty("const uint VO_LOW_MATERIAL_QUALITY", (void*)&VO_LOW_MATERIAL_QUALITY);
     engine->RegisterGlobalProperty("const uint VO_DISABLE_SHADOWS", (void*)&VO_DISABLE_SHADOWS);
     engine->RegisterGlobalProperty("const uint VO_DISABLE_OCCLUSION", (void*)&VO_DISABLE_OCCLUSION);
-    
+
     engine->RegisterEnum("FillMode");
     engine->RegisterEnumValue("FillMode", "FILL_SOLID", FILL_SOLID);
     engine->RegisterEnumValue("FillMode", "FILL_WIREFRAME", FILL_WIREFRAME);
     engine->RegisterEnumValue("FillMode", "FILL_POINT", FILL_POINT);
-    
+
     RegisterComponent<Camera>(engine, "Camera");
     engine->RegisterObjectMethod("Camera", "void SetOrthoSize(const Vector2&in)", asMETHODPR(Camera, SetOrthoSize, (const Vector2&), void), asCALL_THISCALL);
     engine->RegisterObjectMethod("Camera", "Frustum GetSplitFrustum(float, float) const", asMETHOD(Camera, GetSplitFrustum), asCALL_THISCALL);
@@ -148,7 +148,7 @@ static void RegisterSkeleton(asIScriptEngine* engine)
     engine->RegisterObjectProperty("Bone", "const BoundingBox boundingBox", offsetof(Bone, boundingBox_));
     engine->RegisterObjectMethod("Bone", "void set_node(Node@+)", asFUNCTION(BoneSetNode), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod("Bone", "Node@+ get_node() const", asFUNCTION(BoneGetNode), asCALL_CDECL_OBJLAST);
-    
+
     engine->RegisterObjectType("Skeleton", 0, asOBJ_REF);
     engine->RegisterObjectBehaviour("Skeleton", asBEHAVE_ADDREF, "void f()", asFUNCTION(FakeAddRef), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectBehaviour("Skeleton", asBEHAVE_RELEASE, "void f()", asFUNCTION(FakeReleaseRef), asCALL_CDECL_OBJLAST);
@@ -288,16 +288,16 @@ static void RegisterRenderPath(asIScriptEngine* engine)
     engine->RegisterEnumValue("RenderCommandType", "CMD_FORWARDLIGHTS", CMD_FORWARDLIGHTS);
     engine->RegisterEnumValue("RenderCommandType", "CMD_LIGHTVOLUMES", CMD_LIGHTVOLUMES);
     engine->RegisterEnumValue("RenderCommandType", "CMD_RENDERUI", CMD_RENDERUI);
-    
+
     engine->RegisterEnum("RenderCommandSortMode");
     engine->RegisterEnumValue("RenderCommandSortMode", "SORT_FRONTTOBACK", SORT_FRONTTOBACK);
     engine->RegisterEnumValue("RenderCommandSortMode", "SORT_BACKTOFRONT", SORT_BACKTOFRONT);
-    
+
     engine->RegisterEnum("RenderTargetSizeMode");
     engine->RegisterEnumValue("RenderTargetSizeMode", "SIZE_ABSOLUTE", SIZE_ABSOLUTE);
     engine->RegisterEnumValue("RenderTargetSizeMode", "SIZE_VIEWPORTDIVISOR", SIZE_VIEWPORTDIVISOR);
     engine->RegisterEnumValue("RenderTargetSizeMode", "SIZE_VIEWPORTMULTIPLIER", SIZE_VIEWPORTMULTIPLIER);
-    
+
     engine->RegisterEnum("TextureUnit");
     engine->RegisterEnumValue("TextureUnit", "TU_DIFFUSE", TU_DIFFUSE);
     engine->RegisterEnumValue("TextureUnit", "TU_ALBEDOBUFFER", TU_ALBEDOBUFFER);
@@ -325,7 +325,7 @@ static void RegisterRenderPath(asIScriptEngine* engine)
     engine->RegisterGlobalProperty("uint CLEAR_COLOR", (void*)&CLEAR_COLOR);
     engine->RegisterGlobalProperty("uint CLEAR_DEPTH", (void*)&CLEAR_DEPTH);
     engine->RegisterGlobalProperty("uint CLEAR_STENCIL", (void*)&CLEAR_STENCIL);
-    
+
     engine->RegisterObjectType("RenderTargetInfo", sizeof(RenderTargetInfo), asOBJ_VALUE | asOBJ_APP_CLASS_C);
     engine->RegisterObjectBehaviour("RenderTargetInfo", asBEHAVE_CONSTRUCT, "void f()", asFUNCTION(ConstructRenderTargetInfo), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectBehaviour("RenderTargetInfo", asBEHAVE_CONSTRUCT, "void f(const RenderTargetInfo&in)", asFUNCTION(ConstructRenderTargetInfoCopy), asCALL_CDECL_OBJLAST);
@@ -341,7 +341,7 @@ static void RegisterRenderPath(asIScriptEngine* engine)
     engine->RegisterObjectProperty("RenderTargetInfo", "bool filtered", offsetof(RenderTargetInfo, filtered_));
     engine->RegisterObjectProperty("RenderTargetInfo", "bool sRGB", offsetof(RenderTargetInfo, sRGB_));
     engine->RegisterObjectProperty("RenderTargetInfo", "bool persistent", offsetof(RenderTargetInfo, persistent_));
-    
+
     engine->RegisterObjectType("RenderPathCommand", sizeof(RenderPathCommand), asOBJ_VALUE | asOBJ_APP_CLASS_C);
     engine->RegisterObjectBehaviour("RenderPathCommand", asBEHAVE_CONSTRUCT, "void f()", asFUNCTION(ConstructRenderPathCommand), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectBehaviour("RenderPathCommand", asBEHAVE_CONSTRUCT, "void f(const RenderPathCommand&in)", asFUNCTION(ConstructRenderPathCommandCopy), asCALL_CDECL_OBJLAST);
@@ -380,7 +380,7 @@ static void RegisterRenderPath(asIScriptEngine* engine)
     engine->RegisterObjectProperty("RenderPathCommand", "String pixelShaderName", offsetof(RenderPathCommand, pixelShaderName_));
     engine->RegisterObjectProperty("RenderPathCommand", "String vertexShaderDefines", offsetof(RenderPathCommand, vertexShaderDefines_));
     engine->RegisterObjectProperty("RenderPathCommand", "String pixelShaderDefines", offsetof(RenderPathCommand, pixelShaderDefines_));
-    
+
     RegisterRefCounted<RenderPath>(engine, "RenderPath");
     engine->RegisterObjectBehaviour("RenderPath", asBEHAVE_FACTORY, "RenderPath@+ f()", asFUNCTION(ConstructRenderPath), asCALL_CDECL);
     engine->RegisterObjectMethod("RenderPath", "RenderPath@ Clone()", asFUNCTION(RenderPathClone), asCALL_CDECL_OBJLAST);
@@ -409,37 +409,37 @@ static void RegisterRenderPath(asIScriptEngine* engine)
 static void RegisterTextures(asIScriptEngine* engine)
 {
     /// \todo Expose getting/setting raw texture data
-    
+
     engine->RegisterEnum("TextureUsage");
     engine->RegisterEnumValue("TextureUsage", "TEXTURE_STATIC", TEXTURE_STATIC);
     engine->RegisterEnumValue("TextureUsage", "TEXTURE_DYNAMIC", TEXTURE_DYNAMIC);
     engine->RegisterEnumValue("TextureUsage", "TEXTURE_RENDERTARGET", TEXTURE_RENDERTARGET);
     engine->RegisterEnumValue("TextureUsage", "TEXTURE_DEPTHSTENCIL", TEXTURE_DEPTHSTENCIL);
-    
+
     engine->RegisterEnum("TextureFilterMode");
     engine->RegisterEnumValue("TextureFilterMode", "FILTER_NEAREST", FILTER_NEAREST);
     engine->RegisterEnumValue("TextureFilterMode", "FILTER_BILINEAR", FILTER_BILINEAR);
     engine->RegisterEnumValue("TextureFilterMode", "FILTER_TRILINEAR", FILTER_TRILINEAR);
     engine->RegisterEnumValue("TextureFilterMode", "FILTER_ANISOTROPIC", FILTER_ANISOTROPIC);
     engine->RegisterEnumValue("TextureFilterMode", "FILTER_DEFAULT", FILTER_DEFAULT);
-    
+
     engine->RegisterEnum("TextureAddressMode");
     engine->RegisterEnumValue("TextureAddressMode", "ADDRESS_WRAP", ADDRESS_WRAP);
     engine->RegisterEnumValue("TextureAddressMode", "ADDRESS_MIRROR", ADDRESS_MIRROR);
     engine->RegisterEnumValue("TextureAddressMode", "ADDRESS_CLAMP", ADDRESS_CLAMP);
     engine->RegisterEnumValue("TextureAddressMode", "ADDRESS_BORDER", ADDRESS_BORDER);
-    
+
     engine->RegisterEnum("TextureCoordinate");
     engine->RegisterEnumValue("TextureCoordinate", "COORD_U", COORD_U);
     engine->RegisterEnumValue("TextureCoordinate", "COORD_V", COORD_V);
     engine->RegisterEnumValue("TextureCoordinate", "COORD_W", COORD_W);
-    
+
     engine->RegisterEnum("RenderSurfaceUpdateMode");
     engine->RegisterEnumValue("RenderSurfaceUpdateMode", "SURFACE_MANUALUPDATE", SURFACE_MANUALUPDATE);
     engine->RegisterEnumValue("RenderSurfaceUpdateMode", "SURFACE_UPDATEVISIBLE", SURFACE_UPDATEVISIBLE);
     engine->RegisterEnumValue("RenderSurfaceUpdateMode", "SURFACE_UPDATEALWAYS", SURFACE_UPDATEALWAYS);
     RegisterTexture<Texture>(engine, "Texture");
-    
+
     RegisterObject<Viewport>(engine, "Viewport");
     engine->RegisterObjectBehaviour("Viewport", asBEHAVE_FACTORY, "Viewport@+ f()", asFUNCTION(ConstructViewport), asCALL_CDECL);
     engine->RegisterObjectBehaviour("Viewport", asBEHAVE_FACTORY, "Viewport@+ f(Scene@+, Camera@+, RenderPath@+ renderPath = null)", asFUNCTION(ConstructViewportSceneCamera), asCALL_CDECL);
@@ -458,7 +458,7 @@ static void RegisterTextures(asIScriptEngine* engine)
     engine->RegisterObjectMethod("Viewport", "Ray GetScreenRay(int, int) const", asMETHOD(Viewport, GetScreenRay), asCALL_THISCALL);
     engine->RegisterObjectMethod("Viewport", "Vector2 WorldToScreenPoint(const Vector3&in) const", asMETHOD(Viewport, WorldToScreenPoint), asCALL_THISCALL);
     engine->RegisterObjectMethod("Viewport", "Vector3 ScreenToWorldPoint(int, int, float) const", asMETHOD(Viewport, ScreenToWorldPoint), asCALL_THISCALL);
-    
+
     engine->RegisterObjectType("RenderSurface", 0, asOBJ_REF);
     engine->RegisterObjectBehaviour("RenderSurface", asBEHAVE_ADDREF, "void f()", asMETHOD(RenderSurface, AddRef), asCALL_THISCALL);
     engine->RegisterObjectBehaviour("RenderSurface", asBEHAVE_RELEASE, "void f()", asMETHOD(RenderSurface, ReleaseRef), asCALL_THISCALL);
@@ -477,7 +477,7 @@ static void RegisterTextures(asIScriptEngine* engine)
     engine->RegisterObjectMethod("RenderSurface", "RenderSurface@+ get_linkedRenderTarget() const", asMETHOD(RenderSurface, GetLinkedRenderTarget), asCALL_THISCALL);
     engine->RegisterObjectMethod("RenderSurface", "void set_linkedDepthStencil(RenderSurface@+)", asMETHOD(RenderSurface, SetLinkedDepthStencil), asCALL_THISCALL);
     engine->RegisterObjectMethod("RenderSurface", "RenderSurface@+ get_linkedDepthStencil() const", asMETHOD(RenderSurface, GetLinkedDepthStencil), asCALL_THISCALL);
-    
+
     RegisterTexture<Texture2D>(engine, "Texture2D");
     engine->RegisterObjectMethod("Texture2D", "bool SetSize(int, int, uint, TextureUsage usage = TEXTURE_STATIC)", asMETHOD(Texture2D, SetSize), asCALL_THISCALL);
     engine->RegisterObjectMethod("Texture2D", "bool SetData(Image@+, bool useAlpha = false)", asFUNCTION(Texture2DSetData), asCALL_CDECL_OBJLAST);
@@ -487,12 +487,12 @@ static void RegisterTextures(asIScriptEngine* engine)
     engine->RegisterObjectMethod("Texture3D", "bool SetSize(int, int, uint, TextureUsage usage = TEXTURE_STATIC)", asMETHOD(Texture3D, SetSize), asCALL_THISCALL);
     engine->RegisterObjectMethod("Texture3D", "bool SetData(Image@+, bool useAlpha = false)", asFUNCTION(Texture3DSetData), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod("Texture3D", "RenderSurface@+ get_renderSurface() const", asMETHOD(Texture3D, GetRenderSurface), asCALL_THISCALL);
-    
+
     RegisterTexture<TextureCube>(engine, "TextureCube");
     engine->RegisterObjectMethod("TextureCube", "bool SetSize(int, uint, TextureUsage usage = TEXTURE_STATIC)", asMETHOD(TextureCube, SetSize), asCALL_THISCALL);
     engine->RegisterObjectMethod("TextureCube", "bool SetData(CubeMapFace, Image@+, bool useAlpha = false)", asFUNCTION(TextureCubeSetData), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod("TextureCube", "RenderSurface@+ get_renderSurfaces(CubeMapFace) const", asMETHOD(TextureCube, GetRenderSurface), asCALL_THISCALL);
-    
+
     engine->RegisterGlobalFunction("uint GetAlphaFormat()", asFUNCTION(Graphics::GetAlphaFormat), asCALL_CDECL);
     engine->RegisterGlobalFunction("uint GetLuminanceFormat()", asFUNCTION(Graphics::GetLuminanceFormat), asCALL_CDECL);
     engine->RegisterGlobalFunction("uint GetLuminanceAlphaFormat()", asFUNCTION(Graphics::GetLuminanceAlphaFormat), asCALL_CDECL);
@@ -593,7 +593,7 @@ static const TechniqueEntry& MaterialGetTechniqueEntry(unsigned index, Material*
         asGetActiveContext()->SetException("Index out of bounds");
         return noTechniqueEntry;
     }
-    
+
     return ptr->GetTechniqueEntry(index);
 }
 
@@ -744,7 +744,7 @@ static void RegisterMaterial(asIScriptEngine* engine)
     engine->RegisterObjectBehaviour("BiasParameters", asBEHAVE_CONSTRUCT, "void f(float, float)", asFUNCTION(ConstructBiasParametersInit), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectProperty("BiasParameters", "float constantBias", offsetof(BiasParameters, constantBias_));
     engine->RegisterObjectProperty("BiasParameters", "float slopeScaledBias", offsetof(BiasParameters, slopeScaledBias_));
-    
+
     engine->RegisterEnum("CompareMode");
     engine->RegisterEnumValue("CompareMode", "CMP_ALWAYS", CMP_ALWAYS);
     engine->RegisterEnumValue("CompareMode", "CMP_EQUAL", CMP_EQUAL);
@@ -753,17 +753,17 @@ static void RegisterMaterial(asIScriptEngine* engine)
     engine->RegisterEnumValue("CompareMode", "CMP_LESSEQUAL", CMP_LESSEQUAL);
     engine->RegisterEnumValue("CompareMode", "CMP_GREATER", CMP_GREATER);
     engine->RegisterEnumValue("CompareMode", "CMP_GREATEREQUAL", CMP_GREATEREQUAL);
-    
+
     engine->RegisterEnum("CullMode");
     engine->RegisterEnumValue("CullMode", "CULL_NONE", CULL_NONE);
     engine->RegisterEnumValue("CullMode", "CULL_CCW", CULL_CCW);
     engine->RegisterEnumValue("CullMode", "CULL_CW", CULL_CW);
-    
+
     engine->RegisterEnum("PassLightingMode");
     engine->RegisterEnumValue("PassLightingMode", "LIGHTING_UNLIT", LIGHTING_UNLIT);
     engine->RegisterEnumValue("PassLightingMode", "LIGHTING_PERVERTEX", LIGHTING_PERVERTEX);
     engine->RegisterEnumValue("PassLightingMode", "LIGHTING_PERPIXEL", LIGHTING_PERPIXEL);
-    
+
     RegisterRefCounted<Pass>(engine, "Pass");
     engine->RegisterObjectMethod("Pass", "void set_blendMode(BlendMode)", asMETHOD(Pass, SetBlendMode), asCALL_THISCALL);
     engine->RegisterObjectMethod("Pass", "BlendMode get_blendMode() const", asMETHOD(Pass, GetBlendMode), asCALL_THISCALL);
@@ -785,7 +785,7 @@ static void RegisterMaterial(asIScriptEngine* engine)
     engine->RegisterObjectMethod("Pass", "const String& get_vertexShaderDefines() const", asMETHOD(Pass, GetVertexShaderDefines), asCALL_THISCALL);
     engine->RegisterObjectMethod("Pass", "void set_pixelShaderDefines(const String&in)", asMETHOD(Pass, SetPixelShaderDefines), asCALL_THISCALL);
     engine->RegisterObjectMethod("Pass", "const String& get_pixelShaderDefines() const", asMETHOD(Pass, GetPixelShaderDefines), asCALL_THISCALL);
-    
+
     RegisterResource<Technique>(engine, "Technique");
     engine->RegisterObjectMethod("Technique", "Pass@+ CreatePass(const String&in)", asMETHOD(Technique, CreatePass), asCALL_THISCALL);
     engine->RegisterObjectMethod("Technique", "void RemovePass(const String&in)", asMETHOD(Technique, RemovePass), asCALL_THISCALL);
@@ -798,7 +798,7 @@ static void RegisterMaterial(asIScriptEngine* engine)
     engine->RegisterObjectMethod("Technique", "uint get_numPasses() const", asMETHOD(Technique, GetNumPasses), asCALL_THISCALL);
     engine->RegisterObjectMethod("Technique", "Array<String>@ get_passNames() const", asFUNCTION(TechniqueGetPassNames), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod("Technique", "Array<Pass@>@ get_passes() const", asFUNCTION(TechniqueGetPasses), asCALL_CDECL_OBJLAST);
-    
+
     engine->RegisterObjectType("TechniqueEntry", sizeof(TechniqueEntry), asOBJ_VALUE | asOBJ_APP_CLASS_CD);
     engine->RegisterObjectBehaviour("TechniqueEntry", asBEHAVE_CONSTRUCT, "void f()", asFUNCTION(ConstructTechniqueEntry), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectBehaviour("TechniqueEntry", asBEHAVE_CONSTRUCT, "void f(const TechniqueEntry&in)", asFUNCTION(ConstructTechniqueEntryCopy), asCALL_CDECL_OBJLAST);
@@ -845,7 +845,7 @@ static void RegisterMaterial(asIScriptEngine* engine)
     engine->RegisterObjectMethod("Material", "const BiasParameters& get_depthBias() const", asMETHOD(Material, GetDepthBias), asCALL_THISCALL);
     engine->RegisterObjectMethod("Material", "void set_scene(Scene@+)", asMETHOD(Material, SetScene), asCALL_THISCALL);
     engine->RegisterObjectMethod("Material", "Scene@+ get_scene() const", asMETHOD(Material, GetScene), asCALL_THISCALL);
-    
+
     engine->RegisterGlobalFunction("String GetTextureUnitName(TextureUnit)", asFUNCTION(Material::GetTextureUnitName), asCALL_CDECL);
 }
 
@@ -889,7 +889,7 @@ static void RegisterAnimation(asIScriptEngine* engine)
     engine->RegisterObjectBehaviour("AnimationTriggerPoint", asBEHAVE_RELEASE, "void f()", asFUNCTION(FakeReleaseRef), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectProperty("AnimationTriggerPoint", "float time", offsetof(AnimationTriggerPoint, time_));
     engine->RegisterObjectProperty("AnimationTriggerPoint", "Variant data", offsetof(AnimationTriggerPoint, data_));
-    
+
     RegisterResource<Animation>(engine, "Animation");
     engine->RegisterObjectMethod("Animation", "const String& get_animationName() const", asMETHOD(Animation, GetAnimationName), asCALL_THISCALL);
     engine->RegisterObjectMethod("Animation", "void AddTrigger(float, bool, const Variant&in)", asMETHOD(Animation, AddTrigger), asCALL_THISCALL);
@@ -911,7 +911,7 @@ static void RegisterDrawable(asIScriptEngine* engine)
     engine->RegisterGlobalProperty("uint DRAWABLE_ANY", (void*)&DRAWABLE_ANY);
     engine->RegisterGlobalProperty("uint DEFAULT_VIEWMASK", (void*)&DEFAULT_VIEWMASK);
     engine->RegisterGlobalProperty("uint DEFAULT_LIGHTMASK", (void*)&DEFAULT_LIGHTMASK);
-    
+
     RegisterDrawable<Drawable>(engine, "Drawable");
 }
 
@@ -951,7 +951,7 @@ static void RegisterLight(asIScriptEngine* engine)
     engine->RegisterEnumValue("LightType", "LIGHT_DIRECTIONAL", LIGHT_DIRECTIONAL);
     engine->RegisterEnumValue("LightType", "LIGHT_SPOT", LIGHT_SPOT);
     engine->RegisterEnumValue("LightType", "LIGHT_POINT", LIGHT_POINT);
-    
+
     engine->RegisterObjectType("CascadeParameters", sizeof(CascadeParameters), asOBJ_VALUE | asOBJ_POD | asOBJ_APP_CLASS_C);
     engine->RegisterObjectBehaviour("CascadeParameters", asBEHAVE_CONSTRUCT, "void f()", asFUNCTION(ConstructCascadeParameters), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectBehaviour("CascadeParameters", asBEHAVE_CONSTRUCT, "void f(const CascadeParameters&in)", asFUNCTION(ConstructCascadeParametersCopy), asCALL_CDECL_OBJLAST);
@@ -962,7 +962,7 @@ static void RegisterLight(asIScriptEngine* engine)
     engine->RegisterObjectProperty("CascadeParameters", "float split4", offsetof(CascadeParameters, splits_[3]));
     engine->RegisterObjectProperty("CascadeParameters", "float fadeStart", offsetof(CascadeParameters, fadeStart_));
     engine->RegisterObjectProperty("CascadeParameters", "float biasAutoAdjust", offsetof(CascadeParameters, biasAutoAdjust_));
-    
+
     engine->RegisterObjectType("FocusParameters", sizeof(FocusParameters), asOBJ_VALUE | asOBJ_POD | asOBJ_APP_CLASS_C);
     engine->RegisterObjectBehaviour("FocusParameters", asBEHAVE_CONSTRUCT, "void f()", asFUNCTION(ConstructFocusParameters), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectBehaviour("FocusParameters", asBEHAVE_CONSTRUCT, "void f(const FocusParameters&in)", asFUNCTION(ConstructFocusParametersCopy), asCALL_CDECL_OBJLAST);
@@ -972,7 +972,7 @@ static void RegisterLight(asIScriptEngine* engine)
     engine->RegisterObjectProperty("FocusParameters", "bool autoSize", offsetof(FocusParameters, autoSize_));
     engine->RegisterObjectProperty("FocusParameters", "float quantize", offsetof(FocusParameters, quantize_));
     engine->RegisterObjectProperty("FocusParameters", "float minView", offsetof(FocusParameters, minView_));
-    
+
     RegisterDrawable<Light>(engine, "Light");
     engine->RegisterObjectMethod("Light", "void set_lightType(LightType)", asMETHOD(Light, SetLightType), asCALL_THISCALL);
     engine->RegisterObjectMethod("Light", "LightType get_lightType() const", asMETHOD(Light, GetLightType), asCALL_THISCALL);
@@ -1106,7 +1106,7 @@ static void RegisterAnimatedModel(asIScriptEngine* engine)
 {
     RegisterRefCounted<AnimationState>(engine, "AnimationState");
     RegisterStaticModel<AnimatedModel>(engine, "AnimatedModel", false);
-    
+
     engine->RegisterObjectBehaviour("AnimationState", asBEHAVE_FACTORY, "AnimationState@+ f(Node@+, Animation@+)", asFUNCTION(ConstructAnimationState), asCALL_CDECL);
     engine->RegisterObjectMethod("AnimationState", "void AddWeight(float)", asMETHOD(AnimationState, AddWeight), asCALL_THISCALL);
     engine->RegisterObjectMethod("AnimationState", "void AddTime(float)", asMETHOD(AnimationState, AddTime), asCALL_THISCALL);
@@ -1202,7 +1202,7 @@ static void RegisterBillboardSet(asIScriptEngine* engine)
     engine->RegisterEnumValue("FaceCameraMode", "FC_ROTATE_Y", FC_ROTATE_Y);
     engine->RegisterEnumValue("FaceCameraMode", "FC_LOOKAT_XYZ", FC_LOOKAT_XYZ);
     engine->RegisterEnumValue("FaceCameraMode", "FC_LOOKAT_Y", FC_LOOKAT_Y);
-    
+
     engine->RegisterObjectType("Billboard", 0, asOBJ_REF);
     engine->RegisterObjectBehaviour("Billboard", asBEHAVE_ADDREF, "void f()", asFUNCTION(FakeAddRef), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectBehaviour("Billboard", asBEHAVE_RELEASE, "void f()", asFUNCTION(FakeReleaseRef), asCALL_CDECL_OBJLAST);
@@ -1212,7 +1212,7 @@ static void RegisterBillboardSet(asIScriptEngine* engine)
     engine->RegisterObjectProperty("Billboard", "Color color", offsetof(Billboard, color_));
     engine->RegisterObjectProperty("Billboard", "float rotation", offsetof(Billboard, rotation_));
     engine->RegisterObjectProperty("Billboard", "bool enabled", offsetof(Billboard, enabled_));
-    
+
     RegisterDrawable<BillboardSet>(engine, "BillboardSet");
     engine->RegisterObjectMethod("BillboardSet", "void Commit()", asMETHOD(BillboardSet, Commit), asCALL_THISCALL);
     engine->RegisterObjectMethod("BillboardSet", "void set_material(Material@+)", asMETHOD(BillboardSet, SetMaterial), asCALL_THISCALL);
@@ -1250,7 +1250,7 @@ static void RegisterParticleEffect(asIScriptEngine* engine)
     engine->RegisterObjectBehaviour("TextureFrame", asBEHAVE_RELEASE, "void f()", asFUNCTION(FakeReleaseRef), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectProperty("TextureFrame", "Rect uv", offsetof(TextureFrame, uv_));
     engine->RegisterObjectProperty("TextureFrame", "float time", offsetof(TextureFrame, time_));
-    
+
     RegisterResource<ParticleEffect>(engine, "ParticleEffect");
     engine->RegisterObjectMethod("ParticleEffect", "bool Load(const XMLElement&in)", asMETHODPR(ParticleEffect, Load, (const XMLElement&), bool), asCALL_THISCALL);
     engine->RegisterObjectMethod("ParticleEffect", "bool Save(XMLElement&in) const", asMETHODPR(ParticleEffect, Save, (XMLElement&) const, bool), asCALL_THISCALL);
@@ -1333,7 +1333,7 @@ static void RegisterParticleEffect(asIScriptEngine* engine)
 }
 
 static void RegisterParticleEmitter(asIScriptEngine* engine)
-{   
+{
     RegisterDrawable<ParticleEmitter>(engine, "ParticleEmitter");
     // Copy from BillboardSet
     engine->RegisterObjectMethod("ParticleEmitter", "void Commit()", asMETHOD(ParticleEmitter, Commit), asCALL_THISCALL);
@@ -1555,12 +1555,12 @@ static void RegisterRenderer(asIScriptEngine* engine)
     engine->RegisterGlobalProperty("const int QUALITY_MEDIUM", (void*)&QUALITY_MEDIUM);
     engine->RegisterGlobalProperty("const int QUALITY_HIGH", (void*)&QUALITY_HIGH);
     engine->RegisterGlobalProperty("const int QUALITY_MAX", (void*)&QUALITY_MAX);
-    
+
     engine->RegisterGlobalProperty("const int SHADOWQUALITY_LOW_16BIT", (void*)&SHADOWQUALITY_LOW_16BIT);
     engine->RegisterGlobalProperty("const int SHADOWQUALITY_LOW_24BIT", (void*)&SHADOWQUALITY_LOW_24BIT);
     engine->RegisterGlobalProperty("const int SHADOWQUALITY_HIGH_16BIT", (void*)&SHADOWQUALITY_HIGH_16BIT);
     engine->RegisterGlobalProperty("const int SHADOWQUALITY_HIGH_24BIT", (void*)&SHADOWQUALITY_HIGH_24BIT);
-    
+
     RegisterObject<Renderer>(engine, "Renderer");
     engine->RegisterObjectMethod("Renderer", "void DrawDebugGeometry(bool) const", asMETHOD(Renderer, DrawDebugGeometry), asCALL_THISCALL);
     engine->RegisterObjectMethod("Renderer", "void ReloadShaders() const", asMETHOD(Renderer, ReloadShaders), asCALL_THISCALL);
@@ -1745,16 +1745,18 @@ static void RegisterOctree(asIScriptEngine* engine)
     engine->RegisterEnumValue("RayQueryLevel", "RAY_AABB", RAY_AABB);
     engine->RegisterEnumValue("RayQueryLevel", "RAY_OBB", RAY_OBB);
     engine->RegisterEnumValue("RayQueryLevel", "RAY_TRIANGLE", RAY_TRIANGLE);
-    
+    engine->RegisterEnumValue("RayQueryLevel", "RAY_TRIANGLE_UV", RAY_TRIANGLE_UV);
+
     engine->RegisterObjectType("RayQueryResult", sizeof(RayQueryResult), asOBJ_VALUE | asOBJ_POD | asOBJ_APP_CLASS_C);
     engine->RegisterObjectBehaviour("RayQueryResult", asBEHAVE_CONSTRUCT, "void f()", asFUNCTION(ConstructRayQueryResult), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectProperty("RayQueryResult", "Vector3 position", offsetof(RayQueryResult, position_));
     engine->RegisterObjectProperty("RayQueryResult", "Vector3 normal", offsetof(RayQueryResult, normal_));
+    engine->RegisterObjectProperty("RayQueryResult", "Vector2 texture_uv", offsetof(RayQueryResult, texture_uv_));
     engine->RegisterObjectProperty("RayQueryResult", "float distance", offsetof(RayQueryResult, distance_));
     engine->RegisterObjectMethod("RayQueryResult", "Drawable@+ get_drawable() const", asFUNCTION(RayQueryResultGetDrawable), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod("RayQueryResult", "Node@+ get_node() const", asFUNCTION(RayQueryResultGetNode), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectProperty("RayQueryResult", "uint subObject", offsetof(RayQueryResult, subObject_));
-    
+
     RegisterComponent<Octree>(engine, "Octree");
     engine->RegisterObjectMethod("Octree", "void SetSize(const BoundingBox&in, uint)", asMETHOD(Octree, SetSize), asCALL_THISCALL);
     engine->RegisterObjectMethod("Octree", "void DrawDebugGeometry(bool) const", asMETHODPR(Octree, DrawDebugGeometry, (bool), void), asCALL_THISCALL);

--- a/Source/Urho3D/Script/GraphicsAPI.cpp
+++ b/Source/Urho3D/Script/GraphicsAPI.cpp
@@ -1751,7 +1751,7 @@ static void RegisterOctree(asIScriptEngine* engine)
     engine->RegisterObjectBehaviour("RayQueryResult", asBEHAVE_CONSTRUCT, "void f()", asFUNCTION(ConstructRayQueryResult), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectProperty("RayQueryResult", "Vector3 position", offsetof(RayQueryResult, position_));
     engine->RegisterObjectProperty("RayQueryResult", "Vector3 normal", offsetof(RayQueryResult, normal_));
-    engine->RegisterObjectProperty("RayQueryResult", "Vector2 texture_uv", offsetof(RayQueryResult, texture_uv_));
+    engine->RegisterObjectProperty("RayQueryResult", "Vector2 textureUV", offsetof(RayQueryResult, textureUV_));
     engine->RegisterObjectProperty("RayQueryResult", "float distance", offsetof(RayQueryResult, distance_));
     engine->RegisterObjectMethod("RayQueryResult", "Drawable@+ get_drawable() const", asFUNCTION(RayQueryResultGetDrawable), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod("RayQueryResult", "Node@+ get_node() const", asFUNCTION(RayQueryResultGetNode), asCALL_CDECL_OBJLAST);


### PR DESCRIPTION
This change adds a new RayQueryLevel - ```RAY_TRIANGLE_UV```
This will ask the query to return texture UV coordinates at Ray-Geometry intersection point.

Since this change is mostly geared towards integrating external UI toolkits, I've only implemented this functionality for StaticModel. _(And frankly doing it for AnimatedModels would be pretty resource intensive)_

This feature will allow us to render UI into textures, place them on the game world objects and properly translate and forward mouse/touch event coordinates to the external UI library.

I've also added a small change to Decals sample to exemplify the usage of this feature. 

