### PR TITLE
Aggregate initializer constructors for container types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ configure*
 *.log
 *.bak
 Thumbs.db
+.directory

--- a/Source/Urho3D/Container/HashMap.h
+++ b/Source/Urho3D/Container/HashMap.h
@@ -28,6 +28,9 @@
 #include "../Container/Vector.h"
 
 #include <cassert>
+#if URHO3D_CXX11
+#include <initializer_list>
+#endif
 
 namespace Urho3D
 {
@@ -237,7 +240,16 @@ public:
         head_ = tail_ = ReserveNode();
         *this = map;
     }
-
+#if URHO3D_CXX11
+    /// Aggregate initialization constructor.
+    HashMap(const std::initializer_list<Pair<T, U>>& list) : HashMap()
+    {
+        for (auto it = list.begin(); it != list.end(); it++)
+        {
+            Insert(*it);
+        }
+    }
+#endif
     /// Destruct.
     ~HashMap()
     {

--- a/Source/Urho3D/Container/HashSet.h
+++ b/Source/Urho3D/Container/HashSet.h
@@ -26,6 +26,9 @@
 #include "../Container/Sort.h"
 
 #include <cassert>
+#if URHO3D_CXX11
+#include <initializer_list>
+#endif
 
 namespace Urho3D
 {
@@ -192,7 +195,16 @@ public:
         head_ = tail_ = ReserveNode();
         *this = set;
     }
-
+#if URHO3D_CXX11
+    /// Aggregate initialization constructor.
+    HashSet(const std::initializer_list<T>& list) : HashSet()
+    {
+        for (auto it = list.begin(); it != list.end(); it++)
+        {
+            Insert(*it);
+        }
+    }
+#endif
     /// Destruct.
     ~HashSet()
     {

--- a/Source/Urho3D/Container/LinkedList.h
+++ b/Source/Urho3D/Container/LinkedList.h
@@ -27,6 +27,9 @@
 #else
 #include <Urho3D/Urho3D.h>
 #endif
+#if URHO3D_CXX11
+#include <initializer_list>
+#endif
 
 namespace Urho3D
 {
@@ -53,7 +56,16 @@ public:
         head_(0)
     {
     }
-
+#if URHO3D_CXX11
+    /// Aggregate initialization constructor.
+    LinkedList(const std::initializer_list<T>& list) : LinkedList()
+    {
+        for (auto it = list.begin(); it != list.end(); it++)
+        {
+            Insert(*it);
+        }
+    }
+#endif
     /// Destruct.
     ~LinkedList()
     {

--- a/Source/Urho3D/Container/List.h
+++ b/Source/Urho3D/Container/List.h
@@ -23,6 +23,9 @@
 #pragma once
 
 #include "../Container/ListBase.h"
+#if URHO3D_CXX11
+#include <initializer_list>
+#endif
 
 namespace Urho3D
 {
@@ -185,7 +188,16 @@ public:
         head_ = tail_ = ReserveNode();
         *this = list;
     }
-
+#if URHO3D_CXX11
+    /// Aggregate initialization constructor.
+    List(const std::initializer_list<T>& list) : List()
+    {
+        for (auto it = list.begin(); it != list.end(); it++)
+        {
+            Push(*it);
+        }
+    }
+#endif
     /// Destruct.
     ~List()
     {

--- a/Source/Urho3D/Container/Vector.h
+++ b/Source/Urho3D/Container/Vector.h
@@ -27,6 +27,9 @@
 #include <cassert>
 #include <cstring>
 #include <new>
+#if URHO3D_CXX11
+#include <initializer_list>
+#endif
 
 #ifdef _MSC_VER
 #pragma warning(push)
@@ -66,7 +69,16 @@ public:
     {
         *this = vector;
     }
-
+#if URHO3D_CXX11
+    /// Aggregate initialization constructor.
+    Vector(const std::initializer_list<T>& list) : Vector()
+    {
+        for (auto it = list.begin(); it != list.end(); it++)
+        {
+            Push(*it);
+        }
+    }
+#endif
     /// Destruct.
     ~Vector()
     {

--- a/Source/Urho3D/Scene/ValueAnimationInfo.h
+++ b/Source/Urho3D/Scene/ValueAnimationInfo.h
@@ -33,7 +33,7 @@ class ValueAnimation;
 struct VAnimEventFrame;
 
 /// Base class for a value animation instance, which includes animation runtime information and updates the target object's value automatically.
-class ValueAnimationInfo : public RefCounted
+class URHO3D_API ValueAnimationInfo : public RefCounted
 {
 public:
     /// Construct without target object.


### PR DESCRIPTION
Discussed [here](http://urho3d.prophpbb.com/topic1988.html). This includes only constructors, `SendEvent()` with const `VariantMap` is not included. They are only active if urho3d is built with `-DURHO3D_C++11` and are disabled on compilers that do not use c++11.

Also piggy-backed few small commits that seemed not worthy of their own PR:

* Added `.directory` files to `.gitignore` as KDE/plasma stores folder settings in there.
* Added `URHO3D_API` to `ValueAnimationInfo` class declaration so it is exposed in shared library.