### PR TITLE
New String::Split implementation

### DIFF
--- a/Source/Urho3D/Container/Str.cpp
+++ b/Source/Urho3D/Container/Str.cpp
@@ -558,9 +558,9 @@ String String::ToUpper() const
     return ret;
 }
 
-Vector<String> String::Split(char separator) const
+Vector<String> String::Split(char separator, StringSplit splitMode) const
 {
-    return Split(CString(), separator);
+    return Split(CString(), separator, splitMode);
 }
 
 void String::Join(const Vector<String>& subStrings, const String& glue)
@@ -1041,49 +1041,27 @@ unsigned String::DecodeUTF16(const wchar_t*& src)
 }
 #endif
 
-Vector<String> String::Split(const char* str, char separator)
+Vector<String> String::Split(const char* str, char separator, StringSplit splitMode)
 {
     Vector<String> ret;
-    unsigned pos = 0;
-    unsigned length = CStringLength(str);
-
-    while (pos < length)
+    const char* strEnd = str + String::CStringLength(str);
+    for (const char* splitEnd = str; splitEnd != strEnd; ++splitEnd)
     {
-        if (str[pos] != separator)
-            break;
-        ++pos;
+        if (*splitEnd == separator)
+        {
+            const ptrdiff_t splitLen = splitEnd - str;
+            if (splitLen > 0 || splitMode == SPLIT_KEEP_EMPTY)
+            {
+                ret.Push(String(str, splitLen));
+            }
+            str = splitEnd + 1;
+        }
     }
 
-    while (pos < length)
+    const ptrdiff_t splitLen = strEnd - str;
+    if (splitLen > 0 || splitMode == SPLIT_KEEP_EMPTY)
     {
-        unsigned start = pos;
-
-        while (start < length)
-        {
-            if (str[start] == separator)
-                break;
-
-            ++start;
-        }
-
-        if (start == length)
-        {
-            ret.Push(String(&str[pos]));
-            break;
-        }
-
-        unsigned end = start;
-
-        while (end < length)
-        {
-            if (str[end] != separator)
-                break;
-
-            ++end;
-        }
-
-        ret.Push(String(&str[pos], start - pos));
-        pos = end;
+        ret.Push(String(str, splitLen));
     }
 
     return ret;

--- a/Source/Urho3D/Container/Str.h
+++ b/Source/Urho3D/Container/Str.h
@@ -36,6 +36,13 @@ static const int MATRIX_CONVERSION_BUFFER_LENGTH = 256;
 
 class WString;
 
+/// Mode for String::Split (default is to keep empty splits)
+enum StringSplit
+{
+    SPLIT_KEEP_EMPTY = 0,
+    SPLIT_OMIT_EMPTY
+};
+
 /// %String class.
 class URHO3D_API String
 {
@@ -388,7 +395,7 @@ public:
     /// Return string in lowercase.
     String ToLower() const;
     /// Return substrings split by a separator char.
-    Vector<String> Split(char separator) const;
+    Vector<String> Split(char separator, StringSplit splitMode = SPLIT_KEEP_EMPTY) const;
     /// Join substrings with a 'glue' string.
     void Join(const Vector<String>& subStrings, const String& glue);
     /// Return index to the first occurrence of a string, or NPOS if not found.
@@ -463,7 +470,7 @@ public:
     }
 
     /// Return substrings split by a separator char.
-    static Vector<String> Split(const char* str, char separator);
+    static Vector<String> Split(const char* str, char separator, StringSplit splitMode = SPLIT_KEEP_EMPTY);
     /// Return a string by joining substrings with a 'glue' string.
     static String Joined(const Vector<String>& subStrings, const String& glue);
     /// Encode Unicode character to UTF8. Pointer will be incremented.


### PR DESCRIPTION
Keeps empty splits by default, optionally omit-able using splitMode parameter - see #1014 