### PR TITLE
vs2015_ucomige_ss_workaround

### DIFF
--- a/Source/Urho3D/Math/Matrix3x4.h
+++ b/Source/Urho3D/Math/Matrix3x4.h
@@ -274,7 +274,7 @@ public:
         c0 = _mm_and_ps(c0, hi);
         hi = _mm_shuffle_ps(c0, c0, _MM_SHUFFLE(1, 1, 1, 1));
         c0 = _mm_and_ps(c0, hi);
-        return !_mm_ucomige_ss(c0, c0);
+        return _mm_cvtsi128_si32(_mm_castps_si128(c0)) == -1;
 #else
         const float* leftData = Data();
         const float* rightData = rhs.Data();

--- a/Source/Urho3D/Math/Matrix4.h
+++ b/Source/Urho3D/Math/Matrix4.h
@@ -236,7 +236,7 @@ public:
         c0 = _mm_and_ps(c0, hi);
         hi = _mm_shuffle_ps(c0, c0, _MM_SHUFFLE(1, 1, 1, 1));
         c0 = _mm_and_ps(c0, hi);
-        return !_mm_ucomige_ss(c0, c0);
+        return _mm_cvtsi128_si32(_mm_castps_si128(c0)) == -1;
 #else
         const float* leftData = Data();
         const float* rightData = rhs.Data();

--- a/Source/Urho3D/Math/Quaternion.h
+++ b/Source/Urho3D/Math/Quaternion.h
@@ -183,7 +183,7 @@ public:
         __m128 c = _mm_cmpeq_ps(_mm_loadu_ps(&w_), _mm_loadu_ps(&rhs.w_));
         c = _mm_and_ps(c, _mm_movehl_ps(c, c));
         c = _mm_and_ps(c, _mm_shuffle_ps(c, c, _MM_SHUFFLE(1, 1, 1, 1)));
-        return !_mm_ucomige_ss(c, c);
+        return _mm_cvtsi128_si32(_mm_castps_si128(c)) == -1;
 #else
         return w_ == rhs.w_ && x_ == rhs.x_ && y_ == rhs.y_ && z_ == rhs.z_;
 #endif


### PR DESCRIPTION
Work around bug #1053 (https://connect.microsoft.com/VisualStudio/feedback/details/2053175) by replacing the SSE1 specific _mm_ucomige_ss() with SSE2 specific _mm_cvtsi128_si32(_mm_castps_si128(c)) == -1. Given that URHO3D_SSE is targeting SSE2, this workaround has no drawbacks. Closes #1053.