### PR TITLE
OnSceneSet()

### DIFF
--- a/Docs/Reference.dox
+++ b/Docs/Reference.dox
@@ -295,6 +295,8 @@ Whenever there is some hierarchical composition, it is recommended (and in fact 
 
 It is also legal to create a Node that does not belong to a scene. This is useful for example with a camera moving in a scene that may be loaded or saved, because then the camera will not be saved along with the actual scene, and will not be destroyed when the scene is loaded.
 
+However, depending on the components used, creating components to a node outside the scene, then moving the node to a scene later may not work completely as expected. For example, a RigidBody component can not store its velocities if it does not have access to the scene's physics world component to actually create the Bullet rigid body object.
+
 \section SceneModel_Update Scene updates
 
 A Scene whose updates are enabled (default) will be automatically updated on each main loop iteration. See \ref Scene::SetUpdateEnabled "SetUpdateEnabled()".

--- a/Docs/Reference.dox
+++ b/Docs/Reference.dox
@@ -293,7 +293,7 @@ Whenever there is some hierarchical composition, it is recommended (and in fact 
 
 %Scene nodes can be freely reparented. In contrast components are always created to the node they belong to, and can not be moved between nodes. Both child nodes and components are stored using SharedPtr containers; this means that detaching a child node from its parent or removing a component will also destroy it, if no other references to it exist. Both Node & Component provide the \ref Node::Remove "Remove()" function to accomplish this without having to go through the parent. Note that no operations on the node or component in question are safe after calling that function.
 
-It is also legal to create a Node that does not belong to a scene. This is useful for example with a camera moving in a scene that may be loaded or saved, because then the camera will not be saved along with the actual scene, and will not be destroyed when the scene is loaded. However, note that creating geometry, physics or script components to an unattached node, and then moving it into a scene later will cause those components to not work correctly.
+It is also legal to create a Node that does not belong to a scene. This is useful for example with a camera moving in a scene that may be loaded or saved, because then the camera will not be saved along with the actual scene, and will not be destroyed when the scene is loaded.
 
 \section SceneModel_Update Scene updates
 

--- a/Source/Urho3D/Graphics/AnimationController.cpp
+++ b/Source/Urho3D/Graphics/AnimationController.cpp
@@ -757,14 +757,12 @@ VariantVector AnimationController::GetNodeAnimationStatesAttr() const
     return ret;
 }
 
-void AnimationController::OnNodeSet(Node* node)
+void AnimationController::OnSceneSet(Scene* scene)
 {
-    if (node)
-    {
-        Scene* scene = GetScene();
-        if (scene && IsEnabledEffective())
-            SubscribeToEvent(scene, E_SCENEPOSTUPDATE, HANDLER(AnimationController, HandleScenePostUpdate));
-    }
+    if (scene && IsEnabledEffective())
+        SubscribeToEvent(scene, E_SCENEPOSTUPDATE, HANDLER(AnimationController, HandleScenePostUpdate));
+    else if (!scene)
+        UnsubscribeFromEvent(E_SCENEPOSTUPDATE);
 }
 
 AnimationState* AnimationController::AddAnimationState(Animation* animation)

--- a/Source/Urho3D/Graphics/AnimationController.h
+++ b/Source/Urho3D/Graphics/AnimationController.h
@@ -174,8 +174,8 @@ public:
     VariantVector GetNodeAnimationStatesAttr() const;
 
 protected:
-    /// Handle node being assigned.
-    virtual void OnNodeSet(Node* node);
+    /// Handle scene being assigned.
+    virtual void OnSceneSet(Scene* scene);
 
 private:
     /// Add an animation state either to AnimatedModel or as a node animation.

--- a/Source/Urho3D/Graphics/Drawable.cpp
+++ b/Source/Urho3D/Graphics/Drawable.cpp
@@ -359,10 +359,13 @@ void Drawable::LimitVertexLights(bool removeConvertedLights)
 void Drawable::OnNodeSet(Node* node)
 {
     if (node)
-    {
-        AddToOctree();
         node->AddListener(this);
-    }
+}
+
+void Drawable::OnSceneSet(Scene* scene)
+{
+    if (scene)
+        AddToOctree();
     else
         RemoveFromOctree();
 }

--- a/Source/Urho3D/Graphics/Drawable.h
+++ b/Source/Urho3D/Graphics/Drawable.h
@@ -257,6 +257,8 @@ public:
 protected:
     /// Handle node being assigned.
     virtual void OnNodeSet(Node* node);
+    /// Handle scene being assigned.
+    virtual void OnSceneSet(Scene* scene);
     /// Handle node transform being dirtied.
     virtual void OnMarkedDirty(Node* node);
     /// Recalculate the world-space bounding box.

--- a/Source/Urho3D/Graphics/ParticleEmitter.cpp
+++ b/Source/Urho3D/Graphics/ParticleEmitter.cpp
@@ -408,16 +408,14 @@ VariantVector ParticleEmitter::GetParticleBillboardsAttr() const
     return ret;
 }
 
