### PR TITLE
Fix missing escape characters for the Zerobrane Studio API.

### DIFF
--- a/Source/Urho3D/LuaScript/pkgs/ToZerobraneStudioHook.lua
+++ b/Source/Urho3D/LuaScript/pkgs/ToZerobraneStudioHook.lua
@@ -107,7 +107,8 @@ function writeFunctionArgs(file, declarations)
       if declaration.def ~= "" then
         param_str = param_str .. " = " .. declaration.def
       end
-      file:write(param_str)
+      local fixedParamStr = param_str:gsub([[(")]], [[\%1]])
+      file:write(fixedParamStr)
     end
     if i ~= count then
       file:write(", ")


### PR DESCRIPTION
Using the latest version of Zerobrane Studio, I realized that the generated API was not loaded properly.
This PR is what I've used for generating this: https://github.com/pkulchenko/ZeroBranePackage/pull/20