### PR TITLE
emscripten_get_now()

### DIFF
--- a/Source/Urho3D/Core/Timer.cpp
+++ b/Source/Urho3D/Core/Timer.cpp
@@ -30,6 +30,8 @@
 #ifdef WIN32
 #include <windows.h>
 #include <mmsystem.h>
+#elif defined(__EMSCRIPTEN__)
+#include <emscripten/emscripten.h>
 #else
 #include <sys/time.h>
 #include <unistd.h>
@@ -71,6 +73,8 @@ static unsigned Tick()
 {
 #ifdef WIN32
     return (unsigned)timeGetTime();
+#elif defined (__EMSCRIPTEN__)
+    return (unsigned)emscripten_get_now();
 #else
     struct timeval time;
     gettimeofday(&time, NULL);
@@ -89,6 +93,8 @@ static long long HiresTick()
     }
     else
         return timeGetTime();
+#elif defined (__EMSCRIPTEN__)
+    return (unsigned)(emscripten_get_now()*1000.0);
 #else
     struct timeval time;
     gettimeofday(&time, NULL);


### PR DESCRIPTION
Code duplication cleanup, and use `emscripten_get_now()` when timing, to get sub-millisecond precision timer results (`gettimeofday` calls to JavaScript `Date.now()`, which has only millisecond precision)