### PR TITLE
Add configuration of maximum layers in DynamicNavigationMesh

### DIFF
--- a/Source/Urho3D/AngelScript/NavigationAPI.cpp
+++ b/Source/Urho3D/AngelScript/NavigationAPI.cpp
@@ -174,6 +174,8 @@ void RegisterDynamicNavigationMesh(asIScriptEngine* engine)
     engine->RegisterObjectMethod("DynamicNavigationMesh", "Array<Vector3>@ FindPath(const Vector3&in, const Vector3&in, const Vector3&in extents = Vector3(1.0, 1.0, 1.0))", asFUNCTION(DynamicNavigationMeshFindPath), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod("DynamicNavigationMesh", "void set_drawObstacles(bool)", asMETHOD(DynamicNavigationMesh, SetDrawObstacles), asCALL_THISCALL);
     engine->RegisterObjectMethod("DynamicNavigationMesh", "bool get_drawObstacles() const", asMETHOD(DynamicNavigationMesh, GetDrawObstacles), asCALL_THISCALL);
+    engine->RegisterObjectMethod("DynamicNavigationMesh", "void set_maxLayers(uint)", asMETHOD(DynamicNavigationMesh, SetMaxLayers), asCALL_THISCALL);
+    engine->RegisterObjectMethod("DynamicNavigationMesh", "bool get_maxLayers() const", asMETHOD(DynamicNavigationMesh, GetMaxLayers), asCALL_THISCALL);
     engine->RegisterObjectMethod("DynamicNavigationMesh", "void set_maxObstacles(uint)", asMETHOD(DynamicNavigationMesh, SetMaxObstacles), asCALL_THISCALL);
     engine->RegisterObjectMethod("DynamicNavigationMesh", "uint get_maxObstacles() const", asMETHOD(DynamicNavigationMesh, GetMaxObstacles), asCALL_THISCALL);
 }

--- a/Source/Urho3D/LuaScript/pkgs/Navigation/DynamicNavigationMesh.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Navigation/DynamicNavigationMesh.pkg
@@ -3,11 +3,14 @@ $#include "Navigation/DynamicNavigationMesh.h"
 class DynamicNavigationMesh : public NavigationMesh
 {
     void SetDrawObstacles(bool enable);
+    void SetMaxLayers(unsigned maxLayers);
     void SetMaxObstacles(unsigned maxObstacles);
 
     bool GetDrawObstacles() const;
+    unsigned GetMaxLayers() const;
     unsigned GetMaxObstacles() const;
 
     tolua_property__get_set bool drawObstacles;
     tolua_property__get_set int maxObstacles;
+    tolua_property__get_set unsigned maxLayers;
 };

--- a/Source/Urho3D/Navigation/DynamicNavigationMesh.h
+++ b/Source/Urho3D/Navigation/DynamicNavigationMesh.h
@@ -70,9 +70,13 @@ public:
 
     /// Set the maximum number of obstacles allowed.
     void SetMaxObstacles(unsigned maxObstacles) { maxObstacles_ = maxObstacles; }
+    /// Set the maximum number of layers that navigation construction can create.
+    void SetMaxLayers(unsigned maxLayers);
 
     /// Return the maximum number of obstacles allowed.
     unsigned GetMaxObstacles() const { return maxObstacles_; }
+    /// Return the maximum number of layers permitted to build.
+    unsigned GetMaxLayers() const { return maxLayers_; }
 
     /// Draw debug geometry for Obstacles.
     void SetDrawObstacles(bool enable) { drawObstacles_ = enable; }
@@ -116,6 +120,8 @@ private:
     dtTileCacheMeshProcess* meshProcessor_;
     /// Maximum number of obstacle objects allowed.
     unsigned maxObstacles_;
+    /// Maximum number of layers that are allowed to be constructed.
+    unsigned maxLayers_;
     /// Debug draw Obstacles.
     bool drawObstacles_;
 };


### PR DESCRIPTION
- Valid range of 3 - 255
- Angelscript + Lua bindings
- Layer maximum changes only effects nav mesh build and does not trigger
a build itself (as with other nav mesh parameters)

Reasoning behind the minimum value of 3 is that layers may occur inside of what the end user would expect to be a "watertight" shape when meshes are stacked on each other. 3 is a reasonably safe lower limit for a scene similar to the 39_CrowdNavigation example.

Default value of 16 is chosen as a reasonably low value that can still cover a "three story building on terrain with extra room for incidental interior layers in solid shapes."

Deals with issue #895