### PR TITLE
Jft editor modifications

### DIFF
--- a/Docs/GettingStarted.dox
+++ b/Docs/GettingStarted.dox
@@ -720,6 +720,7 @@ Left mouse         - Select nodes or drag the node transform gizmo. Hold Shift t
                      select components instead. Hold Ctrl to multiselect.
 Right mouse        - Hold down and move mouse to rotate camera
 Middle mouse       - Hold down orbits the camera around selected objects
+Shift+Right mouse   - Hold down pans the camera
 Shift+Middle mouse - Hold down pans the camera
 
 WSAD or arrows     - Move
@@ -728,6 +729,7 @@ E                  - Ascend
 Q                  - Descend
 Shift+E,Q          - Ascend or descend faster
 
+Home                 - Center view on currently selected object
 Numpad5            - Toggle orthographic / perspective camera
 Numpad1            - Front view
 Numpad3            - Right hand view
@@ -772,6 +774,15 @@ F12                - Toggle UI
 \endverbatim
 
 Press right mouse button in the 3D view if you want to defocus the active window without changing the object selection.
+
+An option in the preferences (Pan using MMB) changes the default behavior of the MMB and RMB to pan the camera, and require using Shift to use camera orbit and rotation.
+
+\verbatim
+Right mouse            -  Hold down pans the camera
+Middle mouse          -  Hold down pans the camera
+Shift+Right mouse    - Hold down and move mouse to rotate camera
+Shift+Middle mouse  - Hold down orbits the camera around selected objects
+\endverbatim
 
 \section EditorInstructions_Workflow Workflow
 

--- a/bin/Data/Scripts/Editor.as
+++ b/bin/Data/Scripts/Editor.as
@@ -231,6 +231,7 @@ void LoadConfig()
     {
         if (uiElem.HasAttribute("minopacity")) uiMinOpacity = uiElem.GetFloat("minopacity");
         if (uiElem.HasAttribute("maxopacity")) uiMaxOpacity = uiElem.GetFloat("maxopacity");
+		if (uiElem.HasAttribute("mmbpan")) uiMmbPan = uiElem.GetBool("mmbpan");
     }
 
     if (!hierarchyElem.isNull)
@@ -338,6 +339,7 @@ void SaveConfig()
 
     uiElem.SetFloat("minopacity", uiMinOpacity);
     uiElem.SetFloat("maxopacity", uiMaxOpacity);
+	uiElem.SetBool("mmbpan", uiMmbPan);
 
     hierarchyElem.SetBool("showinternaluielement", showInternalUIElement);
     hierarchyElem.SetBool("showtemporaryobject", showTemporaryObject);

--- a/bin/Data/Scripts/Editor/EditorPreferences.as
+++ b/bin/Data/Scripts/Editor/EditorPreferences.as
@@ -92,8 +92,7 @@ void UpdateEditorPreferencesDialog()
     uiMaxOpacityEdit.text = String(uiMaxOpacity);
 
 	CheckBox@ middleMousePanToggle = preferencesDialog.GetChild("UIMiddleMousePan", true);
-    middleMousePanToggle.checked = mmbPan;
-	
+    middleMousePanToggle.checked = uiMmbPan;	
 	
     CheckBox@ showInternalUIElementToggle = preferencesDialog.GetChild("ShowInternalUIElement", true);
     showInternalUIElementToggle.checked = showInternalUIElement;

--- a/bin/Data/Scripts/Editor/EditorPreferences.as
+++ b/bin/Data/Scripts/Editor/EditorPreferences.as
@@ -91,6 +91,10 @@ void UpdateEditorPreferencesDialog()
     LineEdit@ uiMaxOpacityEdit = preferencesDialog.GetChild("UIMaxOpacity", true);
     uiMaxOpacityEdit.text = String(uiMaxOpacity);
 