-void ParticleEmitter::OnNodeSet(Node* node)
+void ParticleEmitter::OnSceneSet(Scene* scene)
 {
-    BillboardSet::OnNodeSet(node);
+    BillboardSet::OnSceneSet(scene);
 
-    if (node)
-    {
-        Scene* scene = GetScene();
-        if (scene && IsEnabledEffective())
-            SubscribeToEvent(scene, E_SCENEPOSTUPDATE, HANDLER(ParticleEmitter, HandleScenePostUpdate));
-    }
+    if (scene && IsEnabledEffective())
+        SubscribeToEvent(scene, E_SCENEPOSTUPDATE, HANDLER(ParticleEmitter, HandleScenePostUpdate));
+    else if (!scene)
+         UnsubscribeFromEvent(E_SCENEPOSTUPDATE);
 }
 
 bool ParticleEmitter::EmitNewParticle()

--- a/Source/Urho3D/Graphics/ParticleEmitter.h
+++ b/Source/Urho3D/Graphics/ParticleEmitter.h
@@ -106,8 +106,8 @@ public:
     VariantVector GetParticleBillboardsAttr() const;
 
 protected:
-    /// Handle node being assigned.
-    virtual void OnNodeSet(Node* node);
+    /// Handle scene being assigned.
+    virtual void OnSceneSet(Scene* scene);
 
     /// Create a new particle. Return true if there was room.
     bool EmitNewParticle();

--- a/Source/Urho3D/LuaScript/LuaScriptInstance.h
+++ b/Source/Urho3D/LuaScript/LuaScriptInstance.h
@@ -128,6 +128,8 @@ public:
     ResourceRef GetScriptFileAttr() const;
 
 protected:
+    /// Handle scene being assigned.
+    virtual void OnSceneSet(Scene* scene);
     /// Handle node transform being dirtied.
     virtual void OnMarkedDirty(Node* node);
 

--- a/Source/Urho3D/Navigation/CrowdAgent.cpp
+++ b/Source/Urho3D/Navigation/CrowdAgent.cpp
@@ -107,17 +107,17 @@ void CrowdAgent::RegisterObject(Context* context)
 void CrowdAgent::OnNodeSet(Node* node)
 {
     if (node)
-    {
-        Scene* scene = GetScene();
-        if (scene)
-        {
-            if (scene == node)
-                LOGERROR(GetTypeName() + " should not be created to the root scene node");
-            crowdManager_ = scene->GetOrCreateComponent<DetourCrowdManager>();
-            AddAgentToCrowd();
-        }
-
         node->AddListener(this);
+}
+
+void CrowdAgent::OnSceneSet(Scene* scene)
+{
+    if (scene)
+    {
+        if (scene == node_)
+            LOGERROR(GetTypeName() + " should not be created to the root scene node");
+        crowdManager_ = scene->GetOrCreateComponent<DetourCrowdManager>();
+        AddAgentToCrowd();
     }
     else
         RemoveAgentFromCrowd();

--- a/Source/Urho3D/Navigation/CrowdAgent.h
+++ b/Source/Urho3D/Navigation/CrowdAgent.h
@@ -133,6 +133,8 @@ protected:
     virtual void OnCrowdAgentReposition(const Vector3& newPos, const Vector3& newVel);
     /// Handle node being assigned.
     virtual void OnNodeSet(Node* node);
+    /// Handle node being assigned.
+    virtual void OnSceneSet(Scene* scene);
     /// \todo Handle node transform being dirtied.
     virtual void OnMarkedDirty(Node* node);
     /// Get internal Detour crowd agent.

--- a/Source/Urho3D/Navigation/DetourCrowdManager.cpp
+++ b/Source/Urho3D/Navigation/DetourCrowdManager.cpp
@@ -78,7 +78,7 @@ void DetourCrowdManager::RegisterObject(Context* context)
 
 void DetourCrowdManager::SetNavigationMesh(NavigationMesh* navMesh)
 {
-    navigationMesh_ = WeakPtr<NavigationMesh>(navMesh);
+    navigationMesh_ = navMesh;
     if (navigationMesh_ && !navigationMesh_->navMeshQuery_)
         navigationMesh_->InitializeQuery();
     CreateCrowd();
@@ -514,23 +514,31 @@ void DetourCrowdManager::HandleNavMeshFullRebuild(StringHash eventType, VariantM
     }
 }
 
-void DetourCrowdManager::OnNodeSet(Node* node)
+void DetourCrowdManager::OnSceneSet(Scene* scene)
 {
     // Subscribe to the scene subsystem update, which will trigger the crowd update step, and grab a reference
     // to the scene's NavigationMesh
-    if (node)
+    if (scene)
     {
-        SubscribeToEvent(node, E_SCENESUBSYSTEMUPDATE, HANDLER(DetourCrowdManager, HandleSceneSubsystemUpdate));
-        SubscribeToEvent(node, E_NAVIGATION_MESH_REBUILT, HANDLER(DetourCrowdManager, HandleNavMeshFullRebuild));
-
+        SubscribeToEvent(scene, E_SCENESUBSYSTEMUPDATE, HANDLER(DetourCrowdManager, HandleSceneSubsystemUpdate));
         NavigationMesh* mesh = GetScene()->GetComponent<NavigationMesh>();
         if (!mesh)
             mesh = GetScene()->GetComponent<DynamicNavigationMesh>();
         if (mesh)
+        {
+            SubscribeToEvent(mesh, E_NAVIGATION_MESH_REBUILT, HANDLER(DetourCrowdManager, HandleNavMeshFullRebuild));
             SetNavigationMesh(mesh);
+        }
         else
             LOGERROR("DetourCrowdManager requires an existing navigation mesh");
     }
+    else
+    {
+        UnsubscribeFromEvent(E_SCENESUBSYSTEMUPDATE);
+        UnsubscribeFromEvent(E_NAVIGATION_MESH_REBUILT);
+        navigationMesh_.Reset();
+    }
+
 }
 
 }

--- a/Source/Urho3D/Navigation/DetourCrowdManager.h
+++ b/Source/Urho3D/Navigation/DetourCrowdManager.h
@@ -116,8 +116,8 @@ protected:
 protected:
     /// Update the crowd simulation.
     void Update(float delta);
-    /// Handle node being assigned.
-    virtual void OnNodeSet(Node* node);
+    /// Handle scene being assigned.
+    virtual void OnSceneSet(Scene* scene);
     /// Get the detour crowd agent.
     const dtCrowdAgent* GetCrowdAgent(int agent);
     /// Get the internal detour crowd component.

--- a/Source/Urho3D/Navigation/DynamicNavigationMesh.cpp
+++ b/Source/Urho3D/Navigation/DynamicNavigationMesh.cpp
@@ -881,11 +881,13 @@ void DynamicNavigationMesh::ReleaseTileCache()
     tileCache_ = 0;
 }
 
