### PR TITLE
Optimized Image::ClearInt() for the four component case (ARGB). In my ca…

### DIFF
--- a/Source/Urho3D/Resource/Image.cpp
+++ b/Source/Urho3D/Resource/Image.cpp
@@ -1114,9 +1114,20 @@ void Image::ClearInt(unsigned uintColor)
         return;
     }
 
-    unsigned char* src = (unsigned char*)&uintColor;
-    for (unsigned i = 0; i < width_ * height_ * depth_ * components_; ++i)
-        data_[i] = src[i % components_];
+    if(components_==4)
+    {
+        uint32_t color=uintColor;
+        uint32_t* data=(uint32_t*)GetData();
+        uint32_t* data_end=(uint32_t*)(GetData()+width_ * height_ * depth_ * components_);
+        for (; data < data_end; data++)
+            *data = color;
+    }
+    else
+    {
+        unsigned char* src = (unsigned char*)&uintColor;
+        for (unsigned i = 0; i < width_ * height_ * depth_ * components_; ++i)
+            data_[i] = src[i % components_];
+    }
 }
 
 bool Image::SaveBMP(const String& fileName) const

--- a/Source/Urho3D/Resource/Image.cpp
+++ b/Source/Urho3D/Resource/Image.cpp
@@ -1114,12 +1114,12 @@ void Image::ClearInt(unsigned uintColor)
         return;
     }
 
-    if(components_==4)
+    if (components_ == 4)
     {
-        uint32_t color=uintColor;
-        uint32_t* data=(uint32_t*)GetData();
-        uint32_t* data_end=(uint32_t*)(GetData()+width_ * height_ * depth_ * components_);
-        for (; data < data_end; data++)
+        uint32_t color = uintColor;
+        uint32_t* data = (uint32_t*)GetData();
+        uint32_t* data_end = (uint32_t*)(GetData() + width_ * height_ * depth_ * components_);
+        for (; data < data_end; ++data)
             *data = color;
     }
     else


### PR DESCRIPTION
…se this optimized ClearInt() only takes ~0.362ms compared to 14.853ms before, see http://i.imgur.com/8O7V77o.jpg vs http://i.imgur.com/qjhkaWw.jpg.
~~There could be an issue, see #1260.~~