### PR TITLE
Private section in ProfilerBlock

### DIFF
--- a/Source/Urho3D/Core/Profiler.h
+++ b/Source/Urho3D/Core/Profiler.h
@@ -133,7 +133,7 @@ public:
         
         return newBlock;
     }
-    
+private:
     /// Block name.
     char* name_;
     /// High-resolution timer for measuring the block duration.


### PR DESCRIPTION
There was no "private:" in ProfilerBlock before data section