-void DynamicNavigationMesh::OnNodeSet(Node* node)
+void DynamicNavigationMesh::OnSceneSet(Scene* scene)
 {
     // Subscribe to the scene subsystem update, which will trigger the tile cache to update the nav mesh
-    if (node)
-        SubscribeToEvent(node, E_SCENESUBSYSTEMUPDATE, HANDLER(DynamicNavigationMesh, HandleSceneSubsystemUpdate));
+    if (scene)
+        SubscribeToEvent(scene, E_SCENESUBSYSTEMUPDATE, HANDLER(DynamicNavigationMesh, HandleSceneSubsystemUpdate));
+    else
+        UnsubscribeFromEvent(E_SCENESUBSYSTEMUPDATE);
 }
 
 void DynamicNavigationMesh::AddObstacle(Obstacle* obstacle, bool silent)

--- a/Source/Urho3D/Navigation/DynamicNavigationMesh.h
+++ b/Source/Urho3D/Navigation/DynamicNavigationMesh.h
@@ -80,8 +80,8 @@ public:
 protected:
     struct TileCacheData;
 
-    /// Subscribe to events when assigned to a node.
-    virtual void OnNodeSet(Node*);
+    /// Subscribe to events when assigned to a scene.
+    virtual void OnSceneSet(Scene* scene);
     /// Trigger the tile cache to make updates to the nav mesh if necessary.
     void HandleSceneSubsystemUpdate(StringHash eventType, VariantMap& eventData);
 

--- a/Source/Urho3D/Navigation/Obstacle.cpp
+++ b/Source/Urho3D/Navigation/Obstacle.cpp
@@ -85,17 +85,17 @@ void Obstacle::SetRadius(float newRadius)
     MarkNetworkUpdate();
 }
 
-void Obstacle::OnNodeSet(Node* node)
+void Obstacle::OnSceneSet(Scene* scene)
 {
-    if (node)
+    if (scene)
     {
-        if (GetScene() == node)
+        if (scene == node_)
         {
             LOGWARNING(GetTypeName() + " should not be created to the root scene node");
             return;
         }
         if (!ownerMesh_)
-            ownerMesh_ = GetScene()->GetComponent<DynamicNavigationMesh>();
+            ownerMesh_ = scene->GetComponent<DynamicNavigationMesh>();
         if (ownerMesh_)
             ownerMesh_->AddObstacle(this);
     }

--- a/Source/Urho3D/Navigation/Obstacle.h
+++ b/Source/Urho3D/Navigation/Obstacle.h
@@ -66,8 +66,8 @@ public:
     void DrawDebugGeometry(bool depthTest);
 
 protected:
-    /// Handle node being assigned, identify our DynamicNavigationMesh.
-    virtual void OnNodeSet(Node* node);
+    /// Handle scene being assigned, identify our DynamicNavigationMesh.
+    virtual void OnSceneSet(Scene* scene);
 
 private:
     /// Radius of this obstacle.

--- a/Source/Urho3D/Physics/CollisionShape.cpp
+++ b/Source/Urho3D/Physics/CollisionShape.cpp
@@ -914,23 +914,30 @@ void CollisionShape::OnNodeSet(Node* node)
 {
     if (node)
     {
-        Scene* scene = GetScene();
-        if (scene)
-        {
-            if (scene == node)
-                LOGWARNING(GetTypeName() + " should not be created to the root scene node");
-
-            physicsWorld_ = scene->GetOrCreateComponent<PhysicsWorld>();
-            physicsWorld_->AddCollisionShape(this);
-        }
-        else
-            LOGERROR("Node is detached from scene, can not create collision shape");
-
         node->AddListener(this);
         cachedWorldScale_ = node->GetWorldScale();
 
         // Terrain collision shape depends on the terrain component's geometry updates. Subscribe to them
         SubscribeToEvent(node, E_TERRAINCREATED, HANDLER(CollisionShape, HandleTerrainCreated));
+    }
+}
+
+void CollisionShape::OnSceneSet(Scene* scene)
+{
+    if (scene)
+    {
+        if (scene == node_)
+            LOGWARNING(GetTypeName() + " should not be created to the root scene node");
+
+        physicsWorld_ = scene->GetOrCreateComponent<PhysicsWorld>();
+        physicsWorld_->AddCollisionShape(this);
+    }
+    else
+    {
+        ReleaseShape();
+
+        if (physicsWorld_)
+            physicsWorld_->RemoveCollisionShape(this);
     }
 }
 

--- a/Source/Urho3D/Physics/CollisionShape.h
+++ b/Source/Urho3D/Physics/CollisionShape.h
@@ -264,6 +264,8 @@ private:
     float margin_;
     /// Recrease collision shape flag.
     bool recreateShape_;
+    /// Shape creation retry flag if attributes initially set without scene.
+    bool retryCreation_;
 };
 
 }

