### PR TITLE
correct the frameWidth and frameHeight

### DIFF
--- a/Source/Tools/SpritePacker/SpritePacker.cpp
+++ b/Source/Tools/SpritePacker/SpritePacker.cpp
@@ -73,7 +73,9 @@ public:
         offsetX(0),
         offsetY(0),
         frameX(0),
-        frameY(0)
+        frameY(0),
+        frameWidth(0),
+        frameHeight(0)
     {
     }
 

--- a/Source/Urho3D/Urho2D/AnimationSet2D.cpp
+++ b/Source/Urho3D/Urho2D/AnimationSet2D.cpp
@@ -342,8 +342,8 @@ bool AnimationSet2D::BeginLoadSpriter(Deserializer& source)
 
 struct SpriteInfo
 {
-    int x;
-    int y;
+    int x = 0;
+    int y = 0;
     Spriter::File* file_;
     SharedPtr<Image> image_;
 };


### PR DESCRIPTION
If someone uses SpritePacker without option -trim, it use incorrect values of frameWidth and frameHeight sometimes, like as 
```
<SubTexture name="2" x="0" y="0" width="64" height="64" frameWidth="1768300646" frameHeight="1696621932" offsetX="0" offsetY="0" />
```

and the Sprite info would be incorrect when we has only one texture.