### PR TITLE
activated generation of class-index

### DIFF
--- a/Docs/Doxyfile.in
+++ b/Docs/Doxyfile.in
@@ -852,7 +852,7 @@ VERBATIM_HEADERS       = NO
 # of all compounds will be generated. Enable this if the project 
 # contains a lot of classes, structs, unions or interfaces.
 
-ALPHABETICAL_INDEX     = NO
+ALPHABETICAL_INDEX     = YES
 
 # If the alphabetical index is enabled (see ALPHABETICAL_INDEX) then 
 # the COLS_IN_ALPHA_INDEX tag can be used to specify the number of columns 


### PR DESCRIPTION
it's common to have an alphabetical class index in the generated documentation. i think it would be helpful here too.