+	CheckBox@ middleMousePanToggle = preferencesDialog.GetChild("UIMiddleMousePan", true);
+    middleMousePanToggle.checked = mmbPan;
+	
+	
     CheckBox@ showInternalUIElementToggle = preferencesDialog.GetChild("ShowInternalUIElement", true);
     showInternalUIElementToggle.checked = showInternalUIElement;
 
@@ -159,6 +163,7 @@ void UpdateEditorPreferencesDialog()
     {
         SubscribeToEvent(uiMinOpacityEdit, "TextFinished", "EditUIMinOpacity");
         SubscribeToEvent(uiMaxOpacityEdit, "TextFinished", "EditUIMaxOpacity");
+		SubscribeToEvent(middleMousePanToggle, "Toggled", "ToggleMiddleMousePan");
         SubscribeToEvent(showInternalUIElementToggle, "Toggled", "ToggleShowInternalUIElement");
         SubscribeToEvent(showTemporaryObjectToggle, "Toggled", "ToggleShowTemporaryObject");
         SubscribeToEvent(nodeItemTextColorEditR, "TextFinished", "EditNodeTextColor");
@@ -230,6 +235,12 @@ void EditUIMaxOpacity(StringHash eventType, VariantMap& eventData)
     edit.text = String(uiMaxOpacity);
     FadeUI();
     UnfadeUI();
+}
+
+void ToggleMiddleMousePan(StringHash eventType, VariantMap& eventData)
+{
+    bool mmbPanEnabled = cast<CheckBox>(eventData["Element"].GetPtr()).checked;
+    SetMMBPan(mmbPanEnabled);
 }
 
 void ToggleShowInternalUIElement(StringHash eventType, VariantMap& eventData)

--- a/bin/Data/Scripts/Editor/EditorUI.as
+++ b/bin/Data/Scripts/Editor/EditorUI.as
@@ -56,6 +56,7 @@ bool uiFaded = false;
 float uiMinOpacity = 0.3;
 float uiMaxOpacity = 0.7;
 bool uiHidden = false;
+bool uiMmbPan = false;
 
 void CreateUI()
 {

--- a/bin/Data/Scripts/Editor/EditorView.as
+++ b/bin/Data/Scripts/Editor/EditorView.as
@@ -6,6 +6,7 @@ Camera@ camera;
 
 Node@ gridNode;
 CustomGeometry@ grid;
+bool mmbPan = false;
 
 UIElement@ viewportUI; // holds the viewport ui, convienent for clearing and hiding
 uint setViewportCursor = 0; // used to set cursor in post update
@@ -999,6 +1000,11 @@ void UpdateViewParameters()
     }
 }
 
+void SetMMBPan(bool enableMMBPan)
+{
+	mmbPan = enableMMBPan;
+}
+
 void CreateGrid()
 {
     if (gridNode !is null)
@@ -1255,16 +1261,23 @@ void UpdateView(float timeStep)
 			cameraNode.worldPosition = centerPoint - q * Vector3(0.0, 0.0,10);
 		}
 	}
-	
+
     // Rotate/orbit/pan camera
