### PR TITLE
Urho3D Editor: Preview drag-moving rotation problem are fixed.

### DIFF
--- a/bin/Data/Scripts/Editor/EditorMaterial.as
+++ b/bin/Data/Scripts/Editor/EditorMaterial.as
@@ -357,7 +357,6 @@ void RotateMaterialPreview(StringHash eventType, VariantMap& eventData)
     {
         float yaw = ((materialPreview.height / 2) - elemY) * (9.0 / materialPreview.height);
         float pitch = ((materialPreview.width / 2) - elemX) * (9.0 / materialPreview.width);
-        
         previewModelNode.Rotate(Quaternion(yaw, pitch, 0),TS_WORLD);
         materialPreview.QueueUpdate();
     }

--- a/bin/Data/Scripts/Editor/EditorMaterial.as
+++ b/bin/Data/Scripts/Editor/EditorMaterial.as
@@ -355,10 +355,10 @@ void RotateMaterialPreview(StringHash eventType, VariantMap& eventData)
     
     if (materialPreview.height > 0 && materialPreview.width > 0)
     {
-        float yaw = ((materialPreview.height / 2) - elemY) * (90.0 / materialPreview.height);
-        float pitch = ((materialPreview.width / 2) - elemX) * (90.0 / materialPreview.width);
-
-        previewModelNode.rotation = previewModelNode.rotation.Slerp(Quaternion(yaw, pitch, 0), 0.1);
+        float yaw = ((materialPreview.height / 2) - elemY) * (9.0 / materialPreview.height);
+        float pitch = ((materialPreview.width / 2) - elemX) * (9.0 / materialPreview.width);
+        
+        previewModelNode.Rotate(Quaternion(yaw, pitch, 0),TS_WORLD);
         materialPreview.QueueUpdate();
     }
 }

--- a/bin/Data/Scripts/Editor/EditorResourceBrowser.as
+++ b/bin/Data/Scripts/Editor/EditorResourceBrowser.as
@@ -1575,10 +1575,10 @@ void RotateResourceBrowserPreview(StringHash eventType, VariantMap& eventData)
     
     if (resourceBrowserPreview.height > 0 && resourceBrowserPreview.width > 0)
     {
-        float yaw = ((resourceBrowserPreview.height / 2) - elemY) * (90.0 / resourceBrowserPreview.height);
-        float pitch = ((resourceBrowserPreview.width / 2) - elemX) * (90.0 / resourceBrowserPreview.width);
+        float yaw = ((resourceBrowserPreview.height / 2) - elemY) * (9.0 / resourceBrowserPreview.height);
+        float pitch = ((resourceBrowserPreview.width / 2) - elemX) * (9.0 / resourceBrowserPreview.width);
 
-        resourcePreviewNode.rotation = resourcePreviewNode.rotation.Slerp(Quaternion(yaw, pitch, 0), 0.1);
+        resourcePreviewNode.Rotate(Quaternion(yaw, pitch, 0),TS_WORLD);
         RefreshBrowserPreview();
     }
 }


### PR DESCRIPTION
Hi, this is my first PR, if something wrong just correct me.

The preview drag-moving did not  work properly while you re-click the mouse button to rotate a object, it always reset the rotation to zero.

Fixed... 