### PR TITLE
Input mousemode updates

### DIFF
--- a/Source/Samples/01_HelloWorld/HelloWorld.cpp
+++ b/Source/Samples/01_HelloWorld/HelloWorld.cpp
@@ -51,6 +51,9 @@ void HelloWorld::Start()
     // like the ScreenMode event sent by the Graphics subsystem when opening the application window. To catch those as well we
     // could subscribe in the constructor instead.
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_FREE);
 }
 
 void HelloWorld::CreateText()

--- a/Source/Samples/02_HelloGUI/HelloGUI.cpp
+++ b/Source/Samples/02_HelloGUI/HelloGUI.cpp
@@ -71,6 +71,9 @@ void HelloGUI::Start()
 
     // Create a draggable Fish
     CreateDraggableFish();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_FREE);
 }
 
 void HelloGUI::InitControls()
@@ -181,7 +184,7 @@ void HelloGUI::CreateDraggableFish()
 
 void HelloGUI::HandleDragBegin(StringHash eventType, VariantMap& eventData)
 {
-    // Get UIElement relative position where input (touch or click) occured (top-left = IntVector2(0,0))
+    // Get UIElement relative position where input (touch or click) occurred (top-left = IntVector2(0,0))
     dragBeginPosition_ = IntVector2(eventData["ElementX"].GetInt(), eventData["ElementY"].GetInt());
 }
 
@@ -198,7 +201,8 @@ void HelloGUI::HandleDragEnd(StringHash eventType, VariantMap& eventData) // For
 
 void HelloGUI::HandleClosePressed(StringHash eventType, VariantMap& eventData)
 {
-    engine_->Exit();
+    if (GetPlatform() != "Web")
+        engine_->Exit();
 }
 
 void HelloGUI::HandleControlClicked(StringHash eventType, VariantMap& eventData)

--- a/Source/Samples/03_Sprites/Sprites.cpp
+++ b/Source/Samples/03_Sprites/Sprites.cpp
@@ -54,6 +54,9 @@ void Sprites::Start()
 
     // Hook up to the frame update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_FREE);
 }
 
 void Sprites::CreateSprites()

--- a/Source/Samples/04_StaticScene/StaticScene.cpp
+++ b/Source/Samples/04_StaticScene/StaticScene.cpp
@@ -63,6 +63,9 @@ void StaticScene::Start()
 
     // Hook up to the frame update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_RELATIVE);
 }
 
 void StaticScene::CreateScene()

--- a/Source/Samples/05_AnimatingScene/AnimatingScene.cpp
+++ b/Source/Samples/05_AnimatingScene/AnimatingScene.cpp
@@ -67,6 +67,9 @@ void AnimatingScene::Start()
 
     // Hook up to the frame update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_RELATIVE);
 }
 
 void AnimatingScene::CreateScene()

--- a/Source/Samples/06_SkeletalAnimation/SkeletalAnimation.cpp
+++ b/Source/Samples/06_SkeletalAnimation/SkeletalAnimation.cpp
@@ -71,6 +71,9 @@ void SkeletalAnimation::Start()
 
     // Hook up to the frame update and render post-update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_ABSOLUTE);
 }
 
 void SkeletalAnimation::CreateScene()

--- a/Source/Samples/07_Billboards/Billboards.cpp
+++ b/Source/Samples/07_Billboards/Billboards.cpp
@@ -68,6 +68,9 @@ void Billboards::Start()
 
     // Hook up to the frame update and render post-update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_ABSOLUTE);
 }
 
 void Billboards::CreateScene()

--- a/Source/Samples/08_Decals/Decals.cpp
+++ b/Source/Samples/08_Decals/Decals.cpp
@@ -68,6 +68,9 @@ void Decals::Start()
 
     // Hook up to the frame update and render post-update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_RELATIVE);
 }
 
 void Decals::CreateScene()

--- a/Source/Samples/09_MultipleViewports/MultipleViewports.cpp
+++ b/Source/Samples/09_MultipleViewports/MultipleViewports.cpp
@@ -68,6 +68,9 @@ void MultipleViewports::Start()
 
     // Hook up to the frame update and render post-update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_ABSOLUTE);
 }
 
 void MultipleViewports::CreateScene()

--- a/Source/Samples/10_RenderToTexture/RenderToTexture.cpp
+++ b/Source/Samples/10_RenderToTexture/RenderToTexture.cpp
@@ -70,6 +70,9 @@ void RenderToTexture::Start()
 
     // Hook up to the frame update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_RELATIVE);
 }
 
 void RenderToTexture::CreateScene()

--- a/Source/Samples/11_Physics/Physics.cpp
+++ b/Source/Samples/11_Physics/Physics.cpp
@@ -72,6 +72,9 @@ void Physics::Start()
 
     // Hook up to the frame update and render post-update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_RELATIVE);
 }
 
 void Physics::CreateScene()

--- a/Source/Samples/12_PhysicsStressTest/PhysicsStressTest.cpp
+++ b/Source/Samples/12_PhysicsStressTest/PhysicsStressTest.cpp
@@ -72,6 +72,9 @@ void PhysicsStressTest::Start()
 
     // Hook up to the frame update and render post-update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_RELATIVE);
 }
 
 void PhysicsStressTest::CreateScene()

--- a/Source/Samples/13_Ragdolls/Ragdolls.cpp
+++ b/Source/Samples/13_Ragdolls/Ragdolls.cpp
@@ -74,6 +74,9 @@ void Ragdolls::Start()
 
     // Hook up to the frame update and render post-update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_ABSOLUTE);
 }
 
 void Ragdolls::CreateScene()

--- a/Source/Samples/14_SoundEffects/SoundEffects.cpp
+++ b/Source/Samples/14_SoundEffects/SoundEffects.cpp
@@ -80,6 +80,9 @@ void SoundEffects::Start()
 
     // Create the user interface
     CreateUI();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_FREE);
 }
 
 void SoundEffects::CreateUI()

--- a/Source/Samples/15_Navigation/Navigation.cpp
+++ b/Source/Samples/15_Navigation/Navigation.cpp
@@ -68,6 +68,9 @@ void Navigation::Start()
 
     // Hook up to the frame update and render post-update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_RELATIVE);
 }
 
 void Navigation::CreateScene()

--- a/Source/Samples/16_Chat/Chat.cpp
+++ b/Source/Samples/16_Chat/Chat.cpp
@@ -75,6 +75,9 @@ void Chat::Start()
 
     // Subscribe to UI and network events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_FREE);
 }
 
 void Chat::CreateUI()

--- a/Source/Samples/17_SceneReplication/SceneReplication.cpp
+++ b/Source/Samples/17_SceneReplication/SceneReplication.cpp
@@ -90,6 +90,9 @@ void SceneReplication::Start()
 
     // Hook up to necessary events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_RELATIVE);
 }
 
 void SceneReplication::CreateScene()

--- a/Source/Samples/18_CharacterDemo/CharacterDemo.cpp
+++ b/Source/Samples/18_CharacterDemo/CharacterDemo.cpp
@@ -81,6 +81,9 @@ void CharacterDemo::Start()
 
     // Subscribe to necessary events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_RELATIVE);
 }
 
 void CharacterDemo::CreateScene()

--- a/Source/Samples/19_VehicleDemo/VehicleDemo.cpp
+++ b/Source/Samples/19_VehicleDemo/VehicleDemo.cpp
@@ -76,6 +76,9 @@ void VehicleDemo::Start()
 
     // Subscribe to necessary events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_RELATIVE);
 }
 
 void VehicleDemo::CreateScene()

--- a/Source/Samples/20_HugeObjectCount/HugeObjectCount.cpp
+++ b/Source/Samples/20_HugeObjectCount/HugeObjectCount.cpp
@@ -67,6 +67,9 @@ void HugeObjectCount::Start()
 
     // Hook up to the frame update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_RELATIVE);
 }
 
 void HugeObjectCount::CreateScene()

--- a/Source/Samples/21_AngelScriptIntegration/AngelScriptIntegration.cpp
+++ b/Source/Samples/21_AngelScriptIntegration/AngelScriptIntegration.cpp
@@ -69,6 +69,9 @@ void AngelScriptIntegration::Start()
 
     // Hook up to the frame update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_RELATIVE);
 }
 
 void AngelScriptIntegration::CreateScene()

--- a/Source/Samples/22_LuaIntegration/LuaIntegration.cpp
+++ b/Source/Samples/22_LuaIntegration/LuaIntegration.cpp
@@ -70,6 +70,9 @@ void LuaIntegration::Start()
 
     // Hook up to the frame update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_RELATIVE);
 }
 
 void LuaIntegration::CreateScene()

--- a/Source/Samples/23_Water/Water.cpp
+++ b/Source/Samples/23_Water/Water.cpp
@@ -70,6 +70,9 @@ void Water::Start()
 
     // Hook up to the frame update event
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_RELATIVE);
 }
 
 void Water::CreateScene()

--- a/Source/Samples/24_Urho2DSprite/Urho2DSprite.cpp
+++ b/Source/Samples/24_Urho2DSprite/Urho2DSprite.cpp
@@ -69,6 +69,9 @@ void Urho2DSprite::Start()
 
     // Hook up to the frame update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_FREE);
 }
 
 void Urho2DSprite::CreateScene()

--- a/Source/Samples/25_Urho2DParticle/Urho2DParticle.cpp
+++ b/Source/Samples/25_Urho2DParticle/Urho2DParticle.cpp
@@ -51,7 +51,7 @@ void Urho2DParticle::Start()
     // Execute base class startup
     Sample::Start();
 
-    // Set mouse visibile
+    // Set mouse visible
     Input* input = GetSubsystem<Input>();
     input->SetMouseVisible(true);
 
@@ -66,6 +66,9 @@ void Urho2DParticle::Start()
 
     // Hook up to the frame update events
     SubscribeToEvents();
+    
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_FREE);
 }
 
 void Urho2DParticle::CreateScene()

--- a/Source/Samples/26_ConsoleInput/ConsoleInput.cpp
+++ b/Source/Samples/26_ConsoleInput/ConsoleInput.cpp
@@ -70,6 +70,7 @@ void ConsoleInput::Start()
 
     // Subscribe key down event
     SubscribeToEvent(E_KEYDOWN, URHO3D_HANDLER(ConsoleInput, HandleEscKeyDown));
+    UnsubscribeFromEvent(E_KEYUP);
 
     // Hide logo to make room for the console
     SetLogoVisible(false);
@@ -85,6 +86,9 @@ void ConsoleInput::Start()
 
     // Show OS mouse cursor
     GetSubsystem<Input>()->SetMouseVisible(true);
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_FREE);
 
     // Open the operating system console window (for stdin / stdout) if not open yet
     OpenConsoleWindow();
@@ -114,7 +118,7 @@ void ConsoleInput::HandleUpdate(StringHash eventType, VariantMap& eventData)
 void ConsoleInput::HandleEscKeyDown(StringHash eventType, VariantMap& eventData)
 {
     // Unlike the other samples, exiting the engine when ESC is pressed instead of just closing the console
-    if (eventData[KeyDown::P_KEY].GetInt() == KEY_ESC)
+    if (eventData[KeyDown::P_KEY].GetInt() == KEY_ESC && GetPlatform() != "Web")
         engine_->Exit();
 }
 

