### PR TITLE
Direction support for particle/billboard

### DIFF
--- a/Source/Urho3D/AngelScript/GraphicsAPI.cpp
+++ b/Source/Urho3D/AngelScript/GraphicsAPI.cpp
@@ -1319,12 +1319,14 @@ static void RegisterBillboardSet(asIScriptEngine* engine)
     engine->RegisterEnumValue("FaceCameraMode", "FC_ROTATE_Y", FC_ROTATE_Y);
     engine->RegisterEnumValue("FaceCameraMode", "FC_LOOKAT_XYZ", FC_LOOKAT_XYZ);
     engine->RegisterEnumValue("FaceCameraMode", "FC_LOOKAT_Y", FC_LOOKAT_Y);
+    engine->RegisterEnumValue("FaceCameraMode", "FC_DIRECTION", FC_DIRECTION);
 
     engine->RegisterObjectType("Billboard", 0, asOBJ_REF);
     engine->RegisterObjectBehaviour("Billboard", asBEHAVE_ADDREF, "void f()", asFUNCTION(FakeAddRef), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectBehaviour("Billboard", asBEHAVE_RELEASE, "void f()", asFUNCTION(FakeReleaseRef), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectProperty("Billboard", "Vector3 position", offsetof(Billboard, position_));
     engine->RegisterObjectProperty("Billboard", "Vector2 size", offsetof(Billboard, size_));
+    engine->RegisterObjectProperty("Billboard", "Vector3 direction", offsetof(Billboard, direction_));
     engine->RegisterObjectProperty("Billboard", "Rect uv", offsetof(Billboard, uv_));
     engine->RegisterObjectProperty("Billboard", "Color color", offsetof(Billboard, color_));
     engine->RegisterObjectProperty("Billboard", "float rotation", offsetof(Billboard, rotation_));
@@ -1429,6 +1431,8 @@ static void RegisterParticleEffect(asIScriptEngine* engine)
     engine->RegisterObjectMethod("ParticleEffect", "float get_sizeAdd() const", asMETHOD(ParticleEffect, GetSizeAdd), asCALL_THISCALL);
     engine->RegisterObjectMethod("ParticleEffect", "void set_sizeMul(float)", asMETHOD(ParticleEffect, SetSizeMul), asCALL_THISCALL);
     engine->RegisterObjectMethod("ParticleEffect", "float get_sizeMul() const", asMETHOD(ParticleEffect, GetSizeMul), asCALL_THISCALL);
+    engine->RegisterObjectMethod("ParticleEffect", "void set_faceCameraMode(FaceCameraMode)", asMETHOD(ParticleEffect, SetFaceCameraMode), asCALL_THISCALL);
+    engine->RegisterObjectMethod("ParticleEffect", "FaceCameraMode get_faceCameraMode() const", asMETHOD(ParticleEffect, GetFaceCameraMode), asCALL_THISCALL);
 
     engine->RegisterObjectMethod("ParticleEffect", "void AddColorTime(Color&, float)", asMETHOD(ParticleEffect, AddColorTime), asCALL_THISCALL);
     engine->RegisterObjectMethod("ParticleEffect", "void AddColorFrame(ColorFrame@+)", asMETHOD(ParticleEffect, AddColorFrame), asCALL_THISCALL);

--- a/Source/Urho3D/Graphics/BillboardSet.cpp
+++ b/Source/Urho3D/Graphics/BillboardSet.cpp
@@ -459,8 +459,8 @@ void BillboardSet::UpdateBufferSize()
     {
         if (faceCameraMode_ == FC_DIRECTION)
         {
-            geometry_->SetVertexBuffer(0, vertexBuffer_, MASK_POSITION | MASK_NORMAL | MASK_COLOR | MASK_TEXCOORD1 | MASK_TANGENT);
-            vertexBuffer_->SetSize(numBillboards * 4, MASK_POSITION | MASK_NORMAL | MASK_COLOR | MASK_TEXCOORD1 | MASK_TANGENT, true);
+            geometry_->SetVertexBuffer(0, vertexBuffer_, MASK_POSITION | MASK_NORMAL | MASK_COLOR | MASK_TEXCOORD1 | MASK_TEXCOORD2 | MASK_TANGENT);
+            vertexBuffer_->SetSize(numBillboards * 4, MASK_POSITION | MASK_NORMAL | MASK_COLOR | MASK_TEXCOORD1 | MASK_TEXCOORD2 | MASK_TANGENT, true);
         } else {
             geometry_->SetVertexBuffer(0, vertexBuffer_, MASK_POSITION | MASK_COLOR | MASK_TEXCOORD1 | MASK_TEXCOORD2);
             vertexBuffer_->SetSize(numBillboards * 4, MASK_POSITION | MASK_COLOR | MASK_TEXCOORD1 | MASK_TEXCOORD2, true);
@@ -618,8 +618,6 @@ void BillboardSet::UpdateVertexBuffer(const FrameInfo& frame)
         }
     } else
     {
-        Vector3 offset;
-        Vector2 vert;
         for (unsigned i = 0; i < enabledBillboards; ++i)
         {
             Billboard& billboard = *sortedBillboards_[i];
@@ -627,84 +625,77 @@ void BillboardSet::UpdateVertexBuffer(const FrameInfo& frame)
             Vector2 size(billboard.size_.x_ * billboardScale.x_, billboard.size_.y_ * billboardScale.y_);
             unsigned color = billboard.color_.ToUInt();
 
-            Quaternion rot3D = frame.camera_->GetFaceCameraRotationAlongDirection(node_->GetWorldTransform() * billboard.position_, billboard.direction_);
-            Vector3 normal = rot3D * Vector3::UP;
-
             float rot2D[2][2];
             rot2D[0][0] = Cos(billboard.rotation_);
             rot2D[0][1] = Sin(billboard.rotation_);
             rot2D[1][0] = -rot2D[0][1];
             rot2D[1][1] = rot2D[0][0];
 
-            vert.x_ = -size.x_ * rot2D[0][0] + size.y_ * rot2D[0][1];
-            vert.y_ = -size.x_ * rot2D[1][0] + size.y_ * rot2D[1][1];
-            offset = rot3D * Vector3(vert.x_, 0.0f, vert.y_);
             dest[0] = billboard.position_.x_;
             dest[1] = billboard.position_.y_;
             dest[2] = billboard.position_.z_;
-            dest[3] = normal.x_;
-            dest[4] = normal.y_;
-            dest[5] = normal.z_;
+            dest[3] = billboard.direction_.x_;
+            dest[4] = billboard.direction_.y_;
+            dest[5] = billboard.direction_.z_;
             ((unsigned&)dest[6]) = color;
             dest[7] = billboard.uv_.min_.x_;
             dest[8] = billboard.uv_.min_.y_;
-            dest[9] = offset.x_;
-            dest[10] = offset.y_;
-            dest[11] = offset.z_;
-            dest[12] = 1.0f;
+            dest[9] = -size.x_ * rot2D[0][0] + size.y_ * rot2D[0][1];
+            dest[10] = -size.x_ * rot2D[1][0] + size.y_ * rot2D[1][1];
+            dest[11] = frame.camera_->GetNode()->GetWorldPosition().x_;
+            dest[12] = frame.camera_->GetNode()->GetWorldPosition().y_;
+            dest[13] = frame.camera_->GetNode()->GetWorldPosition().z_;
+            dest[14] = 1.0f;
 
-            vert.x_ = size.x_ * rot2D[0][0] + size.y_ * rot2D[0][1];
-            vert.y_ = size.x_ * rot2D[1][0] + size.y_ * rot2D[1][1];
-            offset = rot3D * Vector3(vert.x_, 0.0f, vert.y_);
-            dest[13] = billboard.position_.x_;
-            dest[14] = billboard.position_.y_;
-            dest[15] = billboard.position_.z_;
-            dest[16] = normal.x_;
-            dest[17] = normal.y_;
-            dest[18] = normal.z_;
-            ((unsigned&)dest[19]) = color;
-            dest[20] = billboard.uv_.max_.x_;
-            dest[21] = billboard.uv_.min_.y_;
-            dest[22] = offset.x_;
-            dest[23] = offset.y_;
-            dest[24] = offset.z_;
-            dest[25] = 1.0f;
+            dest[15] = billboard.position_.x_;
+            dest[16] = billboard.position_.y_;
+            dest[17] = billboard.position_.z_;
+            dest[18] = billboard.direction_.x_;
+            dest[19] = billboard.direction_.y_;
+            dest[20] = billboard.direction_.z_;
+            ((unsigned&)dest[21]) = color;
+            dest[22] = billboard.uv_.max_.x_;
+            dest[23] = billboard.uv_.min_.y_;
+            dest[24] = size.x_ * rot2D[0][0] + size.y_ * rot2D[0][1];
+            dest[25] = size.x_ * rot2D[1][0] + size.y_ * rot2D[1][1];
+            dest[26] = frame.camera_->GetNode()->GetWorldPosition().x_;
+            dest[27] = frame.camera_->GetNode()->GetWorldPosition().y_;
+            dest[28] = frame.camera_->GetNode()->GetWorldPosition().z_;
+            dest[29] = 1.0f;
 
-            vert.x_ = size.x_ * rot2D[0][0] - size.y_ * rot2D[0][1];
-            vert.y_ = size.x_ * rot2D[1][0] - size.y_ * rot2D[1][1];
-            offset = rot3D * Vector3(vert.x_, 0.0f, vert.y_);
-            dest[26] = billboard.position_.x_;
-            dest[27] = billboard.position_.y_;
-            dest[28] = billboard.position_.z_;
-            dest[29] = normal.x_;
-            dest[30] = normal.y_;
-            dest[31] = normal.z_;
-            ((unsigned&)dest[32]) = color;
-            dest[33] = billboard.uv_.max_.x_;
-            dest[34] = billboard.uv_.max_.y_;
-            dest[35] = offset.x_;
-            dest[36] = offset.y_;
-            dest[37] = offset.z_;
-            dest[38] = 1.0f;
+            dest[30] = billboard.position_.x_;
+            dest[31] = billboard.position_.y_;
+            dest[32] = billboard.position_.z_;
+            dest[33] = billboard.direction_.x_;
+            dest[34] = billboard.direction_.y_;
+            dest[35] = billboard.direction_.z_;
+            ((unsigned&)dest[36]) = color;
+            dest[37] = billboard.uv_.max_.x_;
+            dest[38] = billboard.uv_.max_.y_;
+            dest[39] = size.x_ * rot2D[0][0] - size.y_ * rot2D[0][1];
+            dest[40] = size.x_ * rot2D[1][0] - size.y_ * rot2D[1][1];
+            dest[41] = frame.camera_->GetNode()->GetWorldPosition().x_;
+            dest[42] = frame.camera_->GetNode()->GetWorldPosition().y_;
+            dest[43] = frame.camera_->GetNode()->GetWorldPosition().z_;
+            dest[44] = 1.0f;
 
-            vert.x_ = -size.x_ * rot2D[0][0] - size.y_ * rot2D[0][1];
-            vert.y_ = -size.x_ * rot2D[1][0] - size.y_ * rot2D[1][1];
-            offset = rot3D * Vector3(vert.x_, 0.0f, vert.y_);
-            dest[39] = billboard.position_.x_;
-            dest[40] = billboard.position_.y_;
-            dest[41] = billboard.position_.z_;
-            dest[42] = normal.x_;
-            dest[43] = normal.y_;
-            dest[44] = normal.z_;
-            ((unsigned&)dest[45]) = color;
-            dest[46] = billboard.uv_.min_.x_;
-            dest[47] = billboard.uv_.max_.y_;
-            dest[48] = offset.x_;
-            dest[49] = offset.y_;
-            dest[50] = offset.z_;
-            dest[51] = 1.0f;
+            dest[45] = billboard.position_.x_;
+            dest[46] = billboard.position_.y_;
+            dest[47] = billboard.position_.z_;
+            dest[48] = billboard.direction_.x_;
+            dest[49] = billboard.direction_.y_;
+            dest[50] = billboard.direction_.z_;
+            ((unsigned&)dest[51]) = color;
+            dest[52] = billboard.uv_.min_.x_;
+            dest[53] = billboard.uv_.max_.y_;
+            dest[54] = -size.x_ * rot2D[0][0] - size.y_ * rot2D[0][1];
+            dest[55] = -size.x_ * rot2D[1][0] - size.y_ * rot2D[1][1];
+            dest[56] = frame.camera_->GetNode()->GetWorldPosition().x_;
+            dest[57] = frame.camera_->GetNode()->GetWorldPosition().y_;
+            dest[58] = frame.camera_->GetNode()->GetWorldPosition().z_;
+            dest[59] = 1.0f;
 
-            dest += 52;
+            dest += 60;
         }
     }
 

--- a/Source/Urho3D/Graphics/BillboardSet.h
+++ b/Source/Urho3D/Graphics/BillboardSet.h
@@ -47,6 +47,8 @@ struct URHO3D_API Billboard
     Color color_;
     /// Rotation.
     float rotation_;
+    /// Direction (For direction based billboard only).
+    Vector3 direction_;
     /// Enabled flag.
     bool enabled_;
     /// Sort distance.
@@ -177,6 +179,8 @@ private:
     bool bufferDirty_;
     /// Force update flag (ignore animation LOD momentarily.)
     bool forceUpdate_;
+    /// Update billboard geometry type
+    bool geometryTypeUpdate_;
     /// Sorting flag. Triggers a vertex buffer rewrite for each view this billboard set is rendered from.
     bool sortThisFrame_;
     /// Frame number on which was last sorted.

--- a/Source/Urho3D/Graphics/Camera.cpp
+++ b/Source/Urho3D/Graphics/Camera.cpp
@@ -576,20 +576,6 @@ Quaternion Camera::GetFaceCameraRotation(const Vector3& position, const Quaterni
     }
 }
 
-Quaternion Camera::GetFaceCameraRotationAlongDirection(const Vector3& position, const Vector3& direction)
-{
-    const Vector3& cameraPos = node_ ? node_->GetWorldPosition() : Vector3::ZERO;
-    Vector3 cameraDir = (position - cameraPos).Normalized();
-
-    Vector3 front = direction.Normalized();
-    Vector3 right = front.CrossProduct(cameraDir).Normalized();
-    Vector3 up = front.CrossProduct(right).Normalized();
-
-    Quaternion rot;
-    rot.FromAxes(right, up, front);
-    return rot;
-}
-
 Matrix3x4 Camera::GetEffectiveWorldTransform() const
 {
     Matrix3x4 worldTransform = node_ ? Matrix3x4(node_->GetWorldPosition(), node_->GetWorldRotation(), 1.0f) : Matrix3x4::IDENTITY;

--- a/Source/Urho3D/Graphics/Camera.cpp
+++ b/Source/Urho3D/Graphics/Camera.cpp
@@ -576,6 +576,20 @@ Quaternion Camera::GetFaceCameraRotation(const Vector3& position, const Quaterni
     }
 }
 
+Quaternion Camera::GetFaceCameraRotationAlongDirection(const Vector3& position, const Vector3& direction)
+{
+    const Vector3& cameraPos = node_ ? node_->GetWorldPosition() : Vector3::ZERO;
+    Vector3 cameraDir = (position - cameraPos).Normalized();
+
+    Vector3 front = direction.Normalized();
+    Vector3 right = front.CrossProduct(cameraDir).Normalized();
+    Vector3 up = front.CrossProduct(right).Normalized();
+
+    Quaternion rot;
+    rot.FromAxes(right, up, front);
+    return rot;
+}
+
 Matrix3x4 Camera::GetEffectiveWorldTransform() const
 {
     Matrix3x4 worldTransform = node_ ? Matrix3x4(node_->GetWorldPosition(), node_->GetWorldRotation(), 1.0f) : Matrix3x4::IDENTITY;

--- a/Source/Urho3D/Graphics/Camera.h
+++ b/Source/Urho3D/Graphics/Camera.h
@@ -185,8 +185,6 @@ public:
     float GetLodDistance(float distance, float scale, float bias) const;
     /// Return a world rotation for facing a camera on certain axes based on the existing world rotation.
     Quaternion GetFaceCameraRotation(const Vector3& position, const Quaternion& rotation, FaceCameraMode mode);
-    /// Return a world rotation for facing a camera on certain axes based on defined world direction.
-    Quaternion GetFaceCameraRotationAlongDirection(const Vector3& position, const Vector3& direction);
     /// Get effective world transform for matrix and frustum calculations including reflection but excluding node scaling.
     Matrix3x4 GetEffectiveWorldTransform() const;
     /// Return if projection parameters are valid for rendering and raycasting.

--- a/Source/Urho3D/Graphics/Camera.h
+++ b/Source/Urho3D/Graphics/Camera.h
@@ -185,6 +185,8 @@ public:
     float GetLodDistance(float distance, float scale, float bias) const;
     /// Return a world rotation for facing a camera on certain axes based on the existing world rotation.
     Quaternion GetFaceCameraRotation(const Vector3& position, const Quaternion& rotation, FaceCameraMode mode);
+    /// Return a world rotation for facing a camera on certain axes based on defined world direction.
+    Quaternion GetFaceCameraRotationAlongDirection(const Vector3& position, const Vector3& direction);
     /// Get effective world transform for matrix and frustum calculations including reflection but excluding node scaling.
     Matrix3x4 GetEffectiveWorldTransform() const;
     /// Return if projection parameters are valid for rendering and raycasting.

--- a/Source/Urho3D/Graphics/GraphicsDefs.h
+++ b/Source/Urho3D/Graphics/GraphicsDefs.h
@@ -55,8 +55,9 @@ enum GeometryType
     GEOM_SKINNED = 1,
     GEOM_INSTANCED = 2,
     GEOM_BILLBOARD = 3,
-    GEOM_STATIC_NOINSTANCING = 4,
-    MAX_GEOMETRYTYPES = 4,
+    GEOM_DIRBILLBOARD = 4,
+    GEOM_STATIC_NOINSTANCING = 5,
+    MAX_GEOMETRYTYPES = 5,
 };
 
 /// Blending mode.
@@ -273,7 +274,8 @@ enum FaceCameraMode
     FC_ROTATE_XYZ,
     FC_ROTATE_Y,
     FC_LOOKAT_XYZ,
-    FC_LOOKAT_Y
+    FC_LOOKAT_Y,
+    FC_DIRECTION
 };
 
 /// Shadow type