-    if (input.mouseButtonDown[MOUSEB_RIGHT] || input.mouseButtonDown[MOUSEB_MIDDLE])
+	bool changeCamViewButton = input.mouseButtonDown[MOUSEB_RIGHT] || input.mouseButtonDown[MOUSEB_MIDDLE];
+    if (changeCamViewButton)
     {
         SetMouseLock();
 
         IntVector2 mouseMove = input.mouseMove;
         if (mouseMove.x != 0 || mouseMove.y != 0)
         {
-            if (input.keyDown[KEY_LSHIFT] && input.mouseButtonDown[MOUSEB_MIDDLE])
+			bool panTheCamera = false;
+			if(mmbPan)
+				panTheCamera = !(changeCamViewButton && input.keyDown[KEY_LSHIFT]);
+			else
+				panTheCamera = (changeCamViewButton && input.keyDown[KEY_LSHIFT]);
+			
+            if (panTheCamera)
             {
                 cameraNode.Translate(Vector3(-mouseMove.x, mouseMove.y, 0) * timeStep * cameraBaseSpeed * 0.5);
             }
@@ -1278,6 +1291,7 @@ void UpdateView(float timeStep)
 
                 Quaternion q = Quaternion(activeViewport.cameraPitch, activeViewport.cameraYaw, 0);
                 cameraNode.rotation = q;
+						
                 if (input.mouseButtonDown[MOUSEB_MIDDLE] && (selectedNodes.length > 0 || selectedComponents.length > 0))
                 {
                     Vector3 centerPoint = SelectedNodesCenterPoint();

--- a/bin/Data/Scripts/Editor/EditorView.as
+++ b/bin/Data/Scripts/Editor/EditorView.as
@@ -6,7 +6,6 @@ Camera@ camera;
 
 Node@ gridNode;
 CustomGeometry@ grid;
-bool mmbPan = false;
 
 UIElement@ viewportUI; // holds the viewport ui, convienent for clearing and hiding
 uint setViewportCursor = 0; // used to set cursor in post update
@@ -1002,7 +1001,7 @@ void UpdateViewParameters()
 
 void SetMMBPan(bool enableMMBPan)
 {
-	mmbPan = enableMMBPan;
+	uiMmbPan  = enableMMBPan;
 }
 
 void CreateGrid()
@@ -1272,7 +1271,7 @@ void UpdateView(float timeStep)
         if (mouseMove.x != 0 || mouseMove.y != 0)
         {
 			bool panTheCamera = false;
-			if(mmbPan)
+			if(uiMmbPan)
 				panTheCamera = !(changeCamViewButton && input.keyDown[KEY_LSHIFT]);
 			else
 				panTheCamera = (changeCamViewButton && input.keyDown[KEY_LSHIFT]);

--- a/bin/Data/Scripts/Editor/EditorView.as
+++ b/bin/Data/Scripts/Editor/EditorView.as
@@ -1245,6 +1245,17 @@ void UpdateView(float timeStep)
         }
     }
 
+	if (input.keyDown[KEY_HOME])
+	{
+		if(selectedNodes.length > 0 || selectedComponents.length > 0)
+		{
+			Quaternion q = Quaternion(activeViewport.cameraPitch, activeViewport.cameraYaw, 0);
+			Vector3 centerPoint = SelectedNodesCenterPoint();
+			Vector3 d = cameraNode.worldPosition - centerPoint;
+			cameraNode.worldPosition = centerPoint - q * Vector3(0.0, 0.0,10);
+		}
+	}
+	
     // Rotate/orbit/pan camera
     if (input.mouseButtonDown[MOUSEB_RIGHT] || input.mouseButtonDown[MOUSEB_MIDDLE])
     {

--- a/bin/Data/UI/EditorPreferencesDialog.xml
+++ b/bin/Data/UI/EditorPreferencesDialog.xml
@@ -51,6 +51,16 @@
                         <attribute name="Max Size" value="50 2147483647" />
                     </element>
                 </element>
+				<element style="ListRow">
+                    <attribute name="Layout Border" value="20 0 0 0" />
+                    <attribute name="Layout Spacing" value="8" />
+                    <element type="CheckBox">
+                        <attribute name="Name" value="UIMiddleMousePan" />
+                    </element>
+                    <element type="Text">
+                        <attribute name="Text" value="Pan using MiddleMouseButton" />
+                    </element>
+                </element>
                 <element type="BorderImage" style="EditorDivider" />
                 <element style="ListRow">
                     <element type="Text">


### PR DESCRIPTION
Some minor tweaks to the editor for more Blender like behavior

- center on selected object using HOME key
- setting for MMB to pan, and use MMB + SHIFT to rotate (currently works the opposite way)

Blender used to be MMB for pan, MMB+SHIFT to rotate for years. Then a couple years ago they switched it around. So the current editor matches fine, but for those of use who (greatly) prefer the original way, that is what this feature is for.