### PR TITLE
Support navigation obstacle transfer between scenes

### DIFF
--- a/Source/Urho3D/AngelScript/APITemplates.h
+++ b/Source/Urho3D/AngelScript/APITemplates.h
@@ -532,6 +532,11 @@ static Component* NodeGetComponentWithType(const String& typeName, bool recursiv
     return ptr->GetComponent(typeName, recursive);
 }
 
+static Component* NodeGetParentComponentWithType(const String& typeName, bool fullTraversal, Node* ptr)
+{
+    return ptr->GetParentComponent(typeName, fullTraversal);
+}
+
 static CScriptArray* NodeGetComponents(Node* ptr)
 {
     return VectorToHandleArray<Component>(ptr->GetComponents(), "Array<Component@>");
@@ -679,6 +684,7 @@ template <class T> void RegisterNode(asIScriptEngine* engine, const char* classN
     engine->RegisterObjectMethod(className, "Array<Component@>@ GetComponents() const", asFUNCTION(NodeGetComponents), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod(className, "Array<Component@>@ GetComponents(const String&in, bool recursive = false) const", asFUNCTION(NodeGetComponentsWithType), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod(className, "Component@+ GetComponent(const String&in, bool recursive = false) const", asFUNCTION(NodeGetComponentWithType), asCALL_CDECL_OBJLAST);
+    engine->RegisterObjectMethod(className, "Component@+ GetParentComponent(const String&in, bool fullTraversal = false) const", asFUNCTION(NodeGetParentComponentWithType), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod(className, "bool HasComponent(const String&in) const", asFUNCTION(NodeHasComponent), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod(className, "Vector3 LocalToWorld(const Vector3&in) const", asMETHODPR(T, LocalToWorld, (const Vector3&) const, Vector3), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "Vector3 LocalToWorld(const Vector4&in) const", asMETHODPR(T, LocalToWorld, (const Vector4&) const, Vector3), asCALL_THISCALL);

--- a/Source/Urho3D/LuaScript/pkgs/Scene/Node.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Scene/Node.pkg
@@ -174,6 +174,8 @@ class Node : public Animatable
 
     // template <class T> T* GetComponent() const;
     Component* GetComponent(const String type, bool recursive = false) const;
+    // template <class T> T* GetParentComponent() const;
+    Component* GetParentComponent(const String type, bool recursive = false) const;
 
     // template <class T> void GetComponents(PODVector<T*>& dest, bool recursive = false) const;
     tolua_outside const PODVector<Component*>& NodeGetComponentsWithType @ GetComponents(const String type, bool recursive = false);

--- a/Source/Urho3D/Navigation/Obstacle.cpp
+++ b/Source/Urho3D/Navigation/Obstacle.cpp
@@ -96,7 +96,7 @@ void Obstacle::OnSceneSet(Scene* scene)
             return;
         }
         if (!ownerMesh_)
-            ownerMesh_ = node_->GetParentComponent<DynamicNavigationMesh>();
+            ownerMesh_ = node_->GetParentComponent<DynamicNavigationMesh>(true);
         if (ownerMesh_)
             ownerMesh_->AddObstacle(this);
     }

--- a/Source/Urho3D/Navigation/Obstacle.cpp
+++ b/Source/Urho3D/Navigation/Obstacle.cpp
@@ -96,7 +96,7 @@ void Obstacle::OnSceneSet(Scene* scene)
             return;
         }
         if (!ownerMesh_)
-            ownerMesh_ = scene->GetComponent<DynamicNavigationMesh>();
+            ownerMesh_ = node_->GetParentComponent<DynamicNavigationMesh>();
         if (ownerMesh_)
             ownerMesh_->AddObstacle(this);
     }
@@ -104,6 +104,8 @@ void Obstacle::OnSceneSet(Scene* scene)
     {
         if (obstacleId_ > 0 && ownerMesh_)
             ownerMesh_->RemoveObstacle(this);
+        
+        ownerMesh_.Reset();
     }
 }
 

--- a/Source/Urho3D/Scene/Node.cpp
+++ b/Source/Urho3D/Scene/Node.cpp
@@ -1135,6 +1135,23 @@ Component* Node::GetComponent(StringHash type, bool recursive) const
     return 0;
 }
 