--- a/Source/Urho3D/Graphics/ParticleEffect.h
+++ b/Source/Urho3D/Graphics/ParticleEffect.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include "../Graphics/GraphicsDefs.h"
 #include "../Resource/Resource.h"
 
 namespace Urho3D
@@ -180,6 +181,8 @@ public:
     void SetSizeAdd(float sizeAdd);
     /// Set particle size multiplicative modifier.
     void SetSizeMul(float sizeMul);
+    /// Set how the particles should rotate in relation to the camera. Default is to follow camera rotation on all axes (FC_ROTATE_XYZ.)
+    void SetFaceCameraMode(FaceCameraMode mode);
 
     /// Add a color frame sorted in the correct position based on time.
     void AddColorTime(const Color& color, const float time);
@@ -316,6 +319,9 @@ public:
     /// Return a texture animation frame, or null if outside range.
     const TextureFrame* GetTextureFrame(unsigned index) const;
 
+    /// Return how the particles rotate in relation to the camera.
+    FaceCameraMode GetFaceCameraMode() const { return faceCameraMode_; }
+
     /// Return random direction.
     Vector3 GetRandomDirection() const;
     /// Return random size.
@@ -401,6 +407,8 @@ private:
     Vector<TextureFrame> textureFrames_;
     /// Material name acquired during BeginLoad().
     String loadMaterialName_;
