### PR TITLE
Added instantaneous rigidbody collision check

### DIFF
--- a/Source/Urho3D/AngelScript/PhysicsAPI.cpp
+++ b/Source/Urho3D/AngelScript/PhysicsAPI.cpp
@@ -280,6 +280,13 @@ static CScriptArray* PhysicsWorldGetRigidBodiesBody(RigidBody* body, PhysicsWorl
     return VectorToHandleArray<RigidBody>(result, "Array<RigidBody@>");
 }
 
+static CScriptArray* PhysicsWorldGetRigidBodiesBodyInstantaneous(RigidBody* body, PhysicsWorld* ptr)
+{
+    PODVector<RigidBody*> result;
+    ptr->GetRigidBodiesInstantaneous(result, body);
+    return VectorToHandleArray<RigidBody>(result, "Array<RigidBody@>");
+}
+
 static void RegisterPhysicsWorld(asIScriptEngine* engine)
 {
     engine->RegisterObjectType("PhysicsRaycastResult", sizeof(PhysicsRaycastResult), asOBJ_VALUE | asOBJ_APP_CLASS_C);
@@ -303,6 +310,7 @@ static void RegisterPhysicsWorld(asIScriptEngine* engine)
     engine->RegisterObjectMethod("PhysicsWorld", "Array<RigidBody@>@ GetRigidBodies(const Sphere&in, uint collisionMask = 0xffff)", asFUNCTION(PhysicsWorldGetRigidBodiesSphere), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod("PhysicsWorld", "Array<RigidBody@>@ GetRigidBodies(const BoundingBox&in, uint collisionMask = 0xffff)", asFUNCTION(PhysicsWorldGetRigidBodiesBox), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod("PhysicsWorld", "Array<RigidBody@>@ GetRigidBodies(RigidBody@+)", asFUNCTION(PhysicsWorldGetRigidBodiesBody), asCALL_CDECL_OBJLAST);
+    engine->RegisterObjectMethod("PhysicsWorld", "Array<RigidBody@>@ GetRigidBodiesInstantaneous(RigidBody@+)", asFUNCTION(PhysicsWorldGetRigidBodiesBodyInstantaneous), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod("PhysicsWorld", "void DrawDebugGeometry(bool)", asMETHODPR(PhysicsWorld, DrawDebugGeometry, (bool), void), asCALL_THISCALL);
     engine->RegisterObjectMethod("PhysicsWorld", "void RemoveCachedGeometry(Model@+)", asMETHOD(PhysicsWorld, RemoveCachedGeometry), asCALL_THISCALL);
     engine->RegisterObjectMethod("PhysicsWorld", "void set_gravity(const Vector3&in)", asMETHOD(PhysicsWorld, SetGravity), asCALL_THISCALL);

--- a/Source/Urho3D/LuaScript/pkgs/Physics/PhysicsWorld.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Physics/PhysicsWorld.pkg
@@ -40,8 +40,6 @@ class PhysicsWorld : public Component
     tolua_outside const PODVector<RigidBody*>& PhysicsWorldGetRigidBodiesBox @ GetRigidBodies(const BoundingBox& box, unsigned collisionMask = M_MAX_UNSIGNED);
     // void GetRigidBodies(PODVector<RigidBody*>& result, const RigidBody* body);
     tolua_outside const PODVector<RigidBody*>& PhysicsWorldGetRigidBodiesBody @ GetRigidBodies(const RigidBody* body);
-    // void GetRigidBodiesInstantaneous(PODVector<RigidBody*>& result, const RigidBody* body);
-    tolua_outside const PODVector<RigidBody*>& PhysicsWorldGetRigidBodiesBodyInstantaneous @ GetRigidBodies(const RigidBody* body);
 
     void DrawDebugGeometry(bool depthTest);
     void RemoveCachedGeometry(Model* model);
@@ -118,6 +116,14 @@ static const PODVector<RigidBody*>& PhysicsWorldGetRigidBodiesBody(PhysicsWorld*
     static PODVector<RigidBody*> result;
     result.Clear();
     physicsWorld->GetRigidBodies(result, body);
+    return result;
+}
+
+static const PODVector<RigidBody*>& PhysicsWorldGetRigidBodiesBodyInstantaneous(PhysicsWorld* physicsWorld, const RigidBody* body)
+{
+    static PODVector<RigidBody*> result;
+    result.Clear();
+    physicsWorld->GetRigidBodiesInstantaneous(result, body);
     return result;
 }
 

--- a/Source/Urho3D/LuaScript/pkgs/Physics/PhysicsWorld.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Physics/PhysicsWorld.pkg
@@ -40,6 +40,8 @@ class PhysicsWorld : public Component
     tolua_outside const PODVector<RigidBody*>& PhysicsWorldGetRigidBodiesBox @ GetRigidBodies(const BoundingBox& box, unsigned collisionMask = M_MAX_UNSIGNED);
     // void GetRigidBodies(PODVector<RigidBody*>& result, const RigidBody* body);
     tolua_outside const PODVector<RigidBody*>& PhysicsWorldGetRigidBodiesBody @ GetRigidBodies(const RigidBody* body);
+    // void GetRigidBodiesInstantaneous(PODVector<RigidBody*>& result, const RigidBody* body);
+    tolua_outside const PODVector<RigidBody*>& PhysicsWorldGetRigidBodiesBodyInstantaneous @ GetRigidBodies(const RigidBody* body);
 
     void DrawDebugGeometry(bool depthTest);
     void RemoveCachedGeometry(Model* model);

--- a/Source/Urho3D/Physics/PhysicsWorld.h
+++ b/Source/Urho3D/Physics/PhysicsWorld.h
@@ -177,7 +177,8 @@ public:
     void GetRigidBodies(PODVector<RigidBody*>& result, const BoundingBox& box, unsigned collisionMask = M_MAX_UNSIGNED);
     /// Return rigid bodies that have been in collision with a specific body on the last simulation step.
     void GetRigidBodies(PODVector<RigidBody*>& result, const RigidBody* body);
-
+    /// Return rigid bodies that are in collision with a specific body as an instantaneous check.
+    void GetRigidBodiesInstantaneous(PODVector<RigidBody*>& result, const RigidBody* body);
     /// Return gravity.
     Vector3 GetGravity() const;
 
@@ -244,9 +245,6 @@ public:
     /// Return whether node dirtying should be disregarded.
     bool IsApplyingTransforms() const { return applyingTransforms_; }
 
-    /// Return whether is currently inside the Bullet substep loop.
-    bool IsSimulating() const { return simulating_; }
-
 protected:
     /// Handle scene being assigned.
     virtual void OnSceneSet(Scene* scene);
@@ -311,14 +309,12 @@ private:
     bool internalEdge_;
     /// Applying transforms flag.
     bool applyingTransforms_;
-    /// Simulating flag.
-    bool simulating_;
-    /// Debug draw depth test mode.
-    bool debugDepthTest_;
     /// Debug renderer.
     DebugRenderer* debugRenderer_;
     /// Debug draw flags.
     int debugMode_;
+    /// Debug draw depth test mode.
+    bool debugDepthTest_;
 };
 
 /// Register Physics library objects.


### PR DESCRIPTION
Added a `GetRigidBodiesInstantaneous` method (plus associated Lua/Angelscript APIs). This function is similar to `PhysicsWorld::GetRigidBodies` but actually performs an instantaneous collision check, instead of relying on cached collision data. This, for instance, allows for checks on static geometry that otherwise do not return the expected results.  