--- a/Source/Urho3D/Physics/CollisionShape.h
+++ b/Source/Urho3D/Physics/CollisionShape.h
@@ -221,6 +221,8 @@ public:
 protected:
     /// Handle node being assigned.
     virtual void OnNodeSet(Node* node);
+    /// Handle scene being assigned.
+    virtual void OnSceneSet(Scene* scene);
     /// Handle node transform being dirtied.
     virtual void OnMarkedDirty(Node* node);
 

--- a/Source/Urho3D/Physics/Constraint.cpp
+++ b/Source/Urho3D/Physics/Constraint.cpp
@@ -441,20 +441,27 @@ void Constraint::OnNodeSet(Node* node)
 {
     if (node)
     {
-        Scene* scene = GetScene();
-        if (scene)
-        {
-            if (scene == node)
-                LOGWARNING(GetTypeName() + " should not be created to the root scene node");
-
-            physicsWorld_ = scene->GetOrCreateComponent<PhysicsWorld>();
-            physicsWorld_->AddConstraint(this);
-        }
-        else
-            LOGERROR("Node is detached from scene, can not create constraint");
-
         node->AddListener(this);
         cachedWorldScale_ = node->GetWorldScale();
+    }
+}
+
+void Constraint::OnSceneSet(Scene* scene)
+{
+    if (scene)
+    {
+        if (scene == node_)
+            LOGWARNING(GetTypeName() + " should not be created to the root scene node");
+
+        physicsWorld_ = scene->GetOrCreateComponent<PhysicsWorld>();
+        physicsWorld_->AddConstraint(this);
+    }
+    else
+    {
+        ReleaseConstraint();
+
+        if (physicsWorld_)
+            physicsWorld_->RemoveConstraint(this);
     }
 }
 

--- a/Source/Urho3D/Physics/Constraint.h
+++ b/Source/Urho3D/Physics/Constraint.h
@@ -136,6 +136,8 @@ public:
 protected:
     /// Handle node being assigned.
     virtual void OnNodeSet(Node* node);
+    /// Handle scene being assigned.
+    virtual void OnSceneSet(Scene* scene);
     /// Handle node transform being dirtied.
     virtual void OnMarkedDirty(Node* node);
     

--- a/Source/Urho3D/Physics/Constraint.h
+++ b/Source/Urho3D/Physics/Constraint.h
@@ -183,6 +183,8 @@ private:
     bool recreateConstraint_;
     /// Coordinate frames dirty flag.
     bool framesDirty_;
+    /// Constraint creation retry flag if attributes initially set without scene.
+    bool retryCreation_;
 };
 
 }

--- a/Source/Urho3D/Physics/PhysicsWorld.cpp
+++ b/Source/Urho3D/Physics/PhysicsWorld.cpp
@@ -653,14 +653,16 @@ void PhysicsWorld::CleanupGeometryCache()
     }
 }
 
-void PhysicsWorld::OnNodeSet(Node* node)
+void PhysicsWorld::OnSceneSet(Scene* scene)
 {
     // Subscribe to the scene subsystem update, which will trigger the physics simulation step
-    if (node)
+    if (scene)
     {
         scene_ = GetScene();
-        SubscribeToEvent(node, E_SCENESUBSYSTEMUPDATE, HANDLER(PhysicsWorld, HandleSceneSubsystemUpdate));
+        SubscribeToEvent(scene_, E_SCENESUBSYSTEMUPDATE, HANDLER(PhysicsWorld, HandleSceneSubsystemUpdate));
     }
+    else
+        UnsubscribeFromEvent(E_SCENESUBSYSTEMUPDATE);
 }
 
 void PhysicsWorld::HandleSceneSubsystemUpdate(StringHash eventType, VariantMap& eventData)

--- a/Source/Urho3D/Physics/PhysicsWorld.h
+++ b/Source/Urho3D/Physics/PhysicsWorld.h
@@ -217,8 +217,8 @@ public:
     bool IsApplyingTransforms() const { return applyingTransforms_; }
 
 protected:
-    /// Handle node being assigned.
-    virtual void OnNodeSet(Node* node);
+    /// Handle scene being assigned.
+    virtual void OnSceneSet(Scene* scene);
 
 private:
     /// Handle the scene subsystem update event, step simulation here.

