### PR TITLE
Add view matrix

### DIFF
--- a/Source/Urho3D/Graphics/DebugRenderer.cpp
+++ b/Source/Urho3D/Graphics/DebugRenderer.cpp
@@ -498,6 +498,8 @@ void DebugRenderer::Render()
     graphics->SetStencilTest(false);
     graphics->SetShaders(vs, ps);
     graphics->SetShaderParameter(VSP_MODEL, Matrix3x4::IDENTITY);
+    graphics->SetShaderParameter(VSP_VIEW, view_);
+    graphics->SetShaderParameter(VSP_VIEWINV, view_.Inverse());
     graphics->SetShaderParameter(VSP_VIEWPROJ, projection_ * view_);
     graphics->SetShaderParameter(PSP_MATDIFFCOLOR, Color(1.0f, 1.0f, 1.0f, 1.0f));
     graphics->SetVertexBuffer(vertexBuffer_);

--- a/Source/Urho3D/Graphics/GraphicsDefs.cpp
+++ b/Source/Urho3D/Graphics/GraphicsDefs.cpp
@@ -49,6 +49,8 @@ extern URHO3D_API const StringHash VSP_GBUFFEROFFSETS("GBufferOffsets");
 extern URHO3D_API const StringHash VSP_LIGHTDIR("LightDir");
 extern URHO3D_API const StringHash VSP_LIGHTPOS("LightPos");
 extern URHO3D_API const StringHash VSP_MODEL("Model");
+extern URHO3D_API const StringHash VSP_VIEW("View");
+extern URHO3D_API const StringHash VSP_VIEWINV("ViewInv");
 extern URHO3D_API const StringHash VSP_VIEWPROJ("ViewProj");
 extern URHO3D_API const StringHash VSP_UOFFSET("UOffset");
 extern URHO3D_API const StringHash VSP_VOFFSET("VOffset");

--- a/Source/Urho3D/Graphics/GraphicsDefs.h
+++ b/Source/Urho3D/Graphics/GraphicsDefs.h
@@ -305,6 +305,8 @@ extern URHO3D_API const StringHash VSP_GBUFFEROFFSETS;
 extern URHO3D_API const StringHash VSP_LIGHTDIR;
 extern URHO3D_API const StringHash VSP_LIGHTPOS;
 extern URHO3D_API const StringHash VSP_MODEL;
+extern URHO3D_API const StringHash VSP_VIEW;
+extern URHO3D_API const StringHash VSP_VIEWINV;
 extern URHO3D_API const StringHash VSP_VIEWPROJ;
 extern URHO3D_API const StringHash VSP_UOFFSET;
 extern URHO3D_API const StringHash VSP_VOFFSET;

--- a/Source/Urho3D/Graphics/Renderer.cpp
+++ b/Source/Urho3D/Graphics/Renderer.cpp
@@ -1418,6 +1418,8 @@ void Renderer::OptimizeLightByStencil(Light* light, Camera* camera)
         graphics_->SetDepthWrite(false);
         graphics_->SetStencilTest(true, CMP_ALWAYS, OP_REF, OP_KEEP, OP_KEEP, lightStencilValue_);
         graphics_->SetShaders(graphics_->GetShader(VS, "Stencil"), graphics_->GetShader(PS, "Stencil"));
+        graphics_->SetShaderParameter(VSP_VIEW, view);
+        graphics_->SetShaderParameter(VSP_VIEWINV, view.Inverse());
         graphics_->SetShaderParameter(VSP_VIEWPROJ, projection * view);
         graphics_->SetShaderParameter(VSP_MODEL, light->GetVolumeTransform(camera));
 

--- a/Source/Urho3D/Graphics/View.cpp
+++ b/Source/Urho3D/Graphics/View.cpp
@@ -756,6 +756,8 @@ void View::SetCameraShaderParameters(Camera* camera, bool setProjection)
         projection.m23_ += projection.m33_ * constantBias;
 #endif
 
+        graphics_->SetShaderParameter(VSP_VIEWINV, camera->GetView().Inverse());
+        graphics_->SetShaderParameter(VSP_VIEW, camera->GetView());
         graphics_->SetShaderParameter(VSP_VIEWPROJ, projection * camera->GetView());
     }
 }

--- a/bin/CoreData/Shaders/GLSL/Uniforms.glsl
+++ b/bin/CoreData/Shaders/GLSL/Uniforms.glsl
@@ -23,6 +23,8 @@ uniform vec4 cGBufferOffsets;
 uniform vec3 cLightDir;
 uniform vec4 cLightPos;
 uniform mat4 cModel;
+uniform mat4 cView;
+uniform mat4 cViewInv;
 uniform mat4 cViewProj;
 uniform vec4 cUOffset;
 uniform vec4 cVOffset;
@@ -99,6 +101,8 @@ uniform CameraVS
     vec4 cDepthMode;
     vec3 cFrustumSize;
     vec4 cGBufferOffsets;
+    mat4 cView;
+    mat4 cViewInv;
     mat4 cViewProj;
     vec4 cClipPlane;
 };

--- a/bin/CoreData/Shaders/HLSL/Uniforms.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Uniforms.hlsl
@@ -22,6 +22,8 @@ uniform float4 cGBufferOffsets;
 uniform float3 cLightDir;
 uniform float4 cLightPos;
 uniform float4x3 cModel;
+uniform float4x3 cView;
+uniform float4x3 cViewInv;
 uniform float4x4 cViewProj;
 uniform float4 cUOffset;
 uniform float4 cVOffset;
@@ -89,6 +91,8 @@ cbuffer CameraVS : register(b1)
     float4 cDepthMode;
     float3 cFrustumSize;
     float4 cGBufferOffsets;
+    float3x4 cView;
+    float3x4 cViewInv;
     float4x4 cViewProj;
     float4 cClipPlane;
 }


### PR DESCRIPTION
Added a view matrix uniform to the shader code. The impetus for this is to allow me to convert world-space normals into view-space normals to perform SSAO calculations in the rendering pipeline. 