### PR TITLE
Applied patch to fix undefined reference error when compiling for Wayland on Linux.

### DIFF
--- a/Source/ThirdParty/SDL/src/video/wayland/SDL_waylanddyn.h
+++ b/Source/ThirdParty/SDL/src/video/wayland/SDL_waylanddyn.h
@@ -79,6 +79,7 @@ void SDL_WAYLAND_UnloadSymbols(void);
 #define wl_proxy_get_user_data (*WAYLAND_wl_proxy_get_user_data)
 #define wl_proxy_add_listener (*WAYLAND_wl_proxy_add_listener)
 #define wl_proxy_marshal_constructor (*WAYLAND_wl_proxy_marshal_constructor)
+#define wl_proxy_marshal_constructor_versioned (*WAYLAND_wl_proxy_marshal_constructor_versioned)
 
 #define wl_seat_interface (*WAYLAND_wl_seat_interface)
 #define wl_surface_interface (*WAYLAND_wl_surface_interface)

--- a/Source/ThirdParty/SDL/src/video/wayland/SDL_waylandsym.h
+++ b/Source/ThirdParty/SDL/src/video/wayland/SDL_waylandsym.h
@@ -55,6 +55,9 @@ SDL_WAYLAND_SYM(void, wl_list_insert_list, (struct wl_list *, struct wl_list *))
 SDL_WAYLAND_MODULE(WAYLAND_CLIENT_1_4)
 SDL_WAYLAND_SYM(struct wl_proxy *, wl_proxy_marshal_constructor, (struct wl_proxy *, uint32_t opcode, const struct wl_interface *interface, ...))
 
+SDL_WAYLAND_MODULE(WAYLAND_CLIENT_1_10)
+SDL_WAYLAND_SYM(struct wl_proxy *, wl_proxy_marshal_constructor_versioned, (struct wl_proxy *proxy, uint32_t opcode, const struct wl_interface *interface, uint32_t version, ...))
+
 SDL_WAYLAND_INTERFACE(wl_seat_interface)
 SDL_WAYLAND_INTERFACE(wl_surface_interface)
 SDL_WAYLAND_INTERFACE(wl_shm_pool_interface)


### PR DESCRIPTION
Applied patch to fix undefined reference error when compiling for Wayland (1.10) on Linux.

This has been fixed in SDL, but no SDL release has been made that includes this fix.

The SDL fix can be found here:
https://hg.libsdl.org/SDL/rev/330f500d5815

In the mean time, this fixes Urho3D compilation on Linux.

```
[ 74%] Linking CXX executable ../../../bin/Urho3DPlayer
../../../lib/libUrho3D.a(SDL_waylandvideo.c.o): In function `display_handle_global':
SDL_waylandvideo.c:(.text+0x593): undefined reference to `wl_proxy_marshal_constructor_versioned'
SDL_waylandvideo.c:(.text+0x5d4): undefined reference to `wl_proxy_marshal_constructor_versioned'
SDL_waylandvideo.c:(.text+0x61d): undefined reference to `wl_proxy_marshal_constructor_versioned'
SDL_waylandvideo.c:(.text+0x684): undefined reference to `wl_proxy_marshal_constructor_versioned'
SDL_waylandvideo.c:(.text+0x6cc): undefined reference to `wl_proxy_marshal_constructor_versioned'
../../../lib/libUrho3D.a(SDL_waylandvideo.c.o):SDL_waylandvideo.c:(.text+0x6fb): more undefined references to `wl_proxy_marshal_constructor_versioned' follow
collect2: error: ld returned 1 exit status
Source/Tools/Urho3DPlayer/CMakeFiles/Urho3DPlayer.dir/build.make:95: recipe for target 'bin/Urho3DPlayer' failed
make[2]: *** [bin/Urho3DPlayer] Error 1
CMakeFiles/Makefile2:1282: recipe for target 'Source/Tools/Urho3DPlayer/CMakeFiles/Urho3DPlayer.dir/all' failed
make[1]: *** [Source/Tools/Urho3DPlayer/CMakeFiles/Urho3DPlayer.dir/all] Error 2
Makefile:149: recipe for target 'all' failed
make: *** [all] Error 2
```