### PR TITLE
OpenGL multi-context support

### DIFF
--- a/Source/Urho3D/Graphics/OpenGL/OGLGraphics.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLGraphics.cpp
@@ -621,6 +621,8 @@ bool Graphics::BeginFrame()
 {
     if (!IsInitialized() || IsDeviceLost())
         return false;
+        
+        SDL_GL_MakeCurrent(impl_->window_, impl_->context_);
     
     // If using an external window, check it for size changes, and reset screen mode if necessary
     if (externalWindow_)

--- a/Source/Urho3D/Graphics/OpenGL/OGLGraphics.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLGraphics.cpp
@@ -2322,6 +2322,8 @@ void Graphics::Release(bool clearGPUObjects, bool closeWindow)
     if (!impl_->window_)
         return;
     
+    SDL_GL_MakeCurrent(impl_->window_, impl_->context_);
+    
     {
         MutexLock lock(gpuObjectMutex_);
         


### PR DESCRIPTION
Urho3D now properly supports multiple contexts with OpenGL. This now resembles the behavior allowed by DX9/DX11, in that a single process or thread can create and manage multiple Urho3D contexts.