--- a/Source/Samples/27_Urho2DPhysics/Urho2DPhysics.cpp
+++ b/Source/Samples/27_Urho2DPhysics/Urho2DPhysics.cpp
@@ -70,6 +70,9 @@ void Urho2DPhysics::Start()
 
     // Hook up to the frame update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_FREE);
 }
 
 void Urho2DPhysics::CreateScene()

--- a/Source/Samples/28_Urho2DPhysicsRope/Urho2DPhysicsRope.cpp
+++ b/Source/Samples/28_Urho2DPhysicsRope/Urho2DPhysicsRope.cpp
@@ -68,6 +68,9 @@ void Urho2DPhysicsRope::Start()
 
     // Hook up to the frame update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_FREE);
 }
 
 void Urho2DPhysicsRope::CreateScene()

--- a/Source/Samples/29_SoundSynthesis/SoundSynthesis.cpp
+++ b/Source/Samples/29_SoundSynthesis/SoundSynthesis.cpp
@@ -67,6 +67,9 @@ void SoundSynthesis::Start()
 
     // Hook up to the frame update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_FREE);
 }
 
 void SoundSynthesis::CreateSound()

--- a/Source/Samples/30_LightAnimation/LightAnimation.cpp
+++ b/Source/Samples/30_LightAnimation/LightAnimation.cpp
@@ -65,6 +65,9 @@ void LightAnimation::Start()
 
     // Hook up to the frame update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_RELATIVE);
 }
 
 void LightAnimation::CreateScene()

--- a/Source/Samples/31_MaterialAnimation/MaterialAnimation.cpp
+++ b/Source/Samples/31_MaterialAnimation/MaterialAnimation.cpp
@@ -64,6 +64,9 @@ void MaterialAnimation::Start()
 
     // Hook up to the frame update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_RELATIVE);
 }
 
 void MaterialAnimation::CreateScene()

--- a/Source/Samples/32_Urho2DConstraints/Urho2DConstraints.cpp
+++ b/Source/Samples/32_Urho2DConstraints/Urho2DConstraints.cpp
@@ -88,6 +88,9 @@ void Urho2DConstraints::Start()
 
     // Hook up to the frame update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_FREE);
 }
 
 void Urho2DConstraints::CreateScene()

--- a/Source/Samples/33_Urho2DSpriterAnimation/Urho2DSpriterAnimation.cpp
+++ b/Source/Samples/33_Urho2DSpriterAnimation/Urho2DSpriterAnimation.cpp
@@ -61,6 +61,9 @@ void Urho2DSpriterAnimation::Start()
     // Setup the viewport for displaying the scene
     SetupViewport();
 
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_FREE);
+
     // Hook up to the frame update events
     SubscribeToEvents();
 }
@@ -158,7 +161,6 @@ void Urho2DSpriterAnimation::SubscribeToEvents()
     // Subscribe HandleUpdate() function for processing update events
     SubscribeToEvent(E_UPDATE, URHO3D_HANDLER(Urho2DSpriterAnimation, HandleUpdate));
     SubscribeToEvent(E_MOUSEBUTTONDOWN, URHO3D_HANDLER(Urho2DSpriterAnimation, HandleMouseButtonDown));
-
 
     // Unsubscribe the SceneUpdate event from base class to prevent camera pitch and yaw in 2D sample
     UnsubscribeFromEvent(E_SCENEUPDATE);

--- a/Source/Samples/34_DynamicGeometry/DynamicGeometry.cpp
+++ b/Source/Samples/34_DynamicGeometry/DynamicGeometry.cpp
@@ -71,6 +71,9 @@ void DynamicGeometry::Start()
 
     // Hook up to the frame update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_RELATIVE);
 }
 
 void DynamicGeometry::CreateScene()

--- a/Source/Samples/35_SignedDistanceFieldText/SignedDistanceFieldText.cpp
+++ b/Source/Samples/35_SignedDistanceFieldText/SignedDistanceFieldText.cpp
@@ -64,6 +64,9 @@ void SignedDistanceFieldText::Start()
 
     // Hook up to the frame update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_RELATIVE);
 }
 
 void SignedDistanceFieldText::CreateScene()

--- a/Source/Samples/36_Urho2DTileMap/Urho2DTileMap.cpp
+++ b/Source/Samples/36_Urho2DTileMap/Urho2DTileMap.cpp
@@ -63,6 +63,9 @@ void Urho2DTileMap::Start()
 
     // Hook up to the frame update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_FREE);
 }
 
 void Urho2DTileMap::CreateScene()

--- a/Source/Samples/37_UIDrag/UIDrag.cpp
+++ b/Source/Samples/37_UIDrag/UIDrag.cpp
@@ -53,6 +53,9 @@ void UIDrag::Start()
 
     // Hook up to the frame update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_FREE);
 }
 
 void UIDrag::CreateGUI()

--- a/Source/Samples/38_SceneAndUILoad/SceneAndUILoad.cpp
+++ b/Source/Samples/38_SceneAndUILoad/SceneAndUILoad.cpp
@@ -59,6 +59,9 @@ void SceneAndUILoad::Start()
 
     // Subscribe to global events for camera movement
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_RELATIVE);
 }
 
 void SceneAndUILoad::CreateScene()

--- a/Source/Samples/39_CrowdNavigation/CrowdNavigation.cpp
+++ b/Source/Samples/39_CrowdNavigation/CrowdNavigation.cpp
@@ -75,6 +75,9 @@ void CrowdNavigation::Start()
 
     // Hook up to the frame update and render post-update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_ABSOLUTE);
 }
 
 void CrowdNavigation::CreateScene()

--- a/Source/Samples/40_Localization/L10n.cpp
+++ b/Source/Samples/40_Localization/L10n.cpp
@@ -62,6 +62,9 @@ void L10n::Start()
 
     // Init the user interface
     CreateGUI();
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_FREE);
 }
 
 void L10n::InitLocalizationSystem()
@@ -215,7 +218,8 @@ void L10n::HandleChangeLangButtonPressed(StringHash eventType, VariantMap& event
 
 void L10n::HandleQuitButtonPressed(StringHash eventType, VariantMap& eventData)
 {
-    engine_->Exit();
+    if (GetPlatform() != "Web")
+        engine_->Exit();
 }
 
 // You can manually change texts, sprites and other aspects of the game when language is changed

--- a/Source/Samples/41_DatabaseDemo/DatabaseDemo.cpp
+++ b/Source/Samples/41_DatabaseDemo/DatabaseDemo.cpp
@@ -79,6 +79,9 @@ void DatabaseDemo::Start()
     // Show OS mouse cursor
     GetSubsystem<Input>()->SetMouseVisible(true);
 
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_FREE);
+
     // Open the operating system console window (for stdin / stdout) if not open yet
     OpenConsoleWindow();
 

--- a/Source/Samples/Sample.h
+++ b/Source/Samples/Sample.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <Urho3D/Engine/Application.h>
+#include <Urho3D/Input/Input.h>
 
 namespace Urho3D
 {
@@ -69,6 +70,8 @@ protected:
     virtual String GetScreenJoystickPatchString() const { return String::EMPTY; }
     /// Initialize touch input on mobile platform.
     void InitTouchInput();
+    /// Initialize mouse mode on non-web platform.
+    void InitMouseMode();
     /// Control logo visibility.
     void SetLogoVisible(bool enable);
 
@@ -84,6 +87,8 @@ protected:
     float pitch_;
     /// Flag to indicate whether touch input has been enabled.
     bool touchEnabled_;
+    /// Mouse mode option to use in the sample.
+    MouseMode useMouseMode_;
 
 private:
     /// Create logo.
@@ -92,8 +97,14 @@ private:
     void SetWindowTitleAndIcon();
     /// Create console and debug HUD.
     void CreateConsoleAndDebugHud();
+    /// Handle request for mouse mode on web platform.
+    void HandleMouseModeRequest(StringHash eventType, VariantMap& eventData);
+    /// Handle request for mouse mode change on web platform.
+    void HandleMouseModeChange(StringHash eventType, VariantMap& eventData);
     /// Handle key down event to process key controls common to all samples.
     void HandleKeyDown(StringHash eventType, VariantMap& eventData);
+    /// Handle key up event to process key controls common to all samples.
+    void HandleKeyUp(StringHash eventType, VariantMap& eventData);
     /// Handle scene update event to control camera's pitch and yaw for all samples.
     void HandleSceneUpdate(StringHash eventType, VariantMap& eventData);
     /// Handle touch begin event to initialize touch input on desktop platform.

--- a/Source/Samples/Sample.h
+++ b/Source/Samples/Sample.h
@@ -71,7 +71,7 @@ protected:
     /// Initialize touch input on mobile platform.
     void InitTouchInput();
     /// Initialize mouse mode on non-web platform.
-    void InitMouseMode();
+    void InitMouseMode(MouseMode mode);
     /// Control logo visibility.
     void SetLogoVisible(bool enable);
 

--- a/Source/Samples/Sample.inl
+++ b/Source/Samples/Sample.inl
@@ -39,6 +39,7 @@
 #include <Urho3D/Core/Timer.h>
 #include <Urho3D/UI/UI.h>
 #include <Urho3D/Resource/XMLFile.h>
+#include <Urho3D/IO/Log.h>
 
 Sample::Sample(Context* context) :
     Application(context),
@@ -47,7 +48,8 @@ Sample::Sample(Context* context) :
     touchEnabled_(false),
     screenJoystickIndex_(M_MAX_UNSIGNED),
     screenJoystickSettingsIndex_(M_MAX_UNSIGNED),
-    paused_(false)
+    paused_(false),
+    useMouseMode_(MM_ABSOLUTE)
 {
 }
 
@@ -85,8 +87,13 @@ void Sample::Start()
     // Create console and debug HUD
     CreateConsoleAndDebugHud();
 
+    // Initiate the mouse mode settings
+    InitMouseMode();
+
     // Subscribe key down event
     SubscribeToEvent(E_KEYDOWN, URHO3D_HANDLER(Sample, HandleKeyDown));
+    // Subscribe key up event
+    SubscribeToEvent(E_KEYUP, URHO3D_HANDLER(Sample, HandleKeyUp));
     // Subscribe scene update event
     SubscribeToEvent(E_SCENEUPDATE, URHO3D_HANDLER(Sample, HandleSceneUpdate));
 }
@@ -113,6 +120,29 @@ void Sample::InitTouchInput()
     }
     screenJoystickIndex_ = input->AddScreenJoystick(layout, cache->GetResource<XMLFile>("UI/DefaultStyle.xml"));
     input->SetScreenJoystickVisible(screenJoystickSettingsIndex_, true);
+}
+
+void Sample::InitMouseMode()
+{
+    Input* input = GetSubsystem<Input>();
+
+    if (GetPlatform() != "Web")
+    {
+        if (useMouseMode_ == MM_FREE)
+            input->SetMouseVisible(true);
+
+        Console* console = GetSubsystem<Console>();
+        if (useMouseMode_ != MM_ABSOLUTE && (!console || !console->IsVisible()))
+        {
+            input->SetMouseMode(useMouseMode_);
+        }
+    }
+    else
+    {
+        input->SetMouseVisible(true);
+         SubscribeToEvent(E_MOUSEBUTTONDOWN, URHO3D_HANDLER(Sample, HandleMouseModeRequest));
+         SubscribeToEvent(E_MOUSEMODECHANGED, URHO3D_HANDLER(Sample, HandleMouseModeChange));
+    }
 }
 
 void Sample::SetLogoVisible(bool enable)
