### PR TITLE
Unite Android hardware keyboard input with other platforms

### DIFF
--- a/Android/src/org/libsdl/app/SDLActivity.java
+++ b/Android/src/org/libsdl/app/SDLActivity.java
@@ -855,22 +855,15 @@ class DummyEdit extends View implements View.OnKeyListener {
     public boolean onKey(View v, int keyCode, KeyEvent event) {
 
         // This handles the hardware keyboard input
-        if (event.isPrintingKey()) {
-            if (event.getAction() == KeyEvent.ACTION_DOWN) {
-                ic.commitText(String.valueOf((char) event.getUnicodeChar()), 1);
-            }
-            return true;
-        }
-
+        // Urho3D: unite input with other platforms
         if (event.getAction() == KeyEvent.ACTION_DOWN) {
             SDLActivity.onNativeKeyDown(keyCode);
-            return true;
+            ic.commitText(String.valueOf((char) event.getUnicodeChar()), 1);
         } else if (event.getAction() == KeyEvent.ACTION_UP) {
             SDLActivity.onNativeKeyUp(keyCode);
-            return true;
         }
 
-        return false;
+        return true;
     }
         
     //


### PR DESCRIPTION
Hi,

While testing out the engine's capabilities on Android (which I've found overwhelming - that stuff works better than AAA engines!) I came across an issue - Android hardware keyboard input behaves weird.

And by weird, I mean truly weird.

Tilde (like many other keys, although this one is especially important to me amongst them) calls E_KEYUP and E_KEYDOWN only when no textboxes (such as the LineEdit) are focused, spacebar doesn't even get written in textboxes, enter key randomly defocuses textboxes where on other platforms it doesn't, backspace, while pressed, totally hangs the application where no other key would - and that's probably only a part of the madness.

After a long while of checking where such issue could even be located, and another long while of figuring out what could be wrong I rechecked my makeshift issue list, where the backspace issue led me to removing random conditionals which seemed unneeded, and so did seem event.isPrintingKey() - Bingo!

In short, not only isn't event.isPrintingKey() needed to block the keys that aren't supposed to print out anything (at least with the more common keys - never ran into such occurrence in my extensive tests), but it also blocks keys it shouldn't, causes random defocusing and may cause random hangups with (seemingly) even more random keys!

While it might still seem bizarre to remove a part of the code which ought to be a major check, in reality the "major check" does more harm than good (if it does any good at all), while it's lack seems to perfectly unite the Android behavior with the rest of platforms, therefore I request this to be pulled.

Huge thanks to anyone making and supporting the engine - You're doing a great job! Keep it up!