### PR TITLE
global-editor-handlers

### DIFF
--- a/bin/Data/Scripts/Editor.as
+++ b/bin/Data/Scripts/Editor.as
@@ -19,6 +19,7 @@
 #include "Scripts/Editor/EditorSoundType.as"
 #include "Scripts/Editor/EditorLayers.as"
 #include "Scripts/Editor/EditorColorWheel.as"
+#include "Scripts/Editor/EditorEventsHandlers.as"
 
 
 String configFileName;
@@ -71,6 +72,7 @@ void FirstFrame()
     SubscribeToEvent("Update", "HandleUpdate");
     SubscribeToEvent("ReloadFinished", "HandleReloadFinished");
     SubscribeToEvent("ReloadFailed", "HandleReloadFailed");
+    EditorSubscribeToEvents();
 }
 
 void Stop()

--- a/bin/Data/Scripts/Editor/EditorColorWheel.as
+++ b/bin/Data/Scripts/Editor/EditorColorWheel.as
@@ -101,11 +101,10 @@ void CreateColorWheel()
         colorFastItem[i].color = colorFast[i]; 
     }
     
-    SubscribeToEvent("MouseMove", "HandleMouseMove");
-    SubscribeToEvent("MouseButtonDown", "HandleMouseButton");
-    
-    SubscribeToEvent("MouseWheel", "HandleMouseWheel");
-    SubscribeToEvent("KeyDown", "HandleKeyDownWheel");
+    //SubscribeToEvent("MouseMove", "HandleColorWheelMouseMove");
+    //SubscribeToEvent("MouseButtonDown", "HandleColorWheelMouseButtonDown");    
+    //SubscribeToEvent("MouseWheel", "HandleColorWheelMouseWheel");
+    //SubscribeToEvent("KeyDown", "HandleColorWheelKeyDown");
        
     SubscribeToEvent(closeButton, "Pressed", "HandleWheelButtons");
     SubscribeToEvent(okButton, "Pressed", "HandleWheelButtons");
@@ -181,19 +180,20 @@ void HandleWheelButtons(StringHash eventType, VariantMap& eventData)
     }
 }
 
-void HandleKeyDownWheel(StringHash eventType, VariantMap& eventData) 
+void HandleColorWheelKeyDown(StringHash eventType, VariantMap& eventData) 
 {
     if (colorWheelWindow.visible == false) return;
+    
     int key = eventData["Key"].GetInt();
     
-    
-    MessageBox(String(key));
-    if (key == KEY_ESC)
+    if (key == KEY_ESC) 
+    {
+        SendEvent(eventTypeWheelDiscardColor, eventData);
         HideColorWheel();
-       
+    }   
 }
 
-void HandleMouseButton(StringHash eventType, VariantMap& eventData) 
+void HandleColorWheelMouseButtonDown(StringHash eventType, VariantMap& eventData) 
 {
     if (colorWheelWindow.visible == false) return;
     
@@ -230,7 +230,7 @@ void HandleMouseButton(StringHash eventType, VariantMap& eventData)
 }
 
 // handler only for BWGradient
-void HandleMouseWheel(StringHash eventType, VariantMap& eventData) 
+void HandleColorWheelMouseWheel(StringHash eventType, VariantMap& eventData) 
 {
     if (colorWheelWindow.visible == false || !isBWGradientHovering ) return;
     
@@ -255,12 +255,13 @@ void HandleMouseWheel(StringHash eventType, VariantMap& eventData)
         bwCursor.SetPosition(bwCursor.position.x, high-7);
         colorVValue = float((IMAGE_SIZE-high) / IMAGE_SIZE);
         
-        UpdateColorInformation();
-            
+        wheelColor.FromHSV(colorHValue,colorSValue,colorVValue, colorAValue);
+        SendEventChangeColor();
+        UpdateColorInformation(); 
     }     
 }
 