+Component* Node::GetParentComponent(StringHash type, bool fullTraversal) const
+{
+    Node* current = GetParent();
+    while (current)
+    {
+        Component* soughtComponent = current->GetComponent(type);
+        if (soughtComponent)
+            return soughtComponent;
+
+        if (fullTraversal)
+            current = current->GetParent();
+        else
+            break;
+    }
+    return 0;
+}
+
 void Node::SetID(unsigned id)
 {
     id_ = id;

--- a/Source/Urho3D/Scene/Node.h
+++ b/Source/Urho3D/Scene/Node.h
@@ -475,6 +475,8 @@ public:
     void GetComponents(PODVector<Component*>& dest, StringHash type, bool recursive = false) const;
     /// Return component by type. If there are several, returns the first.
     Component* GetComponent(StringHash type, bool recursive = false) const;
+    /// Return component in parent node. If there are several, returns the first. May optional traverse up to the root node.
+    Component* GetParentComponent(StringHash type, bool fullTraversal = false) const;
     /// Return whether has a specific component.
     bool HasComponent(StringHash type) const;
 
@@ -489,12 +491,16 @@ public:
 
     /// Return first component derived from class.
     template <class T> T* GetDerivedComponent(bool recursive = false) const;
+    /// Return first component derived from class in the parent node, or if fully traversing then the first node up the tree with one.
+    template <class T> T* GetParentDerivedComponent(bool fullTraversal = false) const;
     /// Return components derived from class.
     template <class T> void GetDerivedComponents(PODVector<T*>& dest, bool recursive = false, bool clearVector = true) const;
     /// Template version of returning child nodes with a specific component.
     template <class T> void GetChildrenWithComponent(PODVector<Node*>& dest, bool recursive = false) const;
     /// Template version of returning a component by type.
     template <class T> T* GetComponent(bool recursive = false) const;
+    /// Template version of returning a parent's component by type.
+    template <class T> T* GetParentComponent(bool fullTraversal = false) const;
     /// Template version of returning all components of type.
     template <class T> void GetComponents(PODVector<T*>& dest, bool recursive = false) const;
     /// Template version of checking whether has a specific component.
@@ -651,6 +657,8 @@ template <class T> void Node::GetChildrenWithComponent(PODVector<Node*>& dest, b
 
 template <class T> T* Node::GetComponent(bool recursive) const { return static_cast<T*>(GetComponent(T::GetTypeStatic(), recursive)); }
 
+template <class T> T* Node::GetParentComponent(bool fullTraversal) const { return static_cast<T*>(GetComponent(T::GetTypeStatic(), fullTraversal)); }
+
 template <class T> void Node::GetComponents(PODVector<T*>& dest, bool recursive) const
 {
     GetComponents(reinterpret_cast<PODVector<Component*>&>(dest), T::GetTypeStatic(), recursive);
@@ -677,6 +685,23 @@ template <class T> T* Node::GetDerivedComponent(bool recursive) const
         }
     }
 
+    return 0;
+}
+
+template <class T> T* Node::GetParentDerivedComponent(bool fullTraversal) const
+{
+    Node* current = GetParent();
+    while (current)
+    {
+        T* soughtComponent = current->GetDerivedComponent<T>();
+        if (soughtComponent)
+            return soughtComponent;
+
+        if (fullTraversal)
+            current = current->GetParent();
+        else
+            break;
+    }
     return 0;
 }
 

--- a/Source/Urho3D/Scene/Node.h
+++ b/Source/Urho3D/Scene/Node.h
@@ -657,7 +657,7 @@ template <class T> void Node::GetChildrenWithComponent(PODVector<Node*>& dest, b
 
 template <class T> T* Node::GetComponent(bool recursive) const { return static_cast<T*>(GetComponent(T::GetTypeStatic(), recursive)); }
 
-template <class T> T* Node::GetParentComponent(bool fullTraversal) const { return static_cast<T*>(GetComponent(T::GetTypeStatic(), fullTraversal)); }
+template <class T> T* Node::GetParentComponent(bool fullTraversal) const { return static_cast<T*>(GetParentComponent(T::GetTypeStatic(), fullTraversal)); }
 
 template <class T> void Node::GetComponents(PODVector<T*>& dest, bool recursive) const
 {


### PR DESCRIPTION
Despite the branch name (that's what I set out to deal with), there's nothing about detour crowd here.

Changelog:

* Obstacles seek upwards in the scene hierarchy to find their DynamicNavigationMesh rather than downwards from the scene root
* Obstacles now properly clear their ownerMesh_ when scene is cleared/reset, enabling moving them from one scene to another
* Addition of Node::GetParentComponent, Node::GetParentDerivedComponent with script bindings for Angelscript and Lua