### PR TITLE
Added private section to the ProfilerBlock

### DIFF
--- a/Source/Urho3D/Core/Profiler.h
+++ b/Source/Urho3D/Core/Profiler.h
@@ -133,7 +133,8 @@ public:
         
         return newBlock;
     }
-    
+
+prviate:
     /// Block name.
     char* name_;
     /// High-resolution timer for measuring the block duration.


### PR DESCRIPTION
Someone forgot to put "private:" before data section.