-void HandleMouseMove(StringHash eventType, VariantMap& eventData) 
+void HandleColorWheelMouseMove(StringHash eventType, VariantMap& eventData) 
 {
     if (colorWheelWindow.visible == false) return;
         

--- a/bin/Data/Scripts/Editor/EditorEventsHandlers.as
+++ b/bin/Data/Scripts/Editor/EditorEventsHandlers.as
@@ -1,4 +1,4 @@
-// Editor main handlers (add your's local handler in proper main handler to prevent losing events)
+// Editor main handlers (add yours local handler in proper main handler to prevent losing events)
 
 void EditorSubscribeToEvents() 
 {
@@ -8,18 +8,33 @@ void EditorSubscribeToEvents()
     SubscribeToEvent("MouseMove", "EditorMainHandleMouseMove");
     SubscribeToEvent("MouseWheel", "EditorMainHandleMouseWheel");
     SubscribeToEvent("MouseButtonDown", "EditorMainHandleMouseButtonDown");
-        
+    SubscribeToEvent("MouseButtonUp", "EditorMainHandleMouseButtonUp");
+    
+    SubscribeToEvent("PostRenderUpdate", "EditorMainHandlePostRenderUpdate");
+    
+    SubscribeToEvent("UIMouseClick", "EditorMainHandleUIMouseClick");
+    SubscribeToEvent("UIMouseClickEnd", "EditorMainHandleUIMouseClickEnd");
+    
+    SubscribeToEvent("BeginViewUpdate", "EditorMainHandleBeginViewUpdate");
+    SubscribeToEvent("EndViewUpdate", "EditorMainHandleEndViewUpdate");
+    SubscribeToEvent("BeginViewRender", "EditorMainHandleBeginViewRender");
+    SubscribeToEvent("EndViewRender", "EditorMainHandleEndViewRender");
+    
 }
 
 void EditorMainHandleKeyDown(StringHash eventType, VariantMap& eventData) 
 {
+    // EditorUI.as handler
+    HandleKeyDown(eventType, eventData);
+    
     // EditorColorWheel.as handler
     HandleColorWheelKeyDown(eventType, eventData);
 }
 
 void EditorMainHandleKeyUp(StringHash eventType, VariantMap& eventData) 
 {
-
+    // EditorUI.as handler
+    UnfadeUI();
 }
 
 void EditorMainHandleMouseMove(StringHash eventType, VariantMap& eventData) 
@@ -54,6 +69,49 @@ void EditorMainHandleMouseButtonDown(StringHash eventType, VariantMap& eventData
         
 }
 
+void EditorMainHandleMouseButtonUp(StringHash eventType, VariantMap& eventData) 
+{
+    // EditorUI.as handler
+    UnfadeUI();
+               
+}
 
+void EditorMainHandlePostRenderUpdate(StringHash eventType, VariantMap& eventData)
+{
+    // EditorView.as handler
+    HandlePostRenderUpdate();
+} 
 
+void EditorMainHandleUIMouseClick(StringHash eventType, VariantMap& eventData) 
+{
+    // EditorView.as handler
+    ViewMouseClick();
+}
 
+void EditorMainHandleUIMouseClickEnd(StringHash eventType, VariantMap& eventData) 
+{
+    // EditorView.as handler
+    ViewMouseClickEnd();
+}
+
+void EditorMainHandleBeginViewUpdate(StringHash eventType, VariantMap& eventData) 
+{
+    // EditorView.as handler
+    HandleBeginViewUpdate(eventType, eventData);
+}
+
+void EditorMainHandleEndViewUpdate(StringHash eventType, VariantMap& eventData) 
+{
+    // EditorView.as handler
+    HandleEndViewUpdate(eventType, eventData);
+}
+
+void EditorMainHandleBeginViewRender(StringHash eventType, VariantMap& eventData) 
+{
+    HandleBeginViewRender(eventType, eventData);
+}
+
+void EditorMainHandleEndViewRender(StringHash eventType, VariantMap& eventData)
+{
+    HandleEndViewRender(eventType, eventData);
+} 

--- a/bin/Data/Scripts/Editor/EditorEventsHandlers.as
+++ b/bin/Data/Scripts/Editor/EditorEventsHandlers.as
@@ -1,0 +1,59 @@
+// Editor main handlers (add your's local handler in proper main handler to prevent losing events)
+
+void EditorSubscribeToEvents() 
+{
+    SubscribeToEvent("KeyDown", "EditorMainHandleKeyDown");
+    SubscribeToEvent("KeyUp", "EditorMainHandleKeyUp");
+       
+    SubscribeToEvent("MouseMove", "EditorMainHandleMouseMove");
+    SubscribeToEvent("MouseWheel", "EditorMainHandleMouseWheel");
+    SubscribeToEvent("MouseButtonDown", "EditorMainHandleMouseButtonDown");
+        
+}
+
+void EditorMainHandleKeyDown(StringHash eventType, VariantMap& eventData) 
+{
+    // EditorColorWheel.as handler
+    HandleColorWheelKeyDown(eventType, eventData);
+}
+
+void EditorMainHandleKeyUp(StringHash eventType, VariantMap& eventData) 
+{
+
+}
+
+void EditorMainHandleMouseMove(StringHash eventType, VariantMap& eventData) 
+{
+    // EditorView.as handler
+    ViewMouseMove();
+    
+    // EditorColorWheel.as handler
+    HandleColorWheelMouseMove(eventType, eventData);
+    
+    // EditorLayer.as handler
+    HandleHideLayerEditor(eventType, eventData);
+}
+
+void EditorMainHandleMouseWheel(StringHash eventType, VariantMap& eventData) 
+{
+    // EditorColorWheel.as handler
+    HandleColorWheelMouseWheel(eventType, eventData);
+    
+    // EditorLayer.as handler
+    HandleMaskTypeScroll(eventType, eventData);    
+}
+
+void EditorMainHandleMouseButtonDown(StringHash eventType, VariantMap& eventData) 
+{
+    // EditorColorWheel.as handler
+    HandleColorWheelMouseButtonDown(eventType, eventData);
+    
+    // EditorLayer.as handler
+    HandleHideLayerEditor(eventType, eventData);
+    
+        
+}
+
+
+
+

--- a/bin/Data/Scripts/Editor/EditorLayers.as
+++ b/bin/Data/Scripts/Editor/EditorLayers.as
@@ -43,9 +43,9 @@ void CreateLayerEditor()
             SubscribeToEvent(bits[i], "Toggled", "ToggleBits");
     }
     