--- a/Source/Urho3D/Physics/RigidBody.cpp
+++ b/Source/Urho3D/Physics/RigidBody.cpp
@@ -909,22 +909,27 @@ void RigidBody::OnMarkedDirty(Node* node)
 void RigidBody::OnNodeSet(Node* node)
 {
     if (node)
-    {
-        Scene* scene = GetScene();
-        if (scene)
-        {
-            if (scene == node)
-                LOGWARNING(GetTypeName() + " should not be created to the root scene node");
-
-            physicsWorld_ = scene->GetOrCreateComponent<PhysicsWorld>();
-            physicsWorld_->AddRigidBody(this);
-
-            AddBodyToWorld();
-        }
-        else
-            LOGERROR("Node is detached from scene, can not create rigid body");
-
         node->AddListener(this);
+}
+
+void RigidBody::OnSceneSet(Scene* scene)
+{
+    if (scene)
+    {
+        if (scene == node_)
+            LOGWARNING(GetTypeName() + " should not be created to the root scene node");
+
+        physicsWorld_ = scene->GetOrCreateComponent<PhysicsWorld>();
+        physicsWorld_->AddRigidBody(this);
+
+        AddBodyToWorld();
+    }
+    else
+    {
+        ReleaseBody();
+
+        if (physicsWorld_)
+            physicsWorld_->RemoveRigidBody(this);
     }
 }
 

--- a/Source/Urho3D/Physics/RigidBody.h
+++ b/Source/Urho3D/Physics/RigidBody.h
@@ -234,6 +234,8 @@ public:
 protected:
     /// Handle node being assigned.
     virtual void OnNodeSet(Node* node);
+    /// Handle scene being assigned.
+    virtual void OnSceneSet(Scene* scene);
     /// Handle node transform being dirtied.
     virtual void OnMarkedDirty(Node* node);
 

--- a/Source/Urho3D/Scene/Component.cpp
+++ b/Source/Urho3D/Scene/Component.cpp
@@ -216,6 +216,10 @@ void Component::OnNodeSet(Node* node)
 {
 }
 
+void Component::OnSceneSet(Scene* scene)
+{
+}
+
 void Component::OnMarkedDirty(Node* node)
 {
 }

--- a/Source/Urho3D/Scene/Component.h
+++ b/Source/Urho3D/Scene/Component.h
@@ -99,6 +99,8 @@ protected:
     virtual void OnAttributeAnimationRemoved();
     /// Handle scene node being assigned at creation.
     virtual void OnNodeSet(Node* node);
+    /// Handle scene being assigned. This may happen several times during the component's lifetime. Scene-wide subsystems and events are subscribed to here.
+    virtual void OnSceneSet(Scene* scene);
     /// Handle scene node transform dirtied.
     virtual void OnMarkedDirty(Node* node);
     /// Handle scene node enabled status changing.

--- a/Source/Urho3D/Scene/LogicComponent.cpp
+++ b/Source/Urho3D/Scene/LogicComponent.cpp
@@ -78,9 +78,7 @@ void LogicComponent::OnNodeSet(Node* node)
 {
     if (node)
     {
-        // We have been attached to a node. Set initial update event subscription state
-        UpdateEventSubscription();
-        // Then execute the user-defined start function
+        // Execute the user-defined start function
         Start();
     }
     else
@@ -90,12 +88,22 @@ void LogicComponent::OnNodeSet(Node* node)
     }
 }
 
