### PR TITLE
C89 compliance in SDL_windowsevents.c when compiling under MSVC2012

### DIFF
--- a/Source/ThirdParty/SDL/src/video/windows/SDL_windowsevents.c
+++ b/Source/ThirdParty/SDL/src/video/windows/SDL_windowsevents.c
@@ -419,11 +419,13 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
     case WM_MBUTTONDOWN:
     case WM_XBUTTONDOWN:
         {
+			SDL_Mouse *mouse;
+
             // Urho3D: in_title_click may be erroneously left on with non-Aero styles, causing the hidden mouse centering to stop working.
             // To work around, reset whenever a normal mouse button up/down event is received
             data->in_title_click = SDL_FALSE;
 
-            SDL_Mouse *mouse = SDL_GetMouse();
+            mouse = SDL_GetMouse();
             if (!emulatedMouse && (!mouse->relative_mode || mouse->relative_mode_warp)) {
                 WIN_CheckWParamMouseButtons(wParam, data);
             }

--- a/Source/ThirdParty/SDL/src/video/windows/SDL_windowsevents.c
+++ b/Source/ThirdParty/SDL/src/video/windows/SDL_windowsevents.c
@@ -419,7 +419,7 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
     case WM_MBUTTONDOWN:
     case WM_XBUTTONDOWN:
         {
-			SDL_Mouse *mouse;
+            SDL_Mouse *mouse;
 
             // Urho3D: in_title_click may be erroneously left on with non-Aero styles, causing the hidden mouse centering to stop working.
             // To work around, reset whenever a normal mouse button up/down event is received


### PR DESCRIPTION
The error message is:
```
error C2275: 'SDL_Mouse' : illegal use of this type as an expression SDL_windowsevents.c    426    1    SDL
```
This happens because MSVC will compile all ```*.c``` files using the C compiler in C89 mode, meaning all variables must be declared at the beginning of each scope. A change previously made by an Urho3D developer violated this constraint (see diff for more info).

GCC and clang will by default ignore such errors and only generate a warning.