### PR TITLE
Urho2D Sprite2D border fix

### DIFF
--- a/Source/Urho3D/Urho2D/Sprite2D.cpp
+++ b/Source/Urho3D/Urho2D/Sprite2D.cpp
@@ -169,8 +169,8 @@ bool Sprite2D::GetTextureRectangle(Rect& rect, bool flipX, bool flipY) const
     rect.min_.x_ = rectangle_.left_ * invWidth + edgeOffset_;
     rect.max_.x_ = rectangle_.right_ * invWidth - edgeOffset_;
 
-    rect.min_.y_ = rectangle_.bottom_ * invHeight + edgeOffset_;
-    rect.max_.y_ = rectangle_.top_ * invHeight - edgeOffset_;
+    rect.min_.y_ = rectangle_.bottom_ * invHeight - edgeOffset_;
+    rect.max_.y_ = rectangle_.top_ * invHeight + edgeOffset_;
 
     if (flipX)
         Swap(rect.min_.x_, rect.max_.x_);

--- a/Source/Urho3D/Urho2D/Sprite2D.cpp
+++ b/Source/Urho3D/Urho2D/Sprite2D.cpp
@@ -107,15 +107,6 @@ bool Sprite2D::EndLoad()
 void Sprite2D::SetTexture(Texture2D* texture)
 {
     texture_ = texture;
-    // Ensure the texture doesn't have wrap addressing as that will cause bleeding bugs on the edges.
-    // Could also choose border mode, but in that case a universally good border color (without alpha bugs)
-    // would be hard to choose. Ideal is for the user to configure the texture parameters in its parameter
-    // XML file.
-    if (texture_->GetAddressMode(COORD_U) == ADDRESS_WRAP)
-    {
-        texture_->SetAddressMode(COORD_U, ADDRESS_CLAMP);
-        texture_->SetAddressMode(COORD_V, ADDRESS_CLAMP);
-    }
 }
 
 void Sprite2D::SetRectangle(const IntRect& rectangle)

--- a/Source/Urho3D/Urho2D/Sprite2D.cpp
+++ b/Source/Urho3D/Urho2D/Sprite2D.cpp
@@ -38,7 +38,8 @@ namespace Urho3D
 Sprite2D::Sprite2D(Context* context) :
     Resource(context),
     hotSpot_(0.5f, 0.5f),
-    offset_(0, 0)
+    offset_(0, 0),
+    edgeOffset_(0.0001f)
 {
 
 }
@@ -137,6 +138,11 @@ void Sprite2D::SetSpriteSheet(SpriteSheet2D* spriteSheet)
     spriteSheet_ = spriteSheet;
 }
 
+void Sprite2D::SetTextureEdgeOffset(float offset)
+{
+    edgeOffset_ = offset;
+}
+
 bool Sprite2D::GetDrawRectangle(Rect& rect, bool flipX, bool flipY) const
 {
     return GetDrawRectangle(rect, hotSpot_, flipX, flipY);
@@ -169,11 +175,11 @@ bool Sprite2D::GetTextureRectangle(Rect& rect, bool flipX, bool flipY) const
     float invWidth = 1.0f / (float)texture_->GetWidth();
     float invHeight = 1.0f / (float)texture_->GetHeight();
 
-    rect.min_.x_ = rectangle_.left_ * invWidth;
-    rect.max_.x_ = rectangle_.right_ * invWidth;
+    rect.min_.x_ = rectangle_.left_ * invWidth + edgeOffset_;
+    rect.max_.x_ = rectangle_.right_ * invWidth - edgeOffset_;
 
-    rect.min_.y_ = rectangle_.bottom_ * invHeight;
-    rect.max_.y_ = rectangle_.top_ * invHeight;
+    rect.min_.y_ = rectangle_.bottom_ * invHeight + edgeOffset_;
+    rect.max_.y_ = rectangle_.top_ * invHeight - edgeOffset_;
 
     if (flipX)
         Swap(rect.min_.x_, rect.max_.x_);

--- a/Source/Urho3D/Urho2D/Sprite2D.h
+++ b/Source/Urho3D/Urho2D/Sprite2D.h
@@ -58,6 +58,8 @@ public:
     void SetOffset(const IntVector2& offset);
     /// Set sprite sheet.
     void SetSpriteSheet(SpriteSheet2D* spriteSheet);
+    /// Set texture edge offset.
+    void SetTextureEdgeOffset(float offset);
 
     /// Return texture.
     Texture2D* GetTexture() const { return texture_; }
@@ -73,6 +75,9 @@ public:
 
     /// Return sprite sheet.
     SpriteSheet2D* GetSpriteSheet() const { return spriteSheet_; }
+
+    /// Return texture edge offset
+    float GetTextureEdgeOffset() const { return edgeOffset_; }
 
     /// Return draw rectangle.
     bool GetDrawRectangle(Rect& rect, bool flipX = false, bool flipY = false) const;
@@ -99,6 +104,8 @@ private:
     WeakPtr<SpriteSheet2D> spriteSheet_;
     /// Texture used while loading.
     SharedPtr<Texture2D> loadTexture_;
+    /// Offset to fix texture edge bleeding.
+    float edgeOffset_;
 };
 
 }


### PR DESCRIPTION
Two commits, the first adds a member variable to Sprite2D that defines an amount to offset a texture 'inwards' to fix texture bleeding issues, which is absolutely paramount when not using full textures, like via a SpriteSheet, and should consequently also resolve the need to set textures to CLAMP'd mode.

The second commit removes the Sprite2D code and comment that force overrides a materials UV mode to CLAMP as that issue should not be resolved as well.  However if this is not wanted then state and I can delete it, but I left it as a secondary commit so it is obvious in the git logs in case a rollback if ever wanted on just that part.