-    SubscribeToEvent("MouseMove", "HandleHideLayerEditor");
-    SubscribeToEvent("MouseButtonDown", "HandleHideLayerEditor");
-    SubscribeToEvent("MouseWheel", "HandleMaskTypeScroll");
+    //SubscribeToEvent("MouseMove", "HandleHideLayerEditor");
+    //SubscribeToEvent("MouseButtonDown", "HandleHideLayerEditor");
+    //SubscribeToEvent("MouseWheel", "HandleMaskTypeScroll");
 }
 
 bool ShowLayerEditor()

--- a/bin/Data/Scripts/Editor/EditorUI.as
+++ b/bin/Data/Scripts/Editor/EditorUI.as
@@ -93,9 +93,9 @@ void CreateUI()
 
     SubscribeToEvent("ScreenMode", "ResizeUI");
     SubscribeToEvent("MenuSelected", "HandleMenuSelected");
-    SubscribeToEvent("KeyDown", "HandleKeyDown");
-    SubscribeToEvent("KeyUp", "UnfadeUI");
-    SubscribeToEvent("MouseButtonUp", "UnfadeUI");
+    //SubscribeToEvent("KeyDown", "HandleKeyDown");
+    //SubscribeToEvent("KeyUp", "UnfadeUI");
+    //SubscribeToEvent("MouseButtonUp", "UnfadeUI");
     SubscribeToEvent("ChangeLanguage", "HandleChangeLanguage");
     
     SubscribeToEvent("WheelChangeColor", "HandleWheelChangeColor");

--- a/bin/Data/Scripts/Editor/EditorView.as
+++ b/bin/Data/Scripts/Editor/EditorView.as
@@ -477,7 +477,7 @@ void CreateCamera()
 
     SubscribeToEvent("PostRenderUpdate", "HandlePostRenderUpdate");
     SubscribeToEvent("UIMouseClick", "ViewMouseClick");
-    SubscribeToEvent("MouseMove", "ViewMouseMove");
+    //SubscribeToEvent("MouseMove", "ViewMouseMove"); 
     SubscribeToEvent("UIMouseClickEnd", "ViewMouseClickEnd");
     SubscribeToEvent("BeginViewUpdate", "HandleBeginViewUpdate");
     SubscribeToEvent("EndViewUpdate", "HandleEndViewUpdate");

--- a/bin/Data/Scripts/Editor/EditorView.as
+++ b/bin/Data/Scripts/Editor/EditorView.as
@@ -475,14 +475,14 @@ void CreateCamera()
     // Note: the camera is not inside the scene, so that it is not listed, and does not get deleted
     ResetCamera();
 
-    SubscribeToEvent("PostRenderUpdate", "HandlePostRenderUpdate");
-    SubscribeToEvent("UIMouseClick", "ViewMouseClick");
+    //SubscribeToEvent("PostRenderUpdate", "HandlePostRenderUpdate");
+    //SubscribeToEvent("UIMouseClick", "ViewMouseClick");
     //SubscribeToEvent("MouseMove", "ViewMouseMove"); 
-    SubscribeToEvent("UIMouseClickEnd", "ViewMouseClickEnd");
-    SubscribeToEvent("BeginViewUpdate", "HandleBeginViewUpdate");
-    SubscribeToEvent("EndViewUpdate", "HandleEndViewUpdate");
-    SubscribeToEvent("BeginViewRender", "HandleBeginViewRender");
-    SubscribeToEvent("EndViewRender", "HandleEndViewRender");
+    //SubscribeToEvent("UIMouseClickEnd", "ViewMouseClickEnd");
+    //SubscribeToEvent("BeginViewUpdate", "HandleBeginViewUpdate");
+    //SubscribeToEvent("EndViewUpdate", "HandleEndViewUpdate");
+    //SubscribeToEvent("BeginViewRender", "HandleBeginViewRender");
+    //SubscribeToEvent("EndViewRender", "HandleEndViewRender");
 
     // Set initial renderpath if defined
     SetRenderPath(renderPathName);


### PR DESCRIPTION
If you trying to minimize or drag editor window to other desktop(monitor), again minimize or/and resize window, it probably lose handle from EditorView.as on handle ViewMouseMove() also ColorWheel lose their handlers and I guess that LayerEditor also something lose (MouseWheel event to scroll mask types) 
And that why I decide to introduce editor-global-events where all local handlers will be placed.

Please, checkout this.
 