@@ -183,9 +213,10 @@ void Sample::CreateConsoleAndDebugHud()
     debugHud->SetDefaultStyle(xmlFile);
 }
 
-void Sample::HandleKeyDown(StringHash eventType, VariantMap& eventData)
+
+void Sample::HandleKeyUp(StringHash eventType, VariantMap& eventData)
 {
-    using namespace KeyDown;
+    using namespace KeyUp;
 
     int key = eventData[P_KEY].GetInt();
 
@@ -196,11 +227,27 @@ void Sample::HandleKeyDown(StringHash eventType, VariantMap& eventData)
         if (console->IsVisible())
             console->SetVisible(false);
         else
-            engine_->Exit();
+        {
+            if (GetPlatform() == "Web")
+            {
+                GetSubsystem<Input>()->SetMouseVisible(true);
+                if (useMouseMode_ != MM_ABSOLUTE)
+                    GetSubsystem<Input>()->SetMouseMode(MM_FREE);
+            }
+            else
+                engine_->Exit();
+        }
     }
+}
 
-    // Toggle console with F1
-    else if (key == KEY_F1)
+void Sample::HandleKeyDown(StringHash eventType, VariantMap& eventData)
+{
+    using namespace KeyDown;
+
+    int key = eventData[P_KEY].GetInt();
+
+    // Toggle console with F1 or Z
+    if (key == KEY_F1 || key == 'Z')
         GetSubsystem<Console>()->Toggle();
 
     // Toggle debug HUD with F2
@@ -356,4 +403,25 @@ void Sample::HandleTouchBegin(StringHash eventType, VariantMap& eventData)
     // On some platforms like Windows the presence of touch input can only be detected dynamically
     InitTouchInput();
     UnsubscribeFromEvent("TouchBegin");
+}
+
+// If the user clicks the canvas, attempt to switch to relative mouse mode on web platform
+void Sample::HandleMouseModeRequest(StringHash eventType, VariantMap& eventData)
+{
+    Console* console = GetSubsystem<Console>();
+    if (console && console->IsVisible())
+        return;
+    Input* input = GetSubsystem<Input>();
+    if (useMouseMode_ == MM_ABSOLUTE)
+        input->SetMouseVisible(false);
+    else if (useMouseMode_ == MM_FREE)
+        input->SetMouseVisible(true);
+    input->SetMouseMode(useMouseMode_);
+}
+
+void Sample::HandleMouseModeChange(StringHash eventType, VariantMap& eventData)
+{
+    Input* input = GetSubsystem<Input>();
+    bool mouseLocked = eventData[MouseModeChanged::P_MOUSELOCK].GetBool();
+    input->SetMouseVisible(!mouseLocked);
 }

--- a/Source/Samples/Sample.inl
+++ b/Source/Samples/Sample.inl
@@ -87,9 +87,6 @@ void Sample::Start()
     // Create console and debug HUD
     CreateConsoleAndDebugHud();
 
-    // Initiate the mouse mode settings
-    InitMouseMode();
-
     // Subscribe key down event
     SubscribeToEvent(E_KEYDOWN, URHO3D_HANDLER(Sample, HandleKeyDown));
     // Subscribe key up event
@@ -122,8 +119,10 @@ void Sample::InitTouchInput()
     input->SetScreenJoystickVisible(screenJoystickSettingsIndex_, true);
 }
 
-void Sample::InitMouseMode()
+void Sample::InitMouseMode(MouseMode mode)
 {
+    useMouseMode_ = mode;
+
     Input* input = GetSubsystem<Input>();
 
     if (GetPlatform() != "Web")
@@ -132,16 +131,18 @@ void Sample::InitMouseMode()
             input->SetMouseVisible(true);
 
         Console* console = GetSubsystem<Console>();
-        if (useMouseMode_ != MM_ABSOLUTE && (!console || !console->IsVisible()))
+        if (useMouseMode_ != MM_ABSOLUTE)
         {
             input->SetMouseMode(useMouseMode_);
+            if (console && console->IsVisible())
+                input->SetMouseMode(MM_ABSOLUTE, true);
         }
     }
     else
     {
         input->SetMouseVisible(true);
-         SubscribeToEvent(E_MOUSEBUTTONDOWN, URHO3D_HANDLER(Sample, HandleMouseModeRequest));
-         SubscribeToEvent(E_MOUSEMODECHANGED, URHO3D_HANDLER(Sample, HandleMouseModeChange));
+        SubscribeToEvent(E_MOUSEBUTTONDOWN, URHO3D_HANDLER(Sample, HandleMouseModeRequest));
+        SubscribeToEvent(E_MOUSEMODECHANGED, URHO3D_HANDLER(Sample, HandleMouseModeChange));
     }
 }
 
@@ -422,6 +423,6 @@ void Sample::HandleMouseModeRequest(StringHash eventType, VariantMap& eventData)
 void Sample::HandleMouseModeChange(StringHash eventType, VariantMap& eventData)
 {
     Input* input = GetSubsystem<Input>();
-    bool mouseLocked = eventData[MouseModeChanged::P_MOUSELOCK].GetBool();
+    bool mouseLocked = eventData[MouseModeChanged::P_MOUSELOCKED].GetBool();
     input->SetMouseVisible(!mouseLocked);
 }

--- a/Source/Urho3D/AngelScript/InputAPI.cpp
+++ b/Source/Urho3D/AngelScript/InputAPI.cpp
@@ -497,6 +497,16 @@ static void InputSetMouseVisible(bool enable, Input* ptr)
     ptr->SetMouseVisible(enable, false);
 }
 
