### PR TITLE
Fix Android MIPS build

### DIFF
--- a/Source/Urho3D/Graphics/Direct3D11/D3D11Texture.cpp
+++ b/Source/Urho3D/Graphics/Direct3D11/D3D11Texture.cpp
@@ -148,11 +148,11 @@ void Texture::SetBackupTexture(Texture* texture)
     backupTexture_ = texture;
 }
 
-void Texture::SetMipsToSkip(int quality, int mips)
+void Texture::SetMipsToSkip(int quality, int toSkip)
 {
     if (quality >= QUALITY_LOW && quality < MAX_TEXTURE_QUALITY_LEVELS)
     {
-        mipsToSkip_[quality] = (unsigned)mips;
+        mipsToSkip_[quality] = (unsigned)toSkip;
 
         // Make sure a higher quality level does not actually skip more mips
         for (int i = 1; i < MAX_TEXTURE_QUALITY_LEVELS; ++i)

--- a/Source/Urho3D/Graphics/Direct3D11/D3D11Texture.h
+++ b/Source/Urho3D/Graphics/Direct3D11/D3D11Texture.h
@@ -60,7 +60,7 @@ public:
     /// Set backup texture to use when rendering to this texture.
     void SetBackupTexture(Texture* texture);
     /// Set mip levels to skip on a quality setting when loading. Ensures higher quality levels do not skip more.
-    void SetMipsToSkip(int quality, int mips);
+    void SetMipsToSkip(int quality, int toSkip);
 
     /// Return texture format.
     unsigned GetFormat() const { return format_; }

--- a/Source/Urho3D/Graphics/Direct3D9/D3D9Texture.cpp
+++ b/Source/Urho3D/Graphics/Direct3D9/D3D9Texture.cpp
@@ -114,11 +114,11 @@ void Texture::SetBackupTexture(Texture* texture)
     backupTexture_ = texture;
 }
 
-void Texture::SetMipsToSkip(int quality, int mips)
+void Texture::SetMipsToSkip(int quality, int toSkip)
 {
     if (quality >= QUALITY_LOW && quality < MAX_TEXTURE_QUALITY_LEVELS)
     {
-        mipsToSkip_[quality] = (unsigned)mips;
+        mipsToSkip_[quality] = (unsigned)toSkip;
 
         // Make sure a higher quality level does not actually skip more mips
         for (int i = 1; i < MAX_TEXTURE_QUALITY_LEVELS; ++i)

--- a/Source/Urho3D/Graphics/Direct3D9/D3D9Texture.h
+++ b/Source/Urho3D/Graphics/Direct3D9/D3D9Texture.h
@@ -61,7 +61,7 @@ public:
     /// Set backup texture to use when rendering to this texture.
     void SetBackupTexture(Texture* texture);
     /// Set mip levels to skip on a quality setting when loading. Ensures higher quality levels do not skip more.
-    void SetMipsToSkip(int quality, int mips);
+    void SetMipsToSkip(int quality, int toSkip);
 
     /// Return texture format.
     unsigned GetFormat() const { return format_; }

--- a/Source/Urho3D/Graphics/OpenGL/OGLTexture.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLTexture.cpp
@@ -162,11 +162,11 @@ void Texture::SetBackupTexture(Texture* texture)
     backupTexture_ = texture;
 }
 
-void Texture::SetMipsToSkip(int quality, int mips)
+void Texture::SetMipsToSkip(int quality, int toSkip)
 {
     if (quality >= QUALITY_LOW && quality < MAX_TEXTURE_QUALITY_LEVELS)
     {
-        mipsToSkip_[quality] = (unsigned)mips;
+        mipsToSkip_[quality] = (unsigned)toSkip;
 
         // Make sure a higher quality level does not actually skip more mips
         for (int i = 1; i < MAX_TEXTURE_QUALITY_LEVELS; ++i)

--- a/Source/Urho3D/Graphics/OpenGL/OGLTexture.h
+++ b/Source/Urho3D/Graphics/OpenGL/OGLTexture.h
@@ -59,7 +59,7 @@ public:
     /// Set backup texture to use when rendering to this texture.
     void SetBackupTexture(Texture* texture);
     /// Set mip levels to skip on a quality setting when loading. Ensures higher quality levels do not skip more.
-    void SetMipsToSkip(int quality, int mips);
+    void SetMipsToSkip(int quality, int toSkip);
     /// Dirty the parameters.
     void SetParametersDirty();
     /// Update changed parameters to OpenGL. Called by Graphics when binding the texture.

--- a/Source/Urho3D/LuaScript/pkgs/Graphics/Texture.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Graphics/Texture.pkg
@@ -8,7 +8,7 @@ class Texture : public Resource
     void SetBorderColor(const Color& color);
     void SetSRGB(bool enable);
     void SetBackupTexture(Texture* texture);
-    void SetMipsToSkip(int quality, int mips);
+    void SetMipsToSkip(int quality, int toSkip);
     
     unsigned GetFormat() const;
     bool IsCompressed() const;


### PR DESCRIPTION
Hi,

While testing out the engine on various Android architectures (wanting to support all of them, as the engine is blazingly fast and smaller than it technically should even be), I came across an issue, or rather, the issue came across me - MIPS build doesn't work, random compilation error.

Seeing as that error is *something with graphics*, I've instantly gotten an image of the librarydrivereverythingOpenGL not supporting MIPS before my eyes, and that I won't be able to publish my app to such of an underrated architecture ~~no one even uses~~, thankfully it turned out (much) easier to fix than that - there is a collision between the mips constant used during compilation, and a random variable in the Texture code named the same way.

Having easily fixed it and verified that with the fix the Android MIPS build compiles (and runs, at least as far as the emulator goes) successfully, I request this to be merged.

As always, Thank You for Your work into making and supporting the engine! Keep it up!