+void LogicComponent::OnSceneSet(Scene* scene)
+{
+    if (scene)
+        UpdateEventSubscription();
+    else
+    {
+        UnsubscribeFromEvent(E_SCENEUPDATE);
+        UnsubscribeFromEvent(E_SCENEPOSTUPDATE);
+        UnsubscribeFromEvent(E_PHYSICSPRESTEP);
+        UnsubscribeFromEvent(E_PHYSICSPOSTSTEP);
+        currentEventMask_ = 0;
+    }
+}
+
 void LogicComponent::UpdateEventSubscription()
 {
-    // If scene node is not assigned yet, no need to update subscription
-    if (!node_)
-        return;
-    
     Scene* scene = GetScene();
     if (!scene)
     {

--- a/Source/Urho3D/Scene/LogicComponent.cpp
+++ b/Source/Urho3D/Scene/LogicComponent.cpp
@@ -96,8 +96,10 @@ void LogicComponent::OnSceneSet(Scene* scene)
     {
         UnsubscribeFromEvent(E_SCENEUPDATE);
         UnsubscribeFromEvent(E_SCENEPOSTUPDATE);
+#ifdef URHO3D_PHYSICS
         UnsubscribeFromEvent(E_PHYSICSPRESTEP);
         UnsubscribeFromEvent(E_PHYSICSPOSTSTEP);
+#endif
         currentEventMask_ = 0;
     }
 }

--- a/Source/Urho3D/Scene/LogicComponent.cpp
+++ b/Source/Urho3D/Scene/LogicComponent.cpp
@@ -108,10 +108,7 @@ void LogicComponent::UpdateEventSubscription()
 {
     Scene* scene = GetScene();
     if (!scene)
-    {
-        LOGWARNING("Node is detached from scene, can not subscribe to update events");
         return;
-    }
     
     bool enabled = IsEnabledEffective();
     

--- a/Source/Urho3D/Scene/LogicComponent.h
+++ b/Source/Urho3D/Scene/LogicComponent.h
@@ -74,6 +74,8 @@ class URHO3D_API LogicComponent : public Component
 protected:
     /// Handle scene node being assigned at creation.
     virtual void OnNodeSet(Node* node);
+    /// Handle scene being assigned.
+    virtual void OnSceneSet(Scene* scene);
     
 private:
     /// Subscribe/unsubscribe to update events based on current enabled state and update event mask.

--- a/Source/Urho3D/Scene/Node.cpp
+++ b/Source/Urho3D/Scene/Node.cpp
@@ -1419,6 +1419,11 @@ void Node::AddComponent(Component* component, unsigned id, CreateMode mode)
 
     components_.Push(SharedPtr<Component>(component));
 
+    if (component->GetNode())
+        LOGWARNING("Component " + component->GetTypeName() + " already belongs to a node!");
+
+    component->SetNode(this);
+
     // If zero ID specified, or the ID is already taken, let the scene assign
     if (scene_)
     {
@@ -1430,10 +1435,6 @@ void Node::AddComponent(Component* component, unsigned id, CreateMode mode)
     else
         component->SetID(id);
 
-    if(component->GetNode())
-        LOGWARNING("Component " + component->GetTypeName() + " already belongs to a node!");
-
-    component->SetNode(this);
     component->OnMarkedDirty(this);
 
     // Check attributes of the new component on next network update, and mark node dirty in all replication states
@@ -1698,7 +1699,6 @@ void Node::RemoveChild(Vector<SharedPtr<Node> >::Iterator i)
     child->parent_ = 0;
     child->MarkDirty();
     child->MarkNetworkUpdate();
-    // Remove the child from the scene already at this point, in case it is not destroyed immediately
     if (scene_)
         scene_->NodeRemoved(child);
 

--- a/Source/Urho3D/Scene/Node.h
+++ b/Source/Urho3D/Scene/Node.h
@@ -421,7 +421,7 @@ public:
     void SetID(unsigned id);
     /// Set scene. Called by Scene.
     void SetScene(Scene* scene);
-    /// Reset scene. Called by Scene.
+    /// Reset scene, ID and owner. Called by Scene.
     void ResetScene();
     /// Set network position attribute.
     void SetNetPositionAttr(const Vector3& value);

--- a/Source/Urho3D/Scene/Scene.cpp
+++ b/Source/Urho3D/Scene/Scene.cpp
@@ -844,6 +844,8 @@ void Scene::ComponentAdded(Component* component)
 
         localComponents_[id] = component;
     }
+
+    component->OnSceneSet(this);
 }
 
 void Scene::ComponentRemoved(Component* component)
@@ -858,6 +860,7 @@ void Scene::ComponentRemoved(Component* component)
         localComponents_.Erase(id);
 
     component->SetID(0);
+    component->OnSceneSet(0);
 }
 
 void Scene::SetVarNamesAttr(const String& value)

--- a/Source/Urho3D/Script/ScriptInstance.cpp
+++ b/Source/Urho3D/Script/ScriptInstance.cpp
@@ -478,6 +478,23 @@ PODVector<unsigned char> ScriptInstance::GetScriptNetworkDataAttr() const
     }
 }
 
+void ScriptInstance::OnSceneSet(Scene* scene)
+{
+    if (scene)
+        UpdateEventSubscription();
+    else
+    {
+        UnsubscribeFromEvent(E_SCENEUPDATE);
+        UnsubscribeFromEvent(E_SCENEPOSTUPDATE);
+#ifdef URHO3D_PHYSICS
+        UnsubscribeFromEvent(E_PHYSICSPRESTEP);
+        UnsubscribeFromEvent(E_PHYSICSPOSTSTEP);
+#endif
+        subscribed_ = false;
+        subscribedPostFixed_ = false;
+    }
+}
+
 void ScriptInstance::OnMarkedDirty(Node* node)
 {
     // Script functions are not safe from worker threads

--- a/Source/Urho3D/Script/ScriptInstance.h
+++ b/Source/Urho3D/Script/ScriptInstance.h
@@ -140,6 +140,8 @@ public:
     PODVector<unsigned char> GetScriptNetworkDataAttr() const;
 
 protected:
+    /// Handle scene being assigned.
+    virtual void OnSceneSet(Scene* scene);
     /// Handle node transform being dirtied.
     virtual void OnMarkedDirty(Node* node);
 

--- a/Source/Urho3D/Urho2D/AnimatedSprite2D.cpp
+++ b/Source/Urho3D/Urho2D/AnimatedSprite2D.cpp
@@ -173,26 +173,17 @@ ResourceRef AnimatedSprite2D::GetAnimationSetAttr() const
     return GetResourceRef(animationSet_, AnimationSet2D::GetTypeStatic());
 }
 
-void AnimatedSprite2D::OnNodeSet(Node* node)
+void AnimatedSprite2D::OnSceneSet(Scene* scene)
 {
-    StaticSprite2D::OnNodeSet(node);
+    StaticSprite2D::OnSceneSet(scene);
 
-    if (node)
+    if (scene)
     {
-        Scene* scene = GetScene();
-        if (scene && IsEnabledEffective())
+        if (IsEnabledEffective())
             SubscribeToEvent(scene, E_SCENEPOSTUPDATE, HANDLER(AnimatedSprite2D, HandleScenePostUpdate));
     }
     else
-    {
-        if (rootNode_)
-            rootNode_->Remove();
-
-        rootNode_ = 0;
-        numTracks_ = 0;
-        trackNodes_.Clear();
-        trackNodeInfos_.Clear();
-    }
+        UnsubscribeFromEvent(E_SCENEPOSTUPDATE);
 }
 
 void AnimatedSprite2D::SetAnimationAttr(const String& name)