+static void InputSetMouseMode(MouseMode mode, Input* ptr)
+{
+    ptr->SetMouseMode(mode, false);
+}
+
+static void InputSetMouseGrabbed(bool enable, Input* ptr)
+{
+    ptr->SetMouseGrabbed(enable, false);
+}
+
 static void RegisterInput(asIScriptEngine* engine)
 {
     engine->RegisterEnum("MouseMode");
@@ -550,10 +560,15 @@ static void RegisterInput(asIScriptEngine* engine)
     engine->RegisterObjectMethod("Input", "void set_mouseVisible(bool)", asFUNCTION(InputSetMouseVisible), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod("Input", "void ResetMouseVisible()", asMETHOD(Input, ResetMouseVisible), asCALL_THISCALL);
     engine->RegisterObjectMethod("Input", "bool get_mouseVisible() const", asMETHOD(Input, IsMouseVisible), asCALL_THISCALL);
-    engine->RegisterObjectMethod("Input", "void set_mouseGrabbed(bool)", asMETHOD(Input, SetMouseGrabbed), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Input", "void SetMouseGrabbed(bool, bool = false)", asMETHOD(Input, SetMouseGrabbed), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Input", "void set_mouseGrabbed(bool)", asFUNCTION(InputSetMouseGrabbed), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod("Input", "bool get_mouseGrabbed() const", asMETHOD(Input, IsMouseGrabbed), asCALL_THISCALL);
-    engine->RegisterObjectMethod("Input", "void set_mouseMode(MouseMode) const", asMETHOD(Input, SetMouseMode), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Input", "void ResetMouseGrabbed()", asMETHOD(Input, ResetMouseGrabbed), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Input", "void SetMouseMode(MouseMode, bool = false)", asMETHOD(Input, SetMouseMode), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Input", "void set_mouseMode(MouseMode)", asFUNCTION(InputSetMouseMode), asCALL_CDECL_OBJLAST);
+    engine->RegisterObjectMethod("Input", "void ResetMouseMode()", asMETHOD(Input, ResetMouseMode), asCALL_THISCALL);
     engine->RegisterObjectMethod("Input", "MouseMode get_mouseMode() const", asMETHOD(Input, GetMouseMode), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Input", "bool get_mouseLocked() const", asMETHOD(Input, IsMouseLocked), asCALL_THISCALL);
     engine->RegisterObjectMethod("Input", "void set_screenJoystickVisible(int, bool)", asMETHOD(Input, SetScreenJoystickVisible), asCALL_THISCALL);
     engine->RegisterObjectMethod("Input", "bool get_screenJoystickVisible(int)", asMETHOD(Input, IsScreenJoystickVisible), asCALL_THISCALL);
     engine->RegisterObjectMethod("Input", "void set_screenKeyboardVisible(bool)", asMETHOD(Input, SetScreenKeyboardVisible), asCALL_THISCALL);

--- a/Source/Urho3D/Core/ProcessUtils.h
+++ b/Source/Urho3D/Core/ProcessUtils.h
@@ -59,7 +59,7 @@ URHO3D_API const Vector<String>& ParseArguments(int argc, char** argv);
 URHO3D_API const Vector<String>& GetArguments();
 /// Read input from the console window. Return empty if no input.
 URHO3D_API String GetConsoleInput();
-/// Return the runtime platform identifier, one of "Windows", "Linux", "Mac OS X", "Android", "iOS" or "Raspberry Pi".
+/// Return the runtime platform identifier, one of "Windows", "Linux", "Mac OS X", "Android", "iOS", "Web" or "Raspberry Pi".
 URHO3D_API String GetPlatform();
 /// Return the number of physical CPU cores.
 URHO3D_API unsigned GetNumPhysicalCPUs();

--- a/Source/Urho3D/Engine/Console.cpp
+++ b/Source/Urho3D/Engine/Console.cpp
@@ -127,21 +127,31 @@ void Console::SetDefaultStyle(XMLFile* style)
 void Console::SetVisible(bool enable)
 {
     Input* input = GetSubsystem<Input>();
+    UI* ui = GetSubsystem<UI>();
+    Cursor* cursor = ui->GetCursor();
+
     background_->SetVisible(enable);
     closeButton_->SetVisible(enable);
+
     if (enable)
     {
         // Check if we have receivers for E_CONSOLECOMMAND every time here in case the handler is being added later dynamically
         bool hasInterpreter = PopulateInterpreter();
         commandLine_->SetVisible(hasInterpreter);
         if (hasInterpreter && focusOnShow_)
-            GetSubsystem<UI>()->SetFocusElement(lineEdit_);
+            ui->SetFocusElement(lineEdit_);
 
         // Ensure the background has no empty space when shown without the lineedit
         background_->SetHeight(background_->GetMinHeight());
 
-        // Show OS mouse
-        input->SetMouseVisible(true, true);
+        if (!cursor)
+        {
+            // Show OS mouse
+            input->SetMouseMode(MM_FREE, true);
+            input->SetMouseVisible(true, true);
+        }
+
+        input->SetMouseGrabbed(false, true);
     }
     else
     {
@@ -149,8 +159,14 @@ void Console::SetVisible(bool enable)
         interpreters_->SetFocus(false);
         lineEdit_->SetFocus(false);
 
-        // Restore OS mouse visibility
-        input->ResetMouseVisible();
+        if (!cursor)
+        {
+            // Restore OS mouse visibility
+            input->ResetMouseMode();
+            input->ResetMouseVisible();
+        }
+
+        input->ResetMouseGrabbed();
     }
 }
 

--- a/Source/Urho3D/Input/Input.h
+++ b/Source/Urho3D/Input/Input.h
@@ -328,6 +328,12 @@ private:
     void SetMouseWheel(int delta);
     /// Internal function to set the mouse cursor position.
     void SetMousePosition(const IntVector2& position);
+    /// Center the mouse position.
+    void CenterMousePosition();
+    /// Suppress next mouse movement.
+    void SuppressNextMouseMove();
+    /// Unsuppress mouse movement.
+    void UnsuppressMouseMove();
     /// Handle screen mode event.
     void HandleScreenMode(StringHash eventType, VariantMap& eventData);
     /// Handle frame start event.
@@ -337,11 +343,18 @@ private:
     /// Handle SDL event.
     void HandleSDLEvent(void* sdlEvent);
 
-#ifdef __EMSCRIPTEN__
+#ifndef __EMSCRIPTEN__
+    /// Set SDL mouse mode relative.
+    void SetMouseModeRelative(SDL_bool enable);
+    /// Set SDL mouse mode absolute.
+    void SetMouseModeAbsolute(SDL_bool enable);
+#else
     /// Set whether the operating system mouse cursor is visible (Emscripten platform only).
     void SetMouseVisibleEmscripten(bool enable, bool suppressEvent = false);
-    /// Set mouse mode (Emscripten platform only).
-    void SetMouseModeEmscripten(MouseMode mode, bool suppressEvent = false);
+    /// Set mouse mode final resolution (Emscripten platform only).
+    void SetMouseModeEmscriptenFinal(MouseMode mode, bool suppressEvent = false);
+    /// SetMouseMode  (Emscripten platform only).
+    void SetMouseModeEmscripten(MouseMode mode, bool suppressEvent);
     /// Handle frame end event.
     void HandleEndFrame(StringHash eventType, VariantMap& eventData);
 #endif
@@ -394,6 +407,10 @@ private:
     MouseMode mouseMode_;
     /// The last mouse mode set by SetMouseMode.
     MouseMode lastMouseMode_;
+#ifndef __EMSCRIPTEN__
+    /// Flag to determine whether SDL mouse relative was used.
+    bool sdlMouseRelative_;
+#endif
     /// Touch emulation mode flag.
     bool touchEmulation_;
     /// Input focus flag.

--- a/Source/Urho3D/Input/Input.h
+++ b/Source/Urho3D/Input/Input.h
@@ -38,7 +38,8 @@ enum MouseMode
     MM_ABSOLUTE = 0,
     MM_RELATIVE,
     MM_WRAP,
-    MM_FREE
+    MM_FREE,
+    MM_INVALID
 };
 
 class Deserializer;
@@ -155,7 +156,9 @@ public:
     /// Reset last mouse visibility that was not suppressed in SetMouseVisible.
     void ResetMouseVisible();
     /// Set whether the mouse is currently being grabbed by an operation.
-    void SetMouseGrabbed(bool grab);
+    void SetMouseGrabbed(bool grab, bool suppressEvent = false);
+    /// Reset the mouse grabbed to the last unsuppressed SetMouseGrabbed call
+    void ResetMouseGrabbed();
     /// Set the mouse mode.
     /** Set the mouse mode behaviour.
      *  MM_ABSOLUTE is the default behaviour, allowing the toggling of operating system cursor visibility and allowing the cursor to escape the window when visible.
@@ -174,7 +177,9 @@ public:
      *  MM_FREE does not grab/confine the mouse cursor even when it is hidden. This can be used for cases where the cursor should render using the operating system
      *  outside the window, and perform custom rendering (with SetMouseVisible(false)) inside.
     */
-    void SetMouseMode(MouseMode mode);
+    void SetMouseMode(MouseMode mode, bool suppressEvent = false);
+    /// Reset the last mouse mode that wasn't suppressed in SetMouseMode
+    void ResetMouseMode();
     /// Add screen joystick.
     /** Return the joystick instance ID when successful or negative on error.
      *  If layout file is not given, use the default screen joystick layout.
@@ -240,28 +245,22 @@ public:
     int GetQualifiers() const;
     /// Return mouse position within window. Should only be used with a visible mouse cursor.
     IntVector2 GetMousePosition() const;
-
     /// Return mouse movement since last frame.
-    const IntVector2& GetMouseMove() const { return mouseMove_; }
-
+    const IntVector2& GetMouseMove() const;
     /// Return horizontal mouse movement since last frame.
-    int GetMouseMoveX() const { return mouseMove_.x_; }
-
+    int GetMouseMoveX() const;
     /// Return vertical mouse movement since last frame.
-    int GetMouseMoveY() const { return mouseMove_.y_; }
-
+    int GetMouseMoveY() const;
     /// Return mouse wheel movement since last frame.
     int GetMouseMoveWheel() const { return mouseMoveWheel_; }
 
     /// Return number of active finger touches.
     unsigned GetNumTouches() const { return touches_.Size(); }
-
     /// Return active finger touch by index.
     TouchState* GetTouch(unsigned index) const;
 
     /// Return number of connected joysticks.
     unsigned GetNumJoysticks() const { return joysticks_.Size(); }
-
     /// Return joystick state by ID, or null if does not exist.
     JoystickState* GetJoystick(SDL_JoystickID id);
     /// Return joystick state by index, or null if does not exist. 0 = first connected joystick.
@@ -282,9 +281,10 @@ public:
 
     /// Return whether the operating system mouse cursor is visible.
     bool IsMouseVisible() const { return mouseVisible_; }
-
     /// Return whether the mouse is currently being grabbed by an operation.
     bool IsMouseGrabbed() const { return mouseGrabbed_; }
+    /// Return whether the mouse is locked to the window
+    bool IsMouseLocked() const;
 
     /// Return the mouse mode.
     MouseMode GetMouseMode() const { return mouseMode_; }
@@ -310,6 +310,8 @@ private:
     void ResetState();
     /// Clear touch states and send touch end events.
     void ResetTouches();
+    /// Reset input accumulation.
+    void ResetInputAccumulation();
     /// Get the index of a touch based on the touch ID.
     unsigned GetTouchIndexFromID(int touchID);
     /// Used internally to return and remove the next available touch index.
@@ -322,12 +324,6 @@ private:
     void SetMouseButton(int button, bool newState);
     /// Handle a key change.
     void SetKey(int key, int scancode, bool newState);
-#ifdef __EMSCRIPTEN__
-    /// Set whether the operating system mouse cursor is visible (Emscripten platform only).
-    void SetMouseVisibleEmscripten(bool enable);
-    /// Set mouse mode (Emscripten platform only).
-    void SetMouseModeEmscripten(MouseMode mode);
-#endif
     /// Handle mouse wheel change.
     void SetMouseWheel(int delta);
     /// Internal function to set the mouse cursor position.
@@ -340,6 +336,15 @@ private:
     void HandleScreenJoystickTouch(StringHash eventType, VariantMap& eventData);
     /// Handle SDL event.
     void HandleSDLEvent(void* sdlEvent);
+
+#ifdef __EMSCRIPTEN__
+    /// Set whether the operating system mouse cursor is visible (Emscripten platform only).
+    void SetMouseVisibleEmscripten(bool enable, bool suppressEvent = false);
+    /// Set mouse mode (Emscripten platform only).
+    void SetMouseModeEmscripten(MouseMode mode, bool suppressEvent = false);
+    /// Handle frame end event.
+    void HandleEndFrame(StringHash eventType, VariantMap& eventData);
+#endif
 
     /// Graphics subsystem.
     WeakPtr<Graphics> graphics_;
@@ -383,8 +388,12 @@ private:
     bool lastMouseVisible_;
     /// Flag to indicate the mouse is being grabbed by an operation. Subsystems like UI that uses mouse should temporarily ignore the mouse hover or click events.
     bool mouseGrabbed_;
+    /// The last mouse grabbed set by SetMouseGrabbed.
+    bool lastMouseGrabbed_;
     /// Determines the mode of mouse behaviour.
     MouseMode mouseMode_;
+    /// The last mouse mode set by SetMouseMode.
+    MouseMode lastMouseMode_;
     /// Touch emulation mode flag.
     bool touchEmulation_;
     /// Input focus flag.
@@ -401,13 +410,16 @@ private:
     bool screenModeChanged_;
     /// Initialized flag.
     bool initialized_;
+
 #ifdef __EMSCRIPTEN__
     /// Emscripten Input glue instance.
     EmscriptenInput* emscriptenInput_;
-    /// Flag used to detect mouse jump when exiting pointer lock.
+    /// Flag used to detect mouse jump when exiting pointer-lock.
     bool emscriptenExitingPointerLock_;
-    /// Flag used to detect mouse jump on initial mouse click when entering pointer lock.
+    /// Flag used to detect mouse jump on initial mouse click when entering pointer-lock.
     bool emscriptenEnteredPointerLock_;
+    /// Flag indicating current pointer-lock status.
+    bool emscriptenPointerLock_;
 #endif
 };
 

--- a/Source/Urho3D/Input/InputEvents.h
+++ b/Source/Urho3D/Input/InputEvents.h
@@ -213,6 +213,7 @@ URHO3D_EVENT(E_MOUSEVISIBLECHANGED, MouseVisibleChanged)
 URHO3D_EVENT(E_MOUSEMODECHANGED, MouseModeChanged)
 {
     URHO3D_PARAM(P_MODE, Mode);                    // MouseMode
+    URHO3D_PARAM(P_MOUSELOCK, PointerLock);      // bool
 }
 
 /// Application exit requested.

--- a/Source/Urho3D/Input/InputEvents.h
+++ b/Source/Urho3D/Input/InputEvents.h
@@ -213,7 +213,7 @@ URHO3D_EVENT(E_MOUSEVISIBLECHANGED, MouseVisibleChanged)
 URHO3D_EVENT(E_MOUSEMODECHANGED, MouseModeChanged)
 {
     URHO3D_PARAM(P_MODE, Mode);                    // MouseMode
-    URHO3D_PARAM(P_MOUSELOCK, PointerLock);      // bool
+    URHO3D_PARAM(P_MOUSELOCKED, MouseLocked);      // bool
 }
 
 /// Application exit requested.

--- a/Source/Urho3D/LuaScript/pkgs/Input/Input.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Input/Input.pkg
@@ -47,8 +47,9 @@ class Input : public Object
 {
     void SetToggleFullscreen(bool enable);
     void SetMouseVisible(bool enable, bool suppressEvent = false);
-    void SetMouseGrabbed(bool grab);
-    void SetMouseMode(MouseMode mode);
+    void SetMouseGrabbed(bool grab, bool suppressEvent = false);
+    void SetMouseMode(MouseMode mode, bool suppressEvent = false);
+    bool IsMouseLocked();
     int AddScreenJoystick(XMLFile* layoutFile = 0, XMLFile* styleFile = 0);
     bool RemoveScreenJoystick(int id);
     void SetScreenJoystickVisible(int id, bool enable);
@@ -115,6 +116,7 @@ class Input : public Object
     tolua_property__get_set bool touchEmulation;
     tolua_property__is_set bool mouseVisible;
     tolua_property__is_set bool mouseGrabbed;
+    tolua_readonly tolua_property__is_set bool mouseLocked;
     tolua_readonly tolua_property__has_set bool focus;
     tolua_readonly tolua_property__is_set bool minimized;
 };

--- a/Source/Urho3D/UI/UI.cpp
+++ b/Source/Urho3D/UI/UI.cpp
@@ -1438,9 +1438,11 @@ void UI::HandleMouseMove(StringHash eventType, VariantMap& eventData)
     {
         if (!input->IsMouseVisible())
         {
-            // Relative mouse motion: move cursor only when visible
-            if (cursor_->IsVisible())
+            if (!input->IsMouseLocked())
+                cursor_->SetPosition(IntVector2(eventData[P_X].GetInt(), eventData[P_Y].GetInt()));
+            else if (cursor_->IsVisible())
             {
+                // Relative mouse motion: move cursor only when visible
                 IntVector2 pos = cursor_->GetPosition();
                 pos.x_ += eventData[P_DX].GetInt();
                 pos.y_ += eventData[P_DY].GetInt();

--- a/bin/Data/LuaScripts/01_HelloWorld.lua
+++ b/bin/Data/LuaScripts/01_HelloWorld.lua
@@ -13,6 +13,9 @@ function Start()
     -- Create "Hello World" Text
     CreateText()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE)
+
     -- Finally, hook-up this HelloWorld instance to handle update events
     SubscribeToEvents()
 end

--- a/bin/Data/LuaScripts/02_HelloGUI.lua
+++ b/bin/Data/LuaScripts/02_HelloGUI.lua
@@ -34,6 +34,9 @@ function Start()
 
     -- Create a draggable Fish
     CreateDraggableFish()
+
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE)
 end
 
 function InitControls()

--- a/bin/Data/LuaScripts/03_Sprites.lua
+++ b/bin/Data/LuaScripts/03_Sprites.lua
@@ -19,6 +19,9 @@ function Start()
     -- Create the sprites to the user interface
     CreateSprites()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE)
+
     -- Hook up to the frame update events
     SubscribeToEvents()
 end

--- a/bin/Data/LuaScripts/04_StaticScene.lua
+++ b/bin/Data/LuaScripts/04_StaticScene.lua
@@ -19,6 +19,9 @@ function Start()
     -- Setup the viewport for displaying the scene
     SetupViewport()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE)
+
     -- Hook up to the frame update events
     SubscribeToEvents()
 end

--- a/bin/Data/LuaScripts/05_AnimatingScene.lua
+++ b/bin/Data/LuaScripts/05_AnimatingScene.lua
@@ -19,6 +19,9 @@ function Start()
     -- Setup the viewport for displaying the scene
     SetupViewport()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE)
+
     -- Hook up to the frame update events
     SubscribeToEvents()
 end

--- a/bin/Data/LuaScripts/06_SkeletalAnimation.lua
+++ b/bin/Data/LuaScripts/06_SkeletalAnimation.lua
@@ -21,6 +21,9 @@ function Start()
     -- Setup the viewport for displaying the scene
     SetupViewport()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE)
+
     -- Hook up to the frame update and render post-update events
     SubscribeToEvents()
 end

--- a/bin/Data/LuaScripts/07_Billboards.lua
+++ b/bin/Data/LuaScripts/07_Billboards.lua
@@ -22,6 +22,9 @@ function Start()
     -- Setup the viewport for displaying the scene
     SetupViewport()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE)
+
     -- Hook up to the frame update and render post-update events
     SubscribeToEvents()
 end

--- a/bin/Data/LuaScripts/08_Decals.lua
+++ b/bin/Data/LuaScripts/08_Decals.lua
@@ -20,6 +20,9 @@ function Start()
     -- Setup the viewport for displaying the scene
     SetupViewport()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE)
+
     -- Hook up to the frame update and render post-update events
     SubscribeToEvents()
 end
@@ -140,8 +143,14 @@ function SubscribeToEvents()
 end
 
 function MoveCamera(timeStep)
+    input.mouseVisible = input.mouseMode ~= MM_RELATIVE
+    mouseDown = input:GetMouseButtonDown(MOUSEB_RIGHT)
+
+    -- Override the MM_RELATIVE mouse grabbed settings, to allow interaction with UI
+    input.mouseGrabbed = mouseDown
+
     -- Right mouse button controls mouse cursor visibility: hide when pressed
-    ui.cursor.visible = not input:GetMouseButtonDown(MOUSEB_RIGHT)
+    ui.cursor.visible = not mouseDown
 
     -- Do not move if the UI has a focused element (the console)
     if ui.focusElement ~= nil then

--- a/bin/Data/LuaScripts/09_MultipleViewports.lua
+++ b/bin/Data/LuaScripts/09_MultipleViewports.lua
@@ -20,6 +20,9 @@ function Start()
     -- Setup the viewports for displaying the scene
     SetupViewports()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE)
+
     -- Hook up to the frame update and render post-update events
     SubscribeToEvents()
 end

--- a/bin/Data/LuaScripts/10_RenderToTexture.lua
+++ b/bin/Data/LuaScripts/10_RenderToTexture.lua
@@ -21,6 +21,9 @@ function Start()
     -- Setup the viewport for displaying the scene
     SetupViewport()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE)
+
     -- Hook up to the frame update events
     SubscribeToEvents()
 end

--- a/bin/Data/LuaScripts/11_Physics.lua
+++ b/bin/Data/LuaScripts/11_Physics.lua
@@ -20,6 +20,9 @@ function Start()
     -- Setup the viewport for displaying the scene
     SetupViewport()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE)
+
     -- Hook up to the frame update and render post-update events
     SubscribeToEvents()
 end

--- a/bin/Data/LuaScripts/12_PhysicsStressTest.lua
+++ b/bin/Data/LuaScripts/12_PhysicsStressTest.lua
@@ -20,6 +20,9 @@ function Start()
     -- Setup the viewport for displaying the scene
     SetupViewport()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE)
+
     -- Hook up to the frame update and render post-update events
     SubscribeToEvents()
 end

--- a/bin/Data/LuaScripts/13_Ragdolls.lua
+++ b/bin/Data/LuaScripts/13_Ragdolls.lua
@@ -19,6 +19,9 @@ function Start()
     -- Setup the viewport for displaying the scene
     SetupViewport()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE)
+
     -- Hook up to the frame update and render post-update events
     SubscribeToEvents()
 end

--- a/bin/Data/LuaScripts/14_SoundEffects.lua
+++ b/bin/Data/LuaScripts/14_SoundEffects.lua
@@ -26,6 +26,9 @@ function Start()
 
     -- Create the user interface
     CreateUI()
+
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE)
 end
 
 function CreateUI()

--- a/bin/Data/LuaScripts/15_Navigation.lua
+++ b/bin/Data/LuaScripts/15_Navigation.lua
@@ -25,6 +25,9 @@ function Start()
     -- Setup the viewport for displaying the scene
     SetupViewport()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE)
+
     -- Hook up to the frame update and render post-update events
     SubscribeToEvents()
 end
@@ -159,8 +162,14 @@ function SubscribeToEvents()
 end
 
 function MoveCamera(timeStep)
+    input.mouseVisible = input.mouseMode ~= MM_RELATIVE
+    mouseDown = input:GetMouseButtonDown(MOUSEB_RIGHT)
+
+    -- Override the MM_RELATIVE mouse grabbed settings, to allow interaction with UI
+    input.mouseGrabbed = mouseDown
+
     -- Right mouse button controls mouse cursor visibility: hide when pressed
-    ui.cursor.visible = not input:GetMouseButtonDown(MOUSEB_RIGHT)
+    ui.cursor.visible = not mouseDown
 
     -- Do not move if the UI has a focused element (the console)
     if ui.focusElement ~= nil then

--- a/bin/Data/LuaScripts/16_Chat.lua
+++ b/bin/Data/LuaScripts/16_Chat.lua
@@ -29,6 +29,9 @@ function Start()
     -- Create the user interface
     CreateUI()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE)
+
     -- Subscribe to UI and network events
     SubscribeToEvents()
 end

--- a/bin/Data/LuaScripts/17_SceneReplication.lua
+++ b/bin/Data/LuaScripts/17_SceneReplication.lua
@@ -38,6 +38,9 @@ function Start()
     -- Setup the viewport for displaying the scene
     SetupViewport()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE)
+
     -- Hook up to necessary events
     SubscribeToEvents()
 end
@@ -222,8 +225,14 @@ function CreateControllableObject()
 end
 
 function MoveCamera()
+    input.mouseVisible = input.mouseMode ~= MM_RELATIVE
+    mouseDown = input:GetMouseButtonDown(MOUSEB_RIGHT)
+
+    -- Override the MM_RELATIVE mouse grabbed settings, to allow interaction with UI
+    input.mouseGrabbed = mouseDown
+
     -- Right mouse button controls mouse cursor visibility: hide when pressed
-    ui.cursor.visible = not input:GetMouseButtonDown(MOUSEB_RIGHT)
+    ui.cursor.visible = not mouseDown
 
     -- Mouse sensitivity as degrees per pixel
     local MOUSE_SENSITIVITY = 0.1

--- a/bin/Data/LuaScripts/18_CharacterDemo.lua
+++ b/bin/Data/LuaScripts/18_CharacterDemo.lua
@@ -41,6 +41,9 @@ function Start()
     -- Create the UI content
     CreateInstructions()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE)
+
     -- Subscribe to necessary events
     SubscribeToEvents()
 end

--- a/bin/Data/LuaScripts/19_VehicleDemo.lua
+++ b/bin/Data/LuaScripts/19_VehicleDemo.lua
@@ -20,7 +20,6 @@ local MAX_WHEEL_ANGLE = 22.5
 local vehicleNode = nil
 
 function Start()
-
     -- Execute the common startup for samples
     SampleStart()
 
@@ -32,6 +31,9 @@ function Start()
 
     -- Create the UI content
     CreateInstructions()
+
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE)
 
     -- Subscribe to necessary events
     SubscribeToEvents()

--- a/bin/Data/LuaScripts/20_HugeObjectCount.lua
+++ b/bin/Data/LuaScripts/20_HugeObjectCount.lua
@@ -24,6 +24,9 @@ function Start()
     -- Setup the viewport for displaying the scene
     SetupViewport()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE)
+
     -- Hook up to the frame update events
     SubscribeToEvents()
 end

--- a/bin/Data/LuaScripts/23_Water.lua
+++ b/bin/Data/LuaScripts/23_Water.lua
@@ -23,6 +23,9 @@ function Start()
     -- Setup the viewport for displaying the scene
     SetupViewport()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE)
+
     -- Hook up to the frame update event
     SubscribeToEvents()
 end

--- a/bin/Data/LuaScripts/24_Urho2DSprite.lua
+++ b/bin/Data/LuaScripts/24_Urho2DSprite.lua
@@ -20,6 +20,9 @@ function Start()
     -- Setup the viewport for displaying the scene
     SetupViewport()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE)
+
     -- Hook up to the frame update events
     SubscribeToEvents()
 end

--- a/bin/Data/LuaScripts/25_Urho2DParticle.lua
+++ b/bin/Data/LuaScripts/25_Urho2DParticle.lua
@@ -24,6 +24,9 @@ function Start()
     -- Setup the viewport for displaying the scene
     SetupViewport()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE)
+
     -- Hook up to the frame update events
     SubscribeToEvents()
 end

--- a/bin/Data/LuaScripts/26_ConsoleInput.lua
+++ b/bin/Data/LuaScripts/26_ConsoleInput.lua
@@ -57,6 +57,9 @@ function Start()
     -- Show OS mouse cursor
     input.mouseVisible = true
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE)
+
     -- Open the operating system console window (for stdin / stdout) if not open yet
     -- Do not open in fullscreen, as this would cause constant device loss
     if not graphics.fullscreen then

--- a/bin/Data/LuaScripts/27_Urho2DPhysics.lua
+++ b/bin/Data/LuaScripts/27_Urho2DPhysics.lua
@@ -18,6 +18,9 @@ function Start()
     -- Setup the viewport for displaying the scene
     SetupViewport()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE)
+
     -- Hook up to the frame update events
     SubscribeToEvents()
 end

--- a/bin/Data/LuaScripts/28_Urho2DPhysicsRope.lua
+++ b/bin/Data/LuaScripts/28_Urho2DPhysicsRope.lua
@@ -19,6 +19,9 @@ function Start()
     -- Setup the viewport for displaying the scene
     SetupViewport()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE)
+
     -- Hook up to the frame update events
     SubscribeToEvents()
 end

--- a/bin/Data/LuaScripts/30_LightAnimation.lua
+++ b/bin/Data/LuaScripts/30_LightAnimation.lua
@@ -17,6 +17,9 @@ function Start()
     -- Setup the viewport for displaying the scene
     SetupViewport()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE)
+
     -- Hook up to the frame update events
     SubscribeToEvents()
 end

--- a/bin/Data/LuaScripts/31_MaterialAnimation.lua
+++ b/bin/Data/LuaScripts/31_MaterialAnimation.lua
@@ -17,6 +17,9 @@ function Start()
     -- Setup the viewport for displaying the scene
     SetupViewport()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE)
+
     -- Hook up to the frame update events
     SubscribeToEvents()
 end

--- a/bin/Data/LuaScripts/32_Urho2DConstraints.lua
+++ b/bin/Data/LuaScripts/32_Urho2DConstraints.lua
@@ -20,6 +20,8 @@ function Start()
     CreateScene()
     input.mouseVisible = true -- Show mouse cursor
     CreateInstructions()
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE)
     SubscribeToEvents()
 end
 

--- a/bin/Data/LuaScripts/33_Urho2DSpriterAnimation.lua
+++ b/bin/Data/LuaScripts/33_Urho2DSpriterAnimation.lua
@@ -22,6 +22,9 @@ function Start()
     -- Setup the viewport for displaying the scene
     SetupViewport()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE)
+
     -- Hook up to the frame update events
     SubscribeToEvents()
 end

--- a/bin/Data/LuaScripts/34_DynamicGeometry.lua
+++ b/bin/Data/LuaScripts/34_DynamicGeometry.lua
@@ -30,6 +30,9 @@ function Start()
     -- Setup the viewport for displaying the scene
     SetupViewport()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE)
+
     -- Hook up to the frame update events
     SubscribeToEvents()
 end
@@ -98,11 +101,11 @@ function CreateScene()
             table.insert(animatingBuffers, cloneModel:GetGeometry(0, 0):GetVertexBuffer(0))
         end
     end
-    
+
     -- Finally create one model (pyramid shape) and a StaticModel to display it from scratch
     -- Note: there are duplicated vertices to enable face normals. We will calculate normals programmatically
     local numVertices = 18
-        
+
     local vertexData = {
         -- Position          Normal
         0.0, 0.5, 0.0,       0.0, 0.0, 0.0,
@@ -129,7 +132,7 @@ function CreateScene()
         -0.5, -0.5, 0.5,     0.0, 0.0, 0.0,
         -0.5, -0.5, -0.5,    0.0, 0.0, 0.0
     }
-    
+
     local indexData = {
         0, 1, 2,
         3, 4, 5,
@@ -280,8 +283,8 @@ function AnimateObjects(timeStep)
             -- If there are duplicate vertices, animate them in phase of the original
             local phase = startPhase + vertexDuplicates[j] * 10.0
             local src = originalVertices[j]
-            local dest = Vector3(src.x * (1.0 + 0.1 * Sin(phase)), 
-                src.y * (1.0 + 0.1 * Sin(phase + 60.0)), 
+            local dest = Vector3(src.x * (1.0 + 0.1 * Sin(phase)),
+                src.y * (1.0 + 0.1 * Sin(phase + 60.0)),
                 src.z * (1.0 + 0.1 * Sin(phase + 120.0)))
 
             -- Write position

--- a/bin/Data/LuaScripts/35_SignedDistanceFieldText.lua
+++ b/bin/Data/LuaScripts/35_SignedDistanceFieldText.lua
@@ -20,6 +20,9 @@ function Start()
     -- Setup the viewport for displaying the scene
     SetupViewport()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE)
+
     -- Hook up to the frame update events
     SubscribeToEvents()
 end
@@ -84,7 +87,7 @@ function CreateScene()
             mushroomTitleText.textEffect = TE_STROKE
             mushroomTitleText.effectColor = Color(0.5, 0.5, 0.5)
         end
-        
+
         mushroomTitleText:SetAlignment(HA_CENTER, VA_CENTER)
     end
 

--- a/bin/Data/LuaScripts/36_Urho2DTileMap.lua
+++ b/bin/Data/LuaScripts/36_Urho2DTileMap.lua
@@ -19,6 +19,9 @@ function Start()
     -- Setup the viewport for displaying the scene
     SetupViewport()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE)
+
     -- Hook up to the frame update events
     SubscribeToEvents()
 end

--- a/bin/Data/LuaScripts/37_UIDrag.lua
+++ b/bin/Data/LuaScripts/37_UIDrag.lua
@@ -24,6 +24,9 @@ function Start()
     CreateGUI()
     CreateInstructions()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE)
+
     -- Hook up to the frame update events
     SubscribeToEvents()
 end
@@ -162,7 +165,7 @@ function HandleUpdate(eventType, eventData)
         t:SetVisible(false)
         i = i + 1
     end
-    
+
     if input:GetKeyPress(KEY_SPACE) then
         elements = ui.root:GetChildrenWithTag("SomeTag")
         for i, element in ipairs(elements) do

--- a/bin/Data/LuaScripts/38_SceneAndUILoad.lua
+++ b/bin/Data/LuaScripts/38_SceneAndUILoad.lua
@@ -19,6 +19,9 @@ function Start()
     -- Setup the viewport for displaying the scene
     SetupViewport()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE)
+
     -- Subscribe to global events for camera movement
     SubscribeToEvents()
 end
@@ -104,8 +107,14 @@ function HandleUpdate(eventType, eventData)
 end
 
 function MoveCamera(timeStep)
+    input.mouseVisible = input.mouseMode ~= MM_RELATIVE
+    mouseDown = input:GetMouseButtonDown(MOUSEB_RIGHT)
+
+    -- Override the MM_RELATIVE mouse grabbed settings, to allow interaction with UI
+    input.mouseGrabbed = mouseDown
+
     -- Right mouse button controls mouse cursor visibility: hide when pressed
-    ui.cursor.visible = not input:GetMouseButtonDown(MOUSEB_RIGHT)
+    ui.cursor.visible = not mouseDown
 
     -- Do not move if the UI has a focused element
     if ui.focusElement ~= nil then

--- a/bin/Data/LuaScripts/39_CrowdNavigation.lua
+++ b/bin/Data/LuaScripts/39_CrowdNavigation.lua
@@ -26,6 +26,9 @@ function Start()
     -- Setup the viewport for displaying the scene
     SetupViewport()
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE)
+
     -- Hook up to the frame update and render post-update events
     SubscribeToEvents()
 end
@@ -313,8 +316,14 @@ function Raycast(maxDistance)
 end
 
 function MoveCamera(timeStep)
+    input.mouseVisible = input.mouseMode ~= MM_RELATIVE
+    mouseDown = input:GetMouseButtonDown(MOUSEB_RIGHT)
+
+    -- Override the MM_RELATIVE mouse grabbed settings, to allow interaction with UI
+    input.mouseGrabbed = mouseDown
+
     -- Right mouse button controls mouse cursor visibility: hide when pressed
-    ui.cursor.visible = not input:GetMouseButtonDown(MOUSEB_RIGHT)
+    ui.cursor.visible = not mouseDown
 
     -- Do not move if the UI has a focused element (the console)
     if ui.focusElement ~= nil then

--- a/bin/Data/LuaScripts/40_Localization.lua
+++ b/bin/Data/LuaScripts/40_Localization.lua
@@ -21,6 +21,9 @@ function Start()
 
     -- Init the user interface
     CreateGUI()
+
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE)
 end
 
 function InitLocalizationSystem()
@@ -173,4 +176,3 @@ function HandleChangeLanguage(eventType, eventData)
 
     -- A text on the button "Press this button" changes automatically
 end
-

--- a/bin/Data/LuaScripts/41_DatabaseDemo.lua
+++ b/bin/Data/LuaScripts/41_DatabaseDemo.lua
@@ -33,6 +33,9 @@ function Start()
     -- Show OS mouse cursor
     input.mouseVisible = true
 
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE)
+
     -- Open the operating system console window (for stdin / stdout) if not open yet
     -- Do not open in fullscreen, as this would cause constant device loss
     if not graphics.fullscreen then

--- a/bin/Data/Scripts/01_HelloWorld.as
+++ b/bin/Data/Scripts/01_HelloWorld.as
@@ -14,6 +14,9 @@ void Start()
     // Create "Hello World" Text
     CreateText();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE);
+
     // Finally, hook-up this HelloWorld instance to handle update events
     SubscribeToEvents();
 }

--- a/bin/Data/Scripts/02_HelloGUI.as
+++ b/bin/Data/Scripts/02_HelloGUI.as
@@ -35,6 +35,9 @@ void Start()
 
     // Create a draggable Fish
     CreateDraggableFish();
+
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE);
 }
 
 void InitControls()

--- a/bin/Data/Scripts/03_Sprites.as
+++ b/bin/Data/Scripts/03_Sprites.as
@@ -21,6 +21,9 @@ void Start()
 
     // Hook up to the frame update events
     SubscribeToEvents();
+
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE);
 }
 
 void CreateSprites()

--- a/bin/Data/Scripts/04_StaticScene.as
+++ b/bin/Data/Scripts/04_StaticScene.as
@@ -20,6 +20,9 @@ void Start()
     // Setup the viewport for displaying the scene
     SetupViewport();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE);
+
     // Hook up to the frame update events
     SubscribeToEvents();
 }

--- a/bin/Data/Scripts/05_AnimatingScene.as
+++ b/bin/Data/Scripts/05_AnimatingScene.as
@@ -20,6 +20,9 @@ void Start()
     // Setup the viewport for displaying the scene
     SetupViewport();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE);
+
     // Hook up to the frame update events
     SubscribeToEvents();
 }

--- a/bin/Data/Scripts/06_SkeletalAnimation.as
+++ b/bin/Data/Scripts/06_SkeletalAnimation.as
@@ -22,6 +22,9 @@ void Start()
     // Setup the viewport for displaying the scene
     SetupViewport();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE);
+
     // Hook up to the frame update and render post-update events
     SubscribeToEvents();
 }

--- a/bin/Data/Scripts/07_Billboards.as
+++ b/bin/Data/Scripts/07_Billboards.as
@@ -20,6 +20,9 @@ void Start()
     // Setup the viewport for displaying the scene
     SetupViewport();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE);
+
     // Hook up to the frame update and render post-update events
     SubscribeToEvents();
 }

--- a/bin/Data/Scripts/08_Decals.as
+++ b/bin/Data/Scripts/08_Decals.as
@@ -21,6 +21,9 @@ void Start()
     // Setup the viewport for displaying the scene
     SetupViewport();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE);
+
     // Hook up to the frame update and render post-update events
     SubscribeToEvents();
 }
@@ -147,8 +150,14 @@ void SubscribeToEvents()
 
 void MoveCamera(float timeStep)
 {
+    input.mouseVisible = input.mouseMode != MM_RELATIVE;
+    bool mouseDown = input.mouseButtonDown[MOUSEB_RIGHT];
+
+    // Override the MM_RELATIVE mouse grabbed settings, to allow interaction with UI
+    input.mouseGrabbed = mouseDown;
+
     // Right mouse button controls mouse cursor visibility: hide when pressed
-    ui.cursor.visible = !input.mouseButtonDown[MOUSEB_RIGHT];
+    ui.cursor.visible = !mouseDown;
 
     // Do not move if the UI has a focused element (the console)
     if (ui.focusElement !is null)

--- a/bin/Data/Scripts/09_MultipleViewports.as
+++ b/bin/Data/Scripts/09_MultipleViewports.as
@@ -21,6 +21,9 @@ void Start()
     // Setup the viewports for displaying the scene
     SetupViewports();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE);
+
     // Hook up to the frame update and render post-update events
     SubscribeToEvents();
 }

--- a/bin/Data/Scripts/10_RenderToTexture.as
+++ b/bin/Data/Scripts/10_RenderToTexture.as
@@ -22,6 +22,9 @@ void Start()
     // Setup the viewport for displaying the scene
     SetupViewport();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE);
+
     // Hook up to the frame update events
     SubscribeToEvents();
 }

--- a/bin/Data/Scripts/11_Physics.as
+++ b/bin/Data/Scripts/11_Physics.as
@@ -21,6 +21,9 @@ void Start()
     // Setup the viewport for displaying the scene
     SetupViewport();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE);
+
     // Hook up to the frame update and render post-update events
     SubscribeToEvents();
 }

--- a/bin/Data/Scripts/12_PhysicsStressTest.as
+++ b/bin/Data/Scripts/12_PhysicsStressTest.as
@@ -20,6 +20,9 @@ void Start()
     // Setup the viewport for displaying the scene
     SetupViewport();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE);
+
     // Hook up to the frame update and render post-update events
     SubscribeToEvents();
 }

--- a/bin/Data/Scripts/13_Ragdolls.as
+++ b/bin/Data/Scripts/13_Ragdolls.as
@@ -20,6 +20,9 @@ void Start()
     // Setup the viewport for displaying the scene
     SetupViewport();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE);
+
     // Hook up to the frame update and render post-update events
     SubscribeToEvents();
 }

--- a/bin/Data/Scripts/14_SoundEffects.as
+++ b/bin/Data/Scripts/14_SoundEffects.as
@@ -27,6 +27,9 @@ void Start()
 
     // Create the user interface
     CreateUI();
+
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE);
 }
 
 void CreateUI()

--- a/bin/Data/Scripts/15_Navigation.as
+++ b/bin/Data/Scripts/15_Navigation.as
@@ -27,6 +27,9 @@ void Start()
     // Setup the viewport for displaying the scene
     SetupViewport();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE);
+
     // Hook up to the frame update and render post-update events
     SubscribeToEvents();
 }
@@ -167,8 +170,14 @@ void SubscribeToEvents()
 
 void MoveCamera(float timeStep)
 {
+    input.mouseVisible = input.mouseMode != MM_RELATIVE;
+    bool mouseDown = input.mouseButtonDown[MOUSEB_RIGHT];
+
+    // Override the MM_RELATIVE mouse grabbed settings, to allow interaction with UI
+    input.mouseGrabbed = mouseDown;
+
     // Right mouse button controls mouse cursor visibility: hide when pressed
-    ui.cursor.visible = !input.mouseButtonDown[MOUSEB_RIGHT];
+    ui.cursor.visible = !mouseDown;
 
     // Do not move if the UI has a focused element (the console)
     if (ui.focusElement !is null)

--- a/bin/Data/Scripts/16_Chat.as
+++ b/bin/Data/Scripts/16_Chat.as
@@ -30,6 +30,9 @@ void Start()
     // Create the user interface
     CreateUI();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE);
+
     // Subscribe to UI and network events
     SubscribeToEvents();
 }

--- a/bin/Data/Scripts/17_SceneReplication.as
+++ b/bin/Data/Scripts/17_SceneReplication.as
@@ -46,6 +46,9 @@ void Start()
     // Setup the viewport for displaying the scene
     SetupViewport();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE);
+
     // Hook up to necessary events
     SubscribeToEvents();
 }
@@ -240,8 +243,14 @@ Node@ CreateControllableObject()
 
 void MoveCamera()
 {
+    input.mouseVisible = input.mouseMode != MM_RELATIVE;
+    bool mouseDown = input.mouseButtonDown[MOUSEB_RIGHT];
+
+    // Override the MM_RELATIVE mouse grabbed settings, to allow interaction with UI
+    input.mouseGrabbed = mouseDown;
+
     // Right mouse button controls mouse cursor visibility: hide when pressed
-    ui.cursor.visible = !input.mouseButtonDown[MOUSEB_RIGHT];
+    ui.cursor.visible = !mouseDown;
 
     // Mouse sensitivity as degrees per pixel
     const float MOUSE_SENSITIVITY = 0.1f;

--- a/bin/Data/Scripts/18_CharacterDemo.as
+++ b/bin/Data/Scripts/18_CharacterDemo.as
@@ -40,6 +40,9 @@ void Start()
     // Create the UI content
     CreateInstructions();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE);
+
     // Subscribe to necessary events
     SubscribeToEvents();
 }

--- a/bin/Data/Scripts/19_VehicleDemo.as
+++ b/bin/Data/Scripts/19_VehicleDemo.as
@@ -33,6 +33,9 @@ void Start()
     // Create the UI content
     CreateInstructions();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE);
+
     // Subscribe to necessary events
     SubscribeToEvents();
 }

--- a/bin/Data/Scripts/20_HugeObjectCount.as
+++ b/bin/Data/Scripts/20_HugeObjectCount.as
@@ -25,6 +25,9 @@ void Start()
     // Setup the viewport for displaying the scene
     SetupViewport();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE);
+
     // Hook up to the frame update events
     SubscribeToEvents();
 }

--- a/bin/Data/Scripts/23_Water.as
+++ b/bin/Data/Scripts/23_Water.as
@@ -24,6 +24,9 @@ void Start()
     // Setup the viewports for displaying the scene and rendering the water reflection
     SetupViewports();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE);
+
     // Hook up to the frame update and render post-update events
     SubscribeToEvents();
 }

--- a/bin/Data/Scripts/24_Urho2DSprite.as
+++ b/bin/Data/Scripts/24_Urho2DSprite.as
@@ -22,6 +22,9 @@ void Start()
     // Setup the viewport for displaying the scene
     SetupViewport();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE);
+
     // Hook up to the frame update events
     SubscribeToEvents();
 }

--- a/bin/Data/Scripts/25_Urho2DParticle.as
+++ b/bin/Data/Scripts/25_Urho2DParticle.as
@@ -25,6 +25,9 @@ void Start()
     // Setup the viewport for displaying the scene
     SetupViewport();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE);
+
     // Hook up to the frame update events
     SubscribeToEvents();
 }

--- a/bin/Data/Scripts/26_ConsoleInput.as
+++ b/bin/Data/Scripts/26_ConsoleInput.as
@@ -58,6 +58,9 @@ void Start()
     // Show OS mouse cursor
     input.mouseVisible = true;
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE);
+
     // Open the operating system console window (for stdin / stdout) if not open yet
     // Do not open in fullscreen, as this would cause constant device loss
     if (!graphics.fullscreen)

--- a/bin/Data/Scripts/27_Urho2DPhysics.as
+++ b/bin/Data/Scripts/27_Urho2DPhysics.as
@@ -19,6 +19,9 @@ void Start()
     // Setup the viewport for displaying the scene
     SetupViewport();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE);
+
     // Hook up to the frame update events
     SubscribeToEvents();
 }

--- a/bin/Data/Scripts/28_Urho2DPhysicsRope.as
+++ b/bin/Data/Scripts/28_Urho2DPhysicsRope.as
@@ -20,6 +20,9 @@ void Start()
     // Setup the viewport for displaying the scene
     SetupViewport();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE);
+
     // Hook up to the frame update events
     SubscribeToEvents();
 }

--- a/bin/Data/Scripts/30_LightAnimation.as
+++ b/bin/Data/Scripts/30_LightAnimation.as
@@ -18,6 +18,9 @@ void Start()
     // Setup the viewport for displaying the scene
     SetupViewport();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE);
+
     // Hook up to the frame update events
     SubscribeToEvents();
 }

--- a/bin/Data/Scripts/31_MaterialAnimation.as
+++ b/bin/Data/Scripts/31_MaterialAnimation.as
@@ -18,6 +18,9 @@ void Start()
     // Setup the viewport for displaying the scene
     SetupViewport();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE);
+
     // Hook up to the frame update events
     SubscribeToEvents();
 }

--- a/bin/Data/Scripts/32_Urho2DConstraints.as
+++ b/bin/Data/Scripts/32_Urho2DConstraints.as
@@ -20,6 +20,8 @@ void Start()
     CreateScene();
     input.mouseVisible = true; // Show mouse cursor
     CreateInstructions();
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE);
     SubscribeToEvents();
 }
 

--- a/bin/Data/Scripts/33_Urho2DSpriterAnimation.as
+++ b/bin/Data/Scripts/33_Urho2DSpriterAnimation.as
@@ -23,6 +23,9 @@ void Start()
     // Setup the viewport for displaying the scene
     SetupViewport();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE);
+
     // Hook up to the frame update events
     SubscribeToEvents();
 }

--- a/bin/Data/Scripts/34_DynamicGeometry.as
+++ b/bin/Data/Scripts/34_DynamicGeometry.as
@@ -27,6 +27,9 @@ void Start()
     // Setup the viewport for displaying the scene
     SetupViewport();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE);
+
     // Hook up to the frame update events
     SubscribeToEvents();
 }
@@ -34,7 +37,7 @@ void Start()
 void CreateScene()
 {
     scene_ = Scene();
-    
+
     // Create the Octree component to the scene so that drawable objects can be rendered. Use default volume
     // (-1000, -1000, -1000) to (1000, 1000, 1000)
     scene_.CreateComponent("Octree");
@@ -46,7 +49,7 @@ void CreateScene()
     zone.fogColor = Color(0.2, 0.2, 0.2);
     zone.fogStart = 200.0;
     zone.fogEnd = 300.0;
-    
+
     // Create a directional light
     Node@ lightNode = scene_.CreateChild("DirectionalLight");
     lightNode.direction = Vector3(-0.6, -1.0, -0.8); // The direction vector does not need to be normalized
@@ -54,7 +57,7 @@ void CreateScene()
     light.lightType = LIGHT_DIRECTIONAL;
     light.color = Color(0.4, 1.0, 0.4);
     light.specularIntensity = 1.5;
-    
+
     // Get the original model and its unmodified vertices, which are used as source data for the animation
     Model@ originalModel = cache.GetResource("Model", "Models/Box.mdl");
     if (originalModel is null)
@@ -103,12 +106,12 @@ void CreateScene()
             animatingBuffers.Push(cloneModel.GetGeometry(0, 0).vertexBuffers[0]);
         }
     }
-    
+
     // Finally create one model (pyramid shape) and a StaticModel to display it from scratch
     // Note: there are duplicated vertices to enable face normals. We will calculate normals programmatically
     {
         const uint numVertices = 18;
-        
+
         float[] vertexData = {
             // Position          Normal
             0.0, 0.5, 0.0,       0.0, 0.0, 0.0,
@@ -135,7 +138,7 @@ void CreateScene()
             -0.5, -0.5, 0.5,     0.0, 0.0, 0.0,
             -0.5, -0.5, -0.5,    0.0, 0.0, 0.0
         };
-        
+
         const uint16[] indexData = {
             0, 1, 2,
             3, 4, 5,
@@ -144,7 +147,7 @@ void CreateScene()
             12, 13, 14,
             15, 16, 17
         };
-        
+
         // Calculate face normals now
         for (uint i = 0; i < numVertices; i += 3)
         {
@@ -265,13 +268,13 @@ void MoveCamera(float timeStep)
 void AnimateObjects(float timeStep)
 {
     animTime += timeStep * 100.0;
-    
+
     // Repeat for each of the cloned vertex buffers
     for (uint i = 0; i < animatingBuffers.length; ++i)
     {
         float startPhase = animTime + i * 30.0;
         VertexBuffer@ buffer = animatingBuffers[i];
-        
+
         // Need to prepare a VectorBuffer with all data (positions, normals, uvs...)
         VectorBuffer newData;
         uint numVertices = buffer.vertexCount;
@@ -285,7 +288,7 @@ void AnimateObjects(float timeStep)
             dest.x = src.x * (1.0 + 0.1 * Sin(phase));
             dest.y = src.y * (1.0 + 0.1 * Sin(phase + 60.0));
             dest.z = src.z * (1.0 + 0.1 * Sin(phase + 120.0));
-            
+
             // Write position
             newData.WriteVector3(dest);
             // Copy other vertex elements
@@ -293,7 +296,7 @@ void AnimateObjects(float timeStep)
             for (uint k = 12; k < vertexSize; k += 4)
                 newData.WriteFloat(originalVertexData.ReadFloat());
         }
-        
+
         buffer.SetData(newData);
     }
 }

--- a/bin/Data/Scripts/35_SignedDistanceFieldText.as
+++ b/bin/Data/Scripts/35_SignedDistanceFieldText.as
@@ -21,6 +21,9 @@ void Start()
     // Setup the viewport for displaying the scene
     SetupViewport();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE);
+
     // Hook up to the frame update events
     SubscribeToEvents();
 }

--- a/bin/Data/Scripts/36_Urho2DTileMap.as
+++ b/bin/Data/Scripts/36_Urho2DTileMap.as
@@ -20,6 +20,9 @@ void Start()
     // Setup the viewport for displaying the scene
     SetupViewport();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE);
+
     // Hook up to the frame update events
     SubscribeToEvents();
 }

--- a/bin/Data/Scripts/37_UIDrag.as
+++ b/bin/Data/Scripts/37_UIDrag.as
@@ -19,10 +19,13 @@ void Start()
     String platform = GetPlatform();
     if (platform != "Android" and platform != "iOS")
         input.mouseVisible = true;
-    
+
     // Create the UI content
     CreateGUI();
     CreateInstructions();
+
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE);
 
     // Hook up to the frame update events
     SubscribeToEvents();
@@ -92,8 +95,8 @@ void CreateInstructions()
 {
     // Construct new Text object, set string to display and font to use
     Text@ instructionText = ui.root.CreateChild("Text");
-    instructionText.text = "Drag on the buttons to move them around.\n" + 
-                           "Touch input allows also multi-drag.\n" + 
+    instructionText.text = "Drag on the buttons to move them around.\n" +
+                           "Touch input allows also multi-drag.\n" +
                            "Press SPACE to show/hide tagged UI elements.";
     instructionText.SetFont(cache.GetResource("Font", "Fonts/Anonymous Pro.ttf"), 15);
     instructionText.textAlignment = HA_CENTER;
@@ -164,7 +167,7 @@ void HandleUpdate(StringHash eventType, VariantMap& eventData)
         Text@ t = root.GetChild("Touch " + String(i));
         TouchState@ ts = input.touches[i];
         t.text = "Touch "+ String(ts.touchID);
-        
+
         IntVector2 pos = ts.position;
         pos.y -= 30;
 
@@ -177,7 +180,7 @@ void HandleUpdate(StringHash eventType, VariantMap& eventData)
         Text@ t = root.GetChild("Touch " + String(i));
         t.visible = false;
     }
-    
+
     if (input.keyPress[KEY_SPACE])
     {
         Array<UIElement@>@ elements = root.GetChildrenWithTag("SomeTag");

--- a/bin/Data/Scripts/38_SceneAndUILoad.as
+++ b/bin/Data/Scripts/38_SceneAndUILoad.as
@@ -19,7 +19,10 @@ void Start()
 
     // Setup the viewport for displaying the scene
     SetupViewport();
-    
+
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE);
+
     // Subscribe to global events for camera movement
     SubscribeToEvents();
 }
@@ -105,8 +108,14 @@ void HandleUpdate(StringHash eventType, VariantMap& eventData)
 
 void MoveCamera(float timeStep)
 {
+    input.mouseVisible = input.mouseMode != MM_RELATIVE;
+    bool mouseDown = input.mouseButtonDown[MOUSEB_RIGHT];
+
+    // Override the MM_RELATIVE mouse grabbed settings, to allow interaction with UI
+    input.mouseGrabbed = mouseDown;
+
     // Right mouse button controls mouse cursor visibility: hide when pressed
-    ui.cursor.visible = !input.mouseButtonDown[MOUSEB_RIGHT];
+    ui.cursor.visible = !mouseDown;
 
     // Do not move if the UI has a focused element
     if (ui.focusElement !is null)

--- a/bin/Data/Scripts/39_CrowdNavigation.as
+++ b/bin/Data/Scripts/39_CrowdNavigation.as
@@ -27,6 +27,9 @@ void Start()
     // Setup the viewport for displaying the scene
     SetupViewport();
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_RELATIVE);
+
     // Hook up to the frame update and render post-update events
     SubscribeToEvents();
 }
@@ -339,8 +342,14 @@ bool Raycast(float maxDistance, Vector3& hitPos, Drawable@& hitDrawable)
 
 void MoveCamera(float timeStep)
 {
+    input.mouseVisible = input.mouseMode != MM_RELATIVE;
+    bool mouseDown = input.mouseButtonDown[MOUSEB_RIGHT];
+
+    // Override the MM_RELATIVE mouse grabbed settings, to allow interaction with UI
+    input.mouseGrabbed = mouseDown;
+
     // Right mouse button controls mouse cursor visibility: hide when pressed
-    ui.cursor.visible = !input.mouseButtonDown[MOUSEB_RIGHT];
+    ui.cursor.visible = !mouseDown;
 
     // Do not move if the UI has a focused element (the console)
     if (ui.focusElement !is null)

--- a/bin/Data/Scripts/40_Localization.as
+++ b/bin/Data/Scripts/40_Localization.as
@@ -10,10 +10,10 @@ void Start()
 {
     // Execute the common startup for samples
     SampleStart();
-    
+
     // Enable OS cursor
     input.mouseVisible = true;
-    
+
     // Load strings from JSON files and subscribe to the change language event
     InitLocalizationSystem();
 
@@ -22,6 +22,9 @@ void Start()
 
     // Init the user interface
     CreateGUI();
+
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE);
 }
 
 void InitLocalizationSystem()
@@ -66,14 +69,14 @@ void CreateGUI()
     window.AddChild(b);
     b.SetStyle("Button");
     b.minHeight = 24;
-    
+
     Text@ t = b.CreateChild("Text", "ButtonTextChangeLang");
     // The showing text value will automatically change when language is changed
     t.autoLocalizable = true;
     // The text value used as a string identifier in this mode.
     // Remember that a letter case of the id and of the lang name is important.
     t.text = "Press this button";
-    
+
     t.SetAlignment(HA_CENTER, VA_CENTER);
     t.SetStyle("Text");
     SubscribeToEvent(b, "Released", "HandleChangeLangButtonPressed");
@@ -85,10 +88,10 @@ void CreateGUI()
     t = b.CreateChild("Text", "ButtonTextQuit");
     t.SetAlignment(HA_CENTER, VA_CENTER);
     t.SetStyle("Text");
-    
+
     // Manually set text in the current language
     t.text = localization.Get("quit");
-    
+
     SubscribeToEvent(b, "Released", "HandleQuitButtonPressed");
 }
 
@@ -96,7 +99,7 @@ void CreateScene()
 {
     scene_ = Scene();
     scene_.CreateComponent("Octree");
-    
+
     Zone@ zone = scene_.CreateComponent("Zone");
     zone.boundingBox = BoundingBox(-1000.0f, 1000.0f);
     zone.ambientColor = Color(0.5f, 0.5f, 0.5f);

--- a/bin/Data/Scripts/41_DatabaseDemo.as
+++ b/bin/Data/Scripts/41_DatabaseDemo.as
@@ -34,6 +34,9 @@ void Start()
     // Show OS mouse cursor
     input.mouseVisible = true;
 
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE);
+
     // Open the operating system console window (for stdin / stdout) if not open yet
     // Do not open in fullscreen, as this would cause constant device loss
     if (!graphics.fullscreen)


### PR DESCRIPTION
Some fixes to the input issues that have popped up on the Web platform, and an attempt to make the mouse modes compatible with the Console.

Related issue: https://github.com/urho3d/Urho3D/issues/917

```
- Added a way to suppress mouse mode and mouse grab changes (SetMouseMode(mode, suppress = false), 
SetMouseGrabbed(grab, suppress = false)), and reset them to a previous unsuppressed state (ResetMouseMode, 
ResetMouseGrabbed).
- Updated Console to react to mouse modes, similarly to mouse visibility previously.
- Console will utilize UI cursor if available.
- Fixed a bug with mouse modes not calling SetMouseGrab correctly.
- Updated samples to use different mouse modes where necessary.
- Updated samples to request pointer lock on mouse down event (Web platform).
- Updated samples that show the UI cursor to show the OS cursor if pointer lock (ie, mouse mode MM_RELATIVE) 
isn't acquired. This conceals a visual bug in UI cursor position (Web platform).
```