### PR TITLE
fixed the wrong behavior of SpriteInfo and SpritePacker

### DIFF
--- a/Source/Tools/SpritePacker/SpritePacker.cpp
+++ b/Source/Tools/SpritePacker/SpritePacker.cpp
@@ -72,6 +72,8 @@ public:
         y(0),
         offsetX(0),
         offsetY(0),
+        frameWidth(0),
+        frameHeight(0),
         frameX(0),
         frameY(0)
     {

--- a/Source/Urho3D/Urho2D/AnimationSet2D.cpp
+++ b/Source/Urho3D/Urho2D/AnimationSet2D.cpp
@@ -342,8 +342,8 @@ bool AnimationSet2D::BeginLoadSpriter(Deserializer& source)
 
 struct SpriteInfo
 {
-    int x;
-    int y;
+    int x = 0;
+    int y = 0;
     Spriter::File* file_;
     SharedPtr<Image> image_;
 };


### PR DESCRIPTION
1, When we have only one texture in a scml file, the SpriteInfo has wrong x and y values
2, When we run SpritePacker without the option "-trim", the frameWidth and frameHeight has wrong values sometimes.