--- a/Source/Urho3D/Urho2D/AnimatedSprite2D.h
+++ b/Source/Urho3D/Urho2D/AnimatedSprite2D.h
@@ -87,8 +87,8 @@ public:
     void SetAnimationAttr(const String& name);
 
 protected:
-    /// Handle node being assigned.
-    virtual void OnNodeSet(Node* node);
+    /// Handle scene being assigned.
+    virtual void OnSceneSet(Scene* scene);
     /// Recalculate the world-space bounding box.
     virtual void OnWorldBoundingBoxUpdate();
     /// Handle draw order changed.

--- a/Source/Urho3D/Urho2D/Constraint2D.cpp
+++ b/Source/Urho3D/Urho2D/Constraint2D.cpp
@@ -125,9 +125,6 @@ void Constraint2D::OnNodeSet(Node* node)
 
     if (node)
     {
-        Scene* scene = GetScene();
-        physicsWorld_ = scene->GetOrCreateComponent<PhysicsWorld2D>();
-
         ownerBody_ = node->GetComponent<RigidBody2D>();
         if (!ownerBody_)
         {
@@ -135,6 +132,12 @@ void Constraint2D::OnNodeSet(Node* node)
             return;
         }
     }
+}
+
+void Constraint2D::OnSceneSet(Scene* scene)
+{
+    if (scene)
+        physicsWorld_ = scene->GetOrCreateComponent<PhysicsWorld2D>();
 }
 
 void Constraint2D::InitializeJointDef(b2JointDef* jointDef)

--- a/Source/Urho3D/Urho2D/Constraint2D.h
+++ b/Source/Urho3D/Urho2D/Constraint2D.h
@@ -73,6 +73,8 @@ public:
 protected:
     /// Handle node being assigned.
     virtual void OnNodeSet(Node* node);
+    /// Handle scene being assigned.
+    virtual void OnSceneSet(Scene* scene);
     /// Return joint def.
     virtual b2JointDef* GetJointDef() { return 0; };
     /// Recreate joint.

--- a/Source/Urho3D/Urho2D/Drawable2D.cpp
+++ b/Source/Urho3D/Urho2D/Drawable2D.cpp
@@ -99,21 +99,16 @@ const Vector<SourceBatch2D>& Drawable2D::GetSourceBatches()
     return sourceBatches_;
 }
 
