### PR TITLE
fixed the wrong behavior of spriter animation

### DIFF
--- a/Source/Tools/SpritePacker/SpritePacker.cpp
+++ b/Source/Tools/SpritePacker/SpritePacker.cpp
@@ -72,6 +72,8 @@ public:
         y(0),
         offsetX(0),
         offsetY(0),
+        frameWidth(0),
+        frameHeight(0),
         frameX(0),
         frameY(0)
     {

--- a/Source/Urho3D/Urho2D/AnimationSet2D.cpp
+++ b/Source/Urho3D/Urho2D/AnimationSet2D.cpp
@@ -427,6 +427,8 @@ bool AnimationSet2D::EndLoadSpriter()
                 }
 
                 SpriteInfo def;
+                def.x = 0;
+                def.y = 0;
                 def.file_ = file;
                 def.image_ = image;
                 spriteInfos.Push(def);

--- a/Source/Urho3D/Urho2D/SpriterData2D.cpp
+++ b/Source/Urho3D/Urho2D/SpriterData2D.cpp
@@ -416,7 +416,13 @@ bool Timeline::Load(const pugi::xml_node& node)
     id_ = node.attribute("id").as_int();
     name_ = node.attribute("name").as_string();
 
-    String typeString = node.attribute("type").as_string("sprite");
+    String typeString;
+    xml_attribute typeAttr = node.attribute("type");
+    if (typeAttr.empty())
+        typeString = node.attribute("object_type").as_string("sprite");
+    else
+        typeString = typeAttr.as_string("sprite");
+    
     if (typeString == "bone")
     {
         objectType_ = BONE;


### PR DESCRIPTION
1, When we has only one texture in scml file, the SpriteInfo has wrong x and y values.
2, When we use SpriterPacker without the option "-trim", it will cause wrong frameWidth and frameHeight values
3, The newest version of Spriter use attribute name "object_type" instead of "type"