### PR TITLE
Write all CMake definitons to header file

### DIFF
--- a/CMake/Modules/GenerateConfigHeader.cmake
+++ b/CMake/Modules/GenerateConfigHeader.cmake
@@ -1,0 +1,22 @@
+set (FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/Config.h")
+
+file (WRITE ${FILE_NAME} "#pragma once")
+
+get_directory_property (URHO3D_COMPILE_DEFINITIONS COMPILE_DEFINITIONS)
+list (REMOVE_ITEM URHO3D_COMPILE_DEFINITIONS HAVE_STDINT_H GLEW_STATIC GLEW_NO_GLU URHO3D_IS_BUILDING ODBC_3_OR_LATER ASSET_DIR_INDICATOR)
+string (REPLACE ";" "\n#define " URHO3D_COMPILE_DEFINITIONS "#define ${URHO3D_COMPILE_DEFINITIONS}")
+file (APPEND ${FILE_NAME} "\n\n${URHO3D_COMPILE_DEFINITIONS}")
+
+define_dependency_libs (${TARGET_NAME})
+string (REPLACE ";" "\")\n#    pragma comment(lib, \"" FORMAT_LIBS "#    pragma comment(lib, \"${LIBS}\")")
+file (APPEND ${FILE_NAME} "\n")
+file (APPEND ${FILE_NAME} "\n#ifdef _MSC_VER")
+file (APPEND ${FILE_NAME} "\n#    ifdef _DEBUG")
+file (APPEND ${FILE_NAME} "\n#        pragma comment(lib, \"Urho3D_d\")")
+file (APPEND ${FILE_NAME} "\n#    else")
+file (APPEND ${FILE_NAME} "\n#        pragma comment(lib, \"Urho3D\")")
+file (APPEND ${FILE_NAME} "\n#    endif")
+file (APPEND ${FILE_NAME} "\n${FORMAT_LIBS}")
+file (APPEND ${FILE_NAME} "\n#endif")
+
+install_header_files (FILES ${FILE_NAME} DESTINATION ${DEST_INCLUDE_DIR})

--- a/Source/Urho3D/CMakeLists.txt
+++ b/Source/Urho3D/CMakeLists.txt
@@ -169,7 +169,7 @@ endif ()
 
 # Generate platform specific export header file
 if (MSVC)
-    set (PRE_EXPORT_HEADER "\n#pragma warning(disable: 4251)\n#pragma warning(disable: 4275)\n")
+    set (PRE_EXPORT_HEADER "\n#pragma warning(disable: 4251)\n#pragma warning(disable: 4275)\n\n#include \"Config.h\"\n")
 endif ()
 if (URHO3D_CLANG_TOOLS)
     set (ANNOTATE_NONSCRIPTABLE "__attribute__((annotate(\"nonscriptable\")))")
@@ -177,6 +177,8 @@ endif ()
 generate_export_header (${TARGET_NAME} ${URHO3D_LIB_TYPE} EXPORT_MACRO_NAME URHO3D_API EXPORT_FILE_NAME Urho3D.h.new)
 execute_process (COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/Urho3D.h.new ${CMAKE_CURRENT_BINARY_DIR}/Urho3D.h)
 file (REMOVE ${CMAKE_CURRENT_BINARY_DIR}/Urho3D.h.new)
+
+include (GenerateConfigHeader)
 
 # Define generated object files
 # This is a hack as it relies on internal working of CMake


### PR DESCRIPTION
https://github.com/urho3d/Urho3D/issues/1065

It is a first try (there are some issues). Any feedback?

Sample result (Config.h)
```
#pragma once

#define URHO3D_MINIDUMPS
#define URHO3D_FILEWATCHER
#define URHO3D_PROFILING
#define URHO3D_LOGGING
#define URHO3D_THREADING
#define URHO3D_ANGELSCRIPT
#define URHO3D_LUA
#define TOLUA_RELEASE
#define URHO3D_NAVIGATION
#define URHO3D_NETWORK
#define URHO3D_PHYSICS
#define URHO3D_URHO2D
#define _CRT_SECURE_NO_WARNINGS

#ifdef _MSC_VER
#    ifdef _DEBUG
#        pragma comment(lib, "Urho3D_d")
#    else
#        pragma comment(lib, "Urho3D")
#    endif
#    pragma comment(lib, "user32")
#    pragma comment(lib, "gdi32")
#    pragma comment(lib, "winmm")
#    pragma comment(lib, "imm32")
#    pragma comment(lib, "ole32")
#    pragma comment(lib, "oleaut32")
#    pragma comment(lib, "version")
#    pragma comment(lib, "uuid")
#    pragma comment(lib, "ws2_32")
#    pragma comment(lib, "winmm")
#    pragma comment(lib, "dbghelp")
#    pragma comment(lib, "opengl32")
#endif
```