+    /// Particle rotation mode in relation to the camera.
+    FaceCameraMode faceCameraMode_;
 };
 
 }

--- a/Source/Urho3D/Graphics/ParticleEmitter.cpp
+++ b/Source/Urho3D/Graphics/ParticleEmitter.cpp
@@ -66,7 +66,7 @@ void ParticleEmitter::RegisterObject(Context* context)
     URHO3D_ACCESSOR_ATTRIBUTE("Is Enabled", IsEnabled, SetEnabled, bool, true, AM_DEFAULT);
     URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Effect", GetEffectAttr, SetEffectAttr, ResourceRef, ResourceRef(ParticleEffect::GetTypeStatic()),
         AM_DEFAULT);
-    URHO3D_ENUM_ATTRIBUTE("Face Camera Mode", faceCameraMode_, faceCameraModeNames, FC_ROTATE_XYZ, AM_DEFAULT);
+    //URHO3D_ENUM_ATTRIBUTE("Face Camera Mode", faceCameraMode_, faceCameraModeNames, FC_ROTATE_XYZ, AM_DEFAULT);
     URHO3D_ACCESSOR_ATTRIBUTE("Can Be Occluded", IsOccludee, SetOccludee, bool, true, AM_DEFAULT);
     URHO3D_ATTRIBUTE("Cast Shadows", bool, castShadows_, false, AM_DEFAULT);
     URHO3D_ACCESSOR_ATTRIBUTE("Draw Distance", GetDrawDistance, SetDrawDistance, float, 0.0f, AM_DEFAULT);