-void Drawable2D::OnNodeSet(Node* node)
+void Drawable2D::OnSceneSet(Scene* scene)
 {
-    // Do not call Drawable::OnNodeSet(node)
-    if (node)
+    // Do not call Drawable::OnSceneSet(node), as 2D drawable components should not be added to the octree
+    // but are instead rendered through Renderer2D
+    if (scene)
     {
-        Scene* scene = GetScene();
-        if (scene)
-        {
-            renderer_ = scene->GetOrCreateComponent<Renderer2D>();
+        renderer_ = scene->GetOrCreateComponent<Renderer2D>();
 
-            if (IsEnabledEffective())
-                renderer_->AddDrawable(this);
-        }
-
-        node->AddListener(this);
+        if (IsEnabledEffective())
+            renderer_->AddDrawable(this);
     }
     else
     {

--- a/Source/Urho3D/Urho2D/Drawable2D.h
+++ b/Source/Urho3D/Urho2D/Drawable2D.h
@@ -90,8 +90,8 @@ public:
     const Vector<SourceBatch2D>& GetSourceBatches();
 
 protected:
-    /// Handle node being assigned.
-    virtual void OnNodeSet(Node* node);
+    /// Handle scene being assigned.
+    virtual void OnSceneSet(Scene* scene);
     /// Handle node transform being dirtied.
     virtual void OnMarkedDirty(Node* node);
     /// Handle draw order changed.

--- a/Source/Urho3D/Urho2D/ParticleEmitter2D.cpp
+++ b/Source/Urho3D/Urho2D/ParticleEmitter2D.cpp
@@ -164,16 +164,14 @@ ResourceRef ParticleEmitter2D::GetSpriteAttr() const
     return Sprite2D::SaveToResourceRef(sprite_);
 }
 
-void ParticleEmitter2D::OnNodeSet(Node* node)
+void ParticleEmitter2D::OnSceneSet(Scene* scene)
 {
-    Drawable2D::OnNodeSet(node);
+    Drawable2D::OnSceneSet(scene);
 
-    if (node)
-    {
-        Scene* scene = GetScene();
-        if (scene && IsEnabledEffective())
-            SubscribeToEvent(scene, E_SCENEPOSTUPDATE, HANDLER(ParticleEmitter2D, HandleScenePostUpdate));
-    }
+    if (scene && IsEnabledEffective())
+        SubscribeToEvent(scene, E_SCENEPOSTUPDATE, HANDLER(ParticleEmitter2D, HandleScenePostUpdate));
+    else if (!scene)
+        UnsubscribeFromEvent(E_SCENEPOSTUPDATE);
 }
 
 void ParticleEmitter2D::OnWorldBoundingBoxUpdate()
@@ -253,7 +251,7 @@ void ParticleEmitter2D::UpdateSourceBatches()
 
 void ParticleEmitter2D::UpdateMaterial()
 {
-    if (sprite_)
+    if (sprite_ && renderer_)
         sourceBatches_[0].material_ = renderer_->GetMaterial(sprite_->GetTexture(), blendMode_);
     else
         sourceBatches_[0].material_ = 0;

--- a/Source/Urho3D/Urho2D/ParticleEmitter2D.h
+++ b/Source/Urho3D/Urho2D/ParticleEmitter2D.h
@@ -116,8 +116,8 @@ public:
     ResourceRef GetSpriteAttr() const;
 
 private:
-    /// Handle node being assigned.
-    virtual void OnNodeSet(Node* node);
+    /// Handle scene being assigned.
+    virtual void OnSceneSet(Scene* scene);
     /// Recalculate the world-space bounding box.
     virtual void OnWorldBoundingBoxUpdate();
     /// Handle draw order changed.

--- a/Source/Urho3D/Urho2D/PhysicsWorld2D.cpp
+++ b/Source/Urho3D/Urho2D/PhysicsWorld2D.cpp
@@ -602,14 +602,13 @@ bool PhysicsWorld2D::GetAutoClearForces() const
     return world_->GetAutoClearForces();
 }
 
-void PhysicsWorld2D::OnNodeSet(Node* node)
+void PhysicsWorld2D::OnSceneSet(Scene* scene)
 {
     // Subscribe to the scene subsystem update, which will trigger the physics simulation step
-    if (node)
-    {
-        scene_ = GetScene();
-        SubscribeToEvent(node, E_SCENESUBSYSTEMUPDATE, HANDLER(PhysicsWorld2D, HandleSceneSubsystemUpdate));
-    }
+    if (scene)
+        SubscribeToEvent(scene, E_SCENESUBSYSTEMUPDATE, HANDLER(PhysicsWorld2D, HandleSceneSubsystemUpdate));
+    else
+        UnsubscribeFromEvent(E_SCENESUBSYSTEMUPDATE);
 }
 
 void PhysicsWorld2D::HandleSceneSubsystemUpdate(StringHash eventType, VariantMap& eventData)

--- a/Source/Urho3D/Urho2D/PhysicsWorld2D.h
+++ b/Source/Urho3D/Urho2D/PhysicsWorld2D.h
@@ -169,8 +169,8 @@ public:
     bool IsApplyingTransforms() const { return applyingTransforms_; }
 
 protected:
-    /// Handle node being assigned.
-    virtual void OnNodeSet(Node* node);
+    /// Handle scene being assigned.
+    virtual void OnSceneSet(Scene* scene);
 
 private:
     /// Handle the scene subsystem update event, step simulation here.

--- a/Source/Urho3D/Urho2D/RigidBody2D.cpp
+++ b/Source/Urho3D/Urho2D/RigidBody2D.cpp
@@ -472,16 +472,27 @@ float RigidBody2D::GetAngularVelocity() const
 
 void RigidBody2D::OnNodeSet(Node* node)
 {
-    Component::OnNodeSet(node);
-
     if (node)
-    {
         node->AddListener(this);
-        Scene* scene = GetScene();
+}
+
+void RigidBody2D::OnSceneSet(Scene* scene)
+{
+    if (scene)
+    {
         physicsWorld_ = scene->GetOrCreateComponent<PhysicsWorld2D>();
 
         CreateBody();
         physicsWorld_->AddRigidBody(this);
+    }
+    else
+    {
+        if (physicsWorld_)
+        {
+            ReleaseBody();
+            physicsWorld_->RemoveRigidBody(this);
+            physicsWorld_.Reset();
+        }
     }
 }
 

--- a/Source/Urho3D/Urho2D/RigidBody2D.h
+++ b/Source/Urho3D/Urho2D/RigidBody2D.h
@@ -146,6 +146,8 @@ public:
 private:
     /// Handle node being assigned.
     virtual void OnNodeSet(Node* node);
+    /// Handle scene being assigned.
+    virtual void OnSceneSet(Scene* scene);
     /// Handle node transform being dirtied.
     virtual void OnMarkedDirty(Node* node);
 

--- a/Source/Urho3D/Urho2D/TileMap2D.cpp
+++ b/Source/Urho3D/Urho2D/TileMap2D.cpp
@@ -175,16 +175,4 @@ ResourceRef TileMap2D::GetTmxFileAttr() const
     return GetResourceRef(tmxFile_, TmxFile2D::GetTypeStatic());
 }
 
-void TileMap2D::OnNodeSet(Node* node)
-{
-    if (!node)
-    {
-        if (rootNode_)
-            rootNode_->Remove();
-
-        rootNode_ = 0;
-        layers_.Clear();
-    }
-}
-
 }

--- a/Source/Urho3D/Urho2D/TileMap2D.h
+++ b/Source/Urho3D/Urho2D/TileMap2D.h
@@ -71,9 +71,6 @@ public:
     ResourceRef GetTmxFileAttr() const;
 
 private:
-    /// Handle node being assigned.
-    virtual void OnNodeSet(Node* node);
-
     /// Tmx file.
     SharedPtr<TmxFile2D> tmxFile_;
     /// Tile map information.


### PR DESCRIPTION
This is a refactoring which creates a new virtual function to Component: OnSceneSet(). This allows components such as drawables to be created outside a scene, to be moved into a scene later, or to be moved into another scene. It should also fix  #748.

Testing would be appreciated. Some things will not work 100%, for example if a RigidBody exists outside the scene and you set its linear velocity, it has nowhere to store it as the Bullet object does not exist yet.