### PR TITLE
Exposing AnimationTrack class as part of the public API

### DIFF
--- a/Source/Urho3D/Graphics/Animation.h
+++ b/Source/Urho3D/Graphics/Animation.h
@@ -51,7 +51,7 @@ struct AnimationKeyFrame
 };
 
 /// Skeletal animation track, stores keyframes of a single bone.
-struct AnimationTrack
+struct URHO3D_API AnimationTrack
 {
     /// Construct.
     AnimationTrack() :
@@ -69,7 +69,7 @@ struct AnimationTrack
     void RemoveKeyFrame(unsigned index);
     /// Remove all keyframes.
     void RemoveAllKeyFrames();
-    
+
     /// Return keyframe at index, or null if not found.
     AnimationKeyFrame* GetKeyFrame(unsigned index);
     /// Return number of keyframes.


### PR DESCRIPTION
I was trying to add procedurally generation animation tracks but was getting the error ```undefined reference to``` whenever I tried using member functions of ```AnimationTrack```.