@@ -205,6 +205,7 @@ void ParticleEmitter::Update(const FrameInfo& frame)
                 particle.velocity_ += lastTimeStep_ * force;
             }
             billboard.position_ += lastTimeStep_ * particle.velocity_ * scaleVector;
+            billboard.direction_ = particle.velocity_.Normalized();
 
             // Rotation
             billboard.rotation_ += lastTimeStep_ * particle.rotationSpeed_;
@@ -338,6 +339,7 @@ void ParticleEmitter::ApplyEffect()
     SetScaled(effect_->IsScaled());
     SetSorted(effect_->IsSorted());
     SetAnimationLodBias(effect_->GetAnimationLodBias());
+    SetFaceCameraMode(effect_->GetFaceCameraMode());
 }
 
 ParticleEffect* ParticleEmitter::GetEffect() const
@@ -408,7 +410,7 @@ VariantVector ParticleEmitter::GetParticleBillboardsAttr() const
         return ret;
     }
 
-    ret.Reserve(billboards_.Size() * 6 + 1);
+    ret.Reserve(billboards_.Size() * 7 + 1);
     ret.Push(billboards_.Size());
 
     for (PODVector<Billboard>::ConstIterator i = billboards_.Begin(); i != billboards_.End(); ++i)
@@ -418,6 +420,7 @@ VariantVector ParticleEmitter::GetParticleBillboardsAttr() const
         ret.Push(Vector4(i->uv_.min_.x_, i->uv_.min_.y_, i->uv_.max_.x_, i->uv_.max_.y_));
         ret.Push(i->color_);
         ret.Push(i->rotation_);
+        ret.Push(i->direction_);
         ret.Push(i->enabled_);
     }
 
@@ -443,9 +446,11 @@ bool ParticleEmitter::EmitNewParticle()
     Particle& particle = particles_[index];
     Billboard& billboard = billboards_[index];
 
-    Vector3 startPos;
     Vector3 startDir;
+    Vector3 startPos;
 
+    startDir = effect_->GetRandomDirection();
+    startDir.Normalize();
 
     switch (effect_->GetEmitterType())
     {
@@ -473,8 +478,18 @@ bool ParticleEmitter::EmitNewParticle()
         break;
     }
 
-    startDir = effect_->GetRandomDirection();
-    startDir.Normalize();
+    particle.size_ = effect_->GetRandomSize();
+    particle.timer_ = 0.0f;
+    particle.timeToLive_ = effect_->GetRandomTimeToLive();
+    particle.scale_ = 1.0f;
+    particle.rotationSpeed_ = effect_->GetRandomRotationSpeed();
+    particle.colorIndex_ = 0;
+    particle.texIndex_ = 0;
+
+    if(faceCameraMode_ == FC_DIRECTION)
+    {
+        startPos += startDir * particle.size_.y_;
+    }
 
     if (!relative_)
     {
@@ -483,13 +498,6 @@ bool ParticleEmitter::EmitNewParticle()
     };
 
     particle.velocity_ = effect_->GetRandomVelocity() * startDir;
-    particle.size_ = effect_->GetRandomSize();
-    particle.timer_ = 0.0f;
-    particle.timeToLive_ = effect_->GetRandomTimeToLive();
-    particle.scale_ = 1.0f;
-    particle.rotationSpeed_ = effect_->GetRandomRotationSpeed();
-    particle.colorIndex_ = 0;
-    particle.texIndex_ = 0;
 
     billboard.position_ = startPos;
     billboard.size_ = particles_[index].size_;
@@ -499,6 +507,7 @@ bool ParticleEmitter::EmitNewParticle()
     const Vector<ColorFrame>& colorFrames_ = effect_->GetColorFrames();
     billboard.color_ = colorFrames_.Size() ? colorFrames_[0].color_ : Color();
     billboard.enabled_ = true;
+    billboard.direction_ = startDir;
 
     return true;
 }

--- a/Source/Urho3D/Graphics/Renderer.cpp
+++ b/Source/Urho3D/Graphics/Renderer.cpp
@@ -180,7 +180,8 @@ static const char* geometryVSVariations[] =
     "",
     "SKINNED ",
     "INSTANCED ",
-    "BILLBOARD "
+    "BILLBOARD ",
+    "DIRBILLBOARD "
 };
 
 static const char* lightVSVariations[] =

--- a/bin/CoreData/Shaders/GLSL/Transform.glsl
+++ b/bin/CoreData/Shaders/GLSL/Transform.glsl
@@ -88,14 +88,29 @@ vec3 GetBillboardNormal()
 #endif
 
 #ifdef DIRBILLBOARD
-vec3 GetBillboardPos(vec4 iPos, vec3 iOffset, mat4 modelMatrix)
+mat3 GetFaceCameraRotation(vec3 cameraPos, vec3 position, vec3 direction)
 {
-    return (iPos * modelMatrix).xyz + iOffset;
+    vec3 cameraDir = normalize(position - cameraPos);
+    vec3 front = normalize(direction);
+    vec3 right = normalize(cross(front, cameraDir));
+    vec3 up = normalize(cross(front, right));
+
+    return mat3(
+        right.x, up.x, front.x,
+        right.y, up.y, front.y,
+        right.z, up.z, front.z
+    );
 }
 
-vec3 GetBillboardNormal()
+vec3 GetBillboardPos(vec4 iPos, vec3 iDirection, vec3 iCameraPos, mat4 modelMatrix)
 {
-    return iNormal;
+    return (iPos * modelMatrix).xyz + 
+        vec3(iTexCoord2.x, 0.0, iTexCoord2.y) * GetFaceCameraRotation(iCameraPos, iPos.xyz, iDirection);
+}
+
+vec3 GetBillboardNormal(vec4 iPos, vec3 iDirection, vec3 iCameraPos)
+{
+    return vec3(0.0, 1.0, 0.0) * GetFaceCameraRotation(iCameraPos, iPos.xyz, iDirection);
 }
 #endif
 
@@ -112,7 +127,7 @@ vec3 GetWorldPos(mat4 modelMatrix)
     #if defined(BILLBOARD)
         return GetBillboardPos(iPos, iTexCoord2, modelMatrix);
     #elif defined(DIRBILLBOARD)
-        return GetBillboardPos(iPos, iTangent.xyz, modelMatrix);
+        return GetBillboardPos(iPos, iNormal, iTangent.xyz, modelMatrix);
     #else
         return (iPos * modelMatrix).xyz;
     #endif
@@ -120,8 +135,10 @@ vec3 GetWorldPos(mat4 modelMatrix)
 
 vec3 GetWorldNormal(mat4 modelMatrix)
 {
-    #if defined(BILLBOARD) || defined(DIRBILLBOARD)
+    #if defined(BILLBOARD)
         return GetBillboardNormal();
+    #elif defined(DIRBILLBOARD)
+        return GetBillboardNormal(iPos, iNormal, iTangent.xyz);
     #else
         return normalize(iNormal * GetNormalMatrix(modelMatrix));
     #endif

--- a/bin/CoreData/Shaders/GLSL/Transform.glsl
+++ b/bin/CoreData/Shaders/GLSL/Transform.glsl
@@ -87,6 +87,18 @@ vec3 GetBillboardNormal()
 }
 #endif
 
+#ifdef DIRBILLBOARD
+vec3 GetBillboardPos(vec4 iPos, vec3 iOffset, mat4 modelMatrix)
+{
+    return (iPos * modelMatrix).xyz + iOffset;
+}
+
+vec3 GetBillboardNormal()
+{
+    return iNormal;
+}
+#endif
+
 #if defined(SKINNED)
     #define iModelMatrix GetSkinMatrix(iBlendWeights, iBlendIndices)
 #elif defined(INSTANCED)
@@ -99,6 +111,8 @@ vec3 GetWorldPos(mat4 modelMatrix)
 {
     #if defined(BILLBOARD)
         return GetBillboardPos(iPos, iTexCoord2, modelMatrix);
+    #elif defined(DIRBILLBOARD)
+        return GetBillboardPos(iPos, iTangent.xyz, modelMatrix);
     #else
         return (iPos * modelMatrix).xyz;
     #endif
@@ -106,7 +120,7 @@ vec3 GetWorldPos(mat4 modelMatrix)
 
 vec3 GetWorldNormal(mat4 modelMatrix)
 {
-    #if defined(BILLBOARD)
+    #if defined(BILLBOARD) || defined(DIRBILLBOARD)
         return GetBillboardNormal();
     #else
         return normalize(iNormal * GetNormalMatrix(modelMatrix));

--- a/bin/CoreData/Shaders/HLSL/Basic.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Basic.hlsl
@@ -19,6 +19,10 @@ void VS(float4 iPos : POSITION,
     #ifdef BILLBOARD
         float2 iSize : TEXCOORD1,
     #endif
+    #ifdef DIRBILLBOARD
+        float3 iNormal : NORMAL,
+        float4 iTangent : TANGENT,
+    #endif
     #ifdef DIFFMAP
         out float2 oTexCoord : TEXCOORD0,
     #endif

--- a/bin/CoreData/Shaders/HLSL/Basic.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Basic.hlsl
@@ -16,7 +16,7 @@ void VS(float4 iPos : POSITION,
     #ifdef INSTANCED
         float4x3 iModelInstance : TEXCOORD2,
     #endif
-    #ifdef BILLBOARD
+    #if defined(BILLBOARD) || defined(DIRBILLBOARD)
         float2 iSize : TEXCOORD1,
     #endif
     #ifdef DIRBILLBOARD

--- a/bin/CoreData/Shaders/HLSL/LitParticle.hlsl
+++ b/bin/CoreData/Shaders/HLSL/LitParticle.hlsl
@@ -21,7 +21,7 @@ void VS(float4 iPos : POSITION,
     #ifdef INSTANCED
         float4x3 iModelInstance : TEXCOORD2,
     #endif
-    #ifdef BILLBOARD
+    #if defined(BILLBOARD) || defined(DIRBILLBOARD)
         float2 iSize : TEXCOORD1,
     #endif
     #ifdef DIRBILLBOARD

--- a/bin/CoreData/Shaders/HLSL/LitParticle.hlsl
+++ b/bin/CoreData/Shaders/HLSL/LitParticle.hlsl
@@ -24,6 +24,9 @@ void VS(float4 iPos : POSITION,
     #ifdef BILLBOARD
         float2 iSize : TEXCOORD1,
     #endif
+    #ifdef DIRBILLBOARD
+        float4 iTangent : TANGENT,
+    #endif
     out float2 oTexCoord : TEXCOORD0,
     out float4 oWorldPos : TEXCOORD3,
     #if PERPIXEL

--- a/bin/CoreData/Shaders/HLSL/LitSolid.hlsl
+++ b/bin/CoreData/Shaders/HLSL/LitSolid.hlsl
@@ -28,7 +28,7 @@ void VS(float4 iPos : POSITION,
     #ifdef INSTANCED
         float4x3 iModelInstance : TEXCOORD2,
     #endif
-    #ifdef BILLBOARD
+    #if defined(BILLBOARD) || defined(DIRBILLBOARD)
         float2 iSize : TEXCOORD1,
     #endif
     #ifndef NORMALMAP

--- a/bin/CoreData/Shaders/HLSL/LitSolid.hlsl
+++ b/bin/CoreData/Shaders/HLSL/LitSolid.hlsl
@@ -18,7 +18,7 @@ void VS(float4 iPos : POSITION,
     #if defined(LIGHTMAP) || defined(AO)
         float2 iTexCoord2 : TEXCOORD1,
     #endif
-    #ifdef NORMALMAP
+    #if defined(NORMALMAP) || defined(DIRBILLBOARD)
         float4 iTangent : TANGENT,
     #endif
     #ifdef SKINNED

--- a/bin/CoreData/Shaders/HLSL/TerrainBlend.hlsl
+++ b/bin/CoreData/Shaders/HLSL/TerrainBlend.hlsl
@@ -48,7 +48,7 @@ void VS(float4 iPos : POSITION,
     #ifdef INSTANCED
         float4x3 iModelInstance : TEXCOORD2,
     #endif
-    #ifdef BILLBOARD
+    #if defined(BILLBOARD) || defined(DIRBILLBOARD)
         float2 iSize : TEXCOORD1,
     #endif
     #ifdef DIRBILLBOARD

--- a/bin/CoreData/Shaders/HLSL/TerrainBlend.hlsl
+++ b/bin/CoreData/Shaders/HLSL/TerrainBlend.hlsl
@@ -51,6 +51,9 @@ void VS(float4 iPos : POSITION,
     #ifdef BILLBOARD
         float2 iSize : TEXCOORD1,
     #endif
+    #ifdef DIRBILLBOARD
+        float4 iTangent : TANGENT,
+    #endif
     out float2 oTexCoord : TEXCOORD0,
     out float3 oNormal : TEXCOORD1,
     out float4 oWorldPos : TEXCOORD2,

--- a/bin/CoreData/Shaders/HLSL/Transform.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Transform.hlsl
@@ -48,6 +48,13 @@ float3 GetBillboardNormal()
 }
 #endif
 
+#ifdef DIRBILLBOARD
+float3 GetBillboardPos(float4 iPos, float3 iOffset, float4x3 modelMatrix)
+{
+    return mul(iPos, modelMatrix) + iOffset;
+}
+#endif
+
 #if defined(SKINNED)
     #define iModelMatrix GetSkinMatrix(iBlendWeights, iBlendIndices);
 #elif defined(INSTANCED)
@@ -56,14 +63,18 @@ float3 GetBillboardNormal()
     #define iModelMatrix cModel
 #endif
 
-#ifdef BILLBOARD
+#if defined(BILLBOARD)
     #define GetWorldPos(modelMatrix) GetBillboardPos(iPos, iSize, modelMatrix)
+#elif defined(DIRBILLBOARD)
+    #define GetWorldPos(modelMatrix) GetBillboardPos(iPos, iTangent.xyz, modelMatrix)
 #else
     #define GetWorldPos(modelMatrix) mul(iPos, modelMatrix)
 #endif
 
-#ifdef BILLBOARD
+#if defined(BILLBOARD)
     #define GetWorldNormal(modelMatrix) GetBillboardNormal()
+#elif defined(DIRBILLBOARD)
+    #define GetWorldNormal(modelMatrix) iNormal
 #else
     #define GetWorldNormal(modelMatrix) normalize(mul(iNormal, (float3x3)modelMatrix))
 #endif

--- a/bin/CoreData/Shaders/HLSL/Unlit.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Unlit.hlsl
@@ -17,7 +17,7 @@ void VS(float4 iPos : POSITION,
     #ifdef INSTANCED
         float4x3 iModelInstance : TEXCOORD2,
     #endif
-    #ifdef BILLBOARD
+    #if defined(BILLBOARD) || defined(DIRBILLBOARD)
         float2 iSize : TEXCOORD1,
     #endif
     #ifdef DIRBILLBOARD

--- a/bin/CoreData/Shaders/HLSL/Unlit.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Unlit.hlsl
@@ -20,6 +20,10 @@ void VS(float4 iPos : POSITION,
     #ifdef BILLBOARD
         float2 iSize : TEXCOORD1,
     #endif
+    #ifdef DIRBILLBOARD
+        float3 iNormal : NORMAL,
+        float4 iTangent : TANGENT,
+    #endif
     out float2 oTexCoord : TEXCOORD0,
     out float4 oWorldPos : TEXCOORD2,
     #ifdef VERTEXCOLOR

--- a/bin/CoreData/Shaders/HLSL/Vegetation.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Vegetation.hlsl
@@ -39,7 +39,7 @@ void VS(float4 iPos : POSITION,
     #if defined(LIGHTMAP) || defined(AO)
         float2 iTexCoord2 : TEXCOORD1,
     #endif
-    #ifdef NORMALMAP
+    #if defined(NORMALMAP) || defined(DIRBILLBOARD)
         float4 iTangent : TANGENT,
     #endif
     #ifdef SKINNED

--- a/bin/CoreData/Shaders/HLSL/Vegetation.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Vegetation.hlsl
@@ -49,7 +49,7 @@ void VS(float4 iPos : POSITION,
     #ifdef INSTANCED
         float4x3 iModelInstance : TEXCOORD2,
     #endif
-    #ifdef BILLBOARD
+    #if defined(BILLBOARD) || defined(DIRBILLBOARD)
         float2 iSize : TEXCOORD1,
     #endif
     #ifndef NORMALMAP

--- a/bin/Data/Particle/Burst.xml
+++ b/bin/Data/Particle/Burst.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<particleeffect>
+	<material name="Materials/Particle.xml" />
+	<numparticles value="200" />
+	<updateinvisible enable="false" />
+	<relative enable="true" />
+	<scaled enable="true" />
+	<sorted enable="false" />
+	<animlodbias value="0" />
+	<emittertype value="Sphere" />
+	<emittersize value="0 0 0" />
+	<direction min="-1 -1 -1" max="1 1 1" />
+	<constantforce value="0 -20 0" />
+	<dampingforce value="0" />
+	<activetime value="0" />
+	<inactivetime value="0" />
+	<emissionrate min="2000" max="2000" />
+	<particlesize min="0.03 0.3" max="0.06 1" />
+	<timetolive min="1" max="1" />
+	<velocity min="8" max="10" />
+	<rotation min="0" max="0" />
+	<rotationspeed min="0" max="0" />
+	<sizedelta add="0" mul="0.01" />
+	<faceCameraMode value="Rotate Along Direction" />
+	<colorfade color="1 1 1 1" time="0" />
+	<colorfade color="0.5 0.75 1 1" time="0.5" />
+	<colorfade color="0 0 0 0" time="1" />
+</particleeffect>

--- a/bin/Data/Scripts/Editor/AttributeEditor.as
+++ b/bin/Data/Scripts/Editor/AttributeEditor.as
@@ -1512,6 +1512,7 @@ void InitVectorStructs()
         "   UV Coordinates",
         "   Color",
         "   Rotation",
+        "   Direction",
         "   Is Enabled"
     };
     vectorStructs.Push(VectorStruct("BillboardSet", "Billboards", billboardVariables, 1));

--- a/bin/Data/Scripts/Editor/EditorParticleEffect.as
+++ b/bin/Data/Scripts/Editor/EditorParticleEffect.as
@@ -128,6 +128,7 @@ void CreateParticleEffectEditor()
     SubscribeToEvent(particleEffectWindow.GetChild("Scaled", true), "Toggled", "EditParticleEffectScaled");
     SubscribeToEvent(particleEffectWindow.GetChild("Sorted", true), "Toggled", "EditParticleEffectSorted");
     SubscribeToEvent(particleEffectWindow.GetChild("Relative", true), "Toggled", "EditParticleEffectRelative");
+    SubscribeToEvent(particleEffectWindow.GetChild("FaceCameraMode", true), "ItemSelected", "EditParticleEffectFaceCameraMode");
     
     SubscribeToEvent(particleEffectWindow.GetChild("ResetViewport", true), "Released", "ParticleEffectResetViewport");
     SubscribeToEvent(particleEffectWindow.GetChild("ShowGrid", true), "Toggled", "ParticleEffectShowGrid");
@@ -692,6 +693,50 @@ void EditParticleEffectEmitterShape(StringHash eventType, VariantMap& eventData)
             editParticleEffect.emitterType = EMITTER_SPHERE;
             break;
     }
+
+    EndParticleEffectEdit();
+}
+
+void EditParticleEffectFaceCameraMode(StringHash eventType, VariantMap& eventData)
+{
+    if (inParticleEffectRefresh)
+        return;
+
+    if (editParticleEffect is null)
+        return;
+
+    BeginParticleEffectEdit();
+
+    DropDownList@ element = eventData["Element"].GetPtr();
+
+    switch (element.selection)
+    {
+        case 0:
+            editParticleEffect.faceCameraMode = FC_NONE;
+            break;
+
+        case 1:
+            editParticleEffect.faceCameraMode = FC_ROTATE_XYZ;
+            break;
+
+        case 2:
+            editParticleEffect.faceCameraMode = FC_ROTATE_Y;
+            break;
+
+        case 3:
+            editParticleEffect.faceCameraMode = FC_LOOKAT_XYZ;
+            break;
+
+        case 4:
+            editParticleEffect.faceCameraMode = FC_LOOKAT_Y;
+            break;
+
+        case 5:
+            editParticleEffect.faceCameraMode = FC_DIRECTION;
+            break;
+    }
+
+    particleEffectEmitter.ApplyEffect();
 
     EndParticleEffectEdit();
 }
@@ -1407,6 +1452,28 @@ void RefreshParticleEffectBasicAttributes()
             break;
         case EMITTER_SPHERE:
             cast<DropDownList>(particleEffectWindow.GetChild("EmitterShape", true)).selection = 1;
+            break;
+    }
+
+    switch (editParticleEffect.faceCameraMode)
+    {
+        case FC_NONE:
+            cast<DropDownList>(particleEffectWindow.GetChild("FaceCameraMode", true)).selection = 0;
+            break;
+        case FC_ROTATE_XYZ:
+            cast<DropDownList>(particleEffectWindow.GetChild("FaceCameraMode", true)).selection = 1;
+            break;
+        case FC_ROTATE_Y:
+            cast<DropDownList>(particleEffectWindow.GetChild("FaceCameraMode", true)).selection = 2;
+            break;
+        case FC_LOOKAT_XYZ:
+            cast<DropDownList>(particleEffectWindow.GetChild("FaceCameraMode", true)).selection = 3;
+            break;
+        case FC_LOOKAT_Y:
+            cast<DropDownList>(particleEffectWindow.GetChild("FaceCameraMode", true)).selection = 4;
+            break;
+        case FC_DIRECTION:
+            cast<DropDownList>(particleEffectWindow.GetChild("FaceCameraMode", true)).selection = 5;
             break;
     }
 

--- a/bin/Data/UI/EditorParticleEffectWindow.xml
+++ b/bin/Data/UI/EditorParticleEffectWindow.xml
@@ -713,6 +713,47 @@
                                     </element>
                                 </element>
                             </element>
+                            <element>
+                                <!-- Face Camera Mode -->
+                                <attribute name="Min Size" value="0 16" />
+                                <attribute name="Max Size" value="2147483647 16" />
+                                <attribute name="Layout Mode" value="Horizontal" />
+                                <attribute name="Layout Spacing" value="10" />
+                                <element type="Text" style="EditorAttributeText">
+                                    <attribute name="Text" value="Face Camera Mode" />
+                                </element>
+                                <element type="DropDownList">
+                                    <attribute name="Name" value="FaceCameraMode" />
+                                    <attribute name="Resize Popup" value="true" />
+                                    <!-- Skip style processing as the purpose of below tags is to populate the content element -->
+                                    <element type="Window" internal="true" popup="true" style="none">
+                                        <element type="ListView" internal="true" style="none">
+                                            <element type="BorderImage" internal="true" style="none">
+                                                <element internal="true" style="none">
+                                                    <element type="Text" style="FileSelectorFilterText">
+                                                        <attribute name="Text" value="None" />
+                                                    </element>
+                                                    <element type="Text" style="FileSelectorFilterText">
+                                                        <attribute name="Text" value="Rotate XYZ" />
+                                                    </element>
+                                                    <element type="Text" style="FileSelectorFilterText">
+                                                        <attribute name="Text" value="Rotate Y" />
+                                                    </element>
+                                                    <element type="Text" style="FileSelectorFilterText">
+                                                        <attribute name="Text" value="LookAt XYZ" />
+                                                    </element>
+                                                    <element type="Text" style="FileSelectorFilterText">
+                                                        <attribute name="Text" value="LookAt Y" />
+                                                    </element>
+                                                    <element type="Text" style="FileSelectorFilterText">
+                                                        <attribute name="Text" value="Rotate Along Direction" />
+                                                    </element>
+                                                </element>
+                                            </element>
+                                        </element>
+                                    </element>
+                                </element>
+                            </element>
 
                             <!-- End of Renderer Attributes -->
                         </element>


### PR DESCRIPTION
This pull request will add particle direction inspired by Unity stretched billboard particles. If any of you have tried that on Unity, stretched particle can create pseudo 3d effect despite still using billboard. It can be really useful for sparking effects and many other stuffs. 

Screenshot:
![partikel_1](https://cloud.githubusercontent.com/assets/5253453/12228806/c5337502-b872-11e5-8836-46a80402e7dd.png)

You can see this particle in action at example 'Particle/Burst.xml' or just see this youtube video: https://www.youtube.com/watch?v=zR7KtF6qtaU

About the implementation, I modify the billboard object to store direction. This data only works if new face camera mode FC_DIRECTION is used. If this mode is used, billboard will rotate facing camera with direction as axis, so it will create pseudo 3D effect. Because every billboard has different rotation, Urho needs to calculate rotation for every billboard. For now, CPU is doing those calculation, but I have plan to move them to the GPU.

What do you guys think?