### PR TITLE
vs2010_sse_alignment_workaround

### DIFF
--- a/Source/Urho3D/Math/Matrix3x4.h
+++ b/Source/Urho3D/Math/Matrix3x4.h
@@ -61,7 +61,13 @@ public:
 
     /// Copy-construct from another matrix.
     Matrix3x4(const Matrix3x4& matrix)
-#ifndef URHO3D_SSE
+#if defined(URHO3D_SSE) && (!defined(_MSC_VER) || _MSC_VER >= 1700) /* Visual Studio 2012 and newer. VS2010 has a bug with these, see https://github.com/urho3d/Urho3D/issues/1044 */
+    {
+        _mm_storeu_ps(&m00_, _mm_loadu_ps(&matrix.m00_));
+        _mm_storeu_ps(&m10_, _mm_loadu_ps(&matrix.m10_));
+        _mm_storeu_ps(&m20_, _mm_loadu_ps(&matrix.m20_));
+    }
+#else
        :m00_(matrix.m00_),
         m01_(matrix.m01_),
         m02_(matrix.m02_),
@@ -74,14 +80,9 @@ public:
         m21_(matrix.m21_),
         m22_(matrix.m22_),
         m23_(matrix.m23_)
-#endif
     {
-#ifdef URHO3D_SSE
-        _mm_storeu_ps(&m00_, _mm_loadu_ps(&matrix.m00_));
-        _mm_storeu_ps(&m10_, _mm_loadu_ps(&matrix.m10_));
-        _mm_storeu_ps(&m20_, _mm_loadu_ps(&matrix.m20_));
-#endif
     }
+#endif
 
     /// Copy-construct from a 3x3 matrix and set the extra elements to identity.
     Matrix3x4(const Matrix3& matrix) :
@@ -198,7 +199,7 @@ public:
     /// Assign from another matrix.
     Matrix3x4& operator =(const Matrix3x4& rhs)
     {
-#ifdef URHO3D_SSE
+#if defined(URHO3D_SSE) && (!defined(_MSC_VER) || _MSC_VER >= 1700) /* Visual Studio 2012 and newer. VS2010 has a bug with these, see https://github.com/urho3d/Urho3D/issues/1044 */
         _mm_storeu_ps(&m00_, _mm_loadu_ps(&rhs.m00_));
         _mm_storeu_ps(&m10_, _mm_loadu_ps(&rhs.m10_));
         _mm_storeu_ps(&m20_, _mm_loadu_ps(&rhs.m20_));


### PR DESCRIPTION
Work around VS2010 compiler bug with SSE and copy construction/assignment misalignment. Closes #1044.