### PR TITLE
Moved container begin and end from std to Urho3D namespace

### DIFF
--- a/Source/Urho3D/Container/HashMap.h
+++ b/Source/Urho3D/Container/HashMap.h
@@ -719,11 +719,6 @@ private:
     unsigned Hash(const T& key) const { return MakeHash(key) & (NumBuckets() - 1); }
 };
 
-}
-
-namespace std
-{
-
 template <class T, class U> typename Urho3D::HashMap<T, U>::ConstIterator begin(const Urho3D::HashMap<T, U>& v) { return v.Begin(); }
 
 template <class T, class U> typename Urho3D::HashMap<T, U>::ConstIterator end(const Urho3D::HashMap<T, U>& v) { return v.End(); }

--- a/Source/Urho3D/Container/HashSet.h
+++ b/Source/Urho3D/Container/HashSet.h
@@ -607,11 +607,6 @@ private:
     unsigned Hash(const T& key) const { return MakeHash(key) & (NumBuckets() - 1); }
 };
 
-}
-
-namespace std
-{
-
 template <class T> typename Urho3D::HashSet<T>::ConstIterator begin(const Urho3D::HashSet<T>& v) { return v.Begin(); }
 
 template <class T> typename Urho3D::HashSet<T>::ConstIterator end(const Urho3D::HashSet<T>& v) { return v.End(); }

--- a/Source/Urho3D/Container/List.h
+++ b/Source/Urho3D/Container/List.h
@@ -474,11 +474,6 @@ private:
     }
 };
 
-}
-
-namespace std
-{
-
 template <class T> typename Urho3D::List<T>::ConstIterator begin(const Urho3D::List<T>& v) { return v.Begin(); }
 
 template <class T> typename Urho3D::List<T>::ConstIterator end(const Urho3D::List<T>& v) { return v.End(); }

--- a/Source/Urho3D/Container/Vector.h
+++ b/Source/Urho3D/Container/Vector.h
@@ -941,11 +941,6 @@ private:
     }
 };
 
-}
-
-namespace std
-{
-
 template <class T> typename Urho3D::Vector<T>::ConstIterator begin(const Urho3D::Vector<T>& v) { return v.Begin(); }
 
 template <class T> typename Urho3D::Vector<T>::ConstIterator end(const Urho3D::Vector<T>& v) { return v.End(); }


### PR DESCRIPTION
This makes range based for loops work for me.
When begin and end are in the std namespace I get compiler errors saying they have not been declared.