### PR TITLE
C++11 event binding (lambdas/std::bind).

### DIFF
--- a/Source/Urho3D/Core/Object.cpp
+++ b/Source/Urho3D/Core/Object.cpp
@@ -181,6 +181,18 @@ void Object::SubscribeToEvent(Object* sender, StringHash eventType, EventHandler
     context_->AddEventReceiver(this, sender, eventType);
 }
 
+#if URHO3D_CXX11
+void Object::SubscribeToEvent(StringHash eventType, const std::function<void(StringHash, VariantMap&)>& function, void* userData/*=0*/)
+{
+    SubscribeToEvent(eventType, new EventHandler11Impl(function, userData));
+}
+
+void Object::SubscribeToEvent(Object* sender, StringHash eventType, const std::function<void(StringHash, VariantMap&)>& function, void* userData/*=0*/)
+{
+    SubscribeToEvent(sender, eventType, new EventHandler11Impl(function, userData));
+}
+#endif
+
 void Object::UnsubscribeFromEvent(StringHash eventType)
 {
     for (;;)


### PR DESCRIPTION
And removed redundant EventHandler() constructor adding default value 0 for `userData`. Less code, does exactly the same. If there was good reason for two constructors to exist please let me know, ill be happy to fix PR in case this is unwanted change.

Now it is possible to:

    SubscribeToEvent(..., [&](StringHash type, VariantMap& args) {
        // win
    });

    void Class::SomeEventHandler(StringHash type, VariantMap& args)
    {
    }

    SubscribeToEvent(..., std::bind(&Class::SomeEventHandler, this)));

    void Class::SomeOtherEventHandler(VariantMap& args)
    {
    }

    SubscribeToEvent(..., std::bind(&Class::SomeOtherEventHandler, this, _2)));

There is an ugly workaround - `EventHandler` asserts that `receiver_` is not `0`. This is not relevant in case of c++11 as receiver is captured by `std::function<>` therefore i set `receiver_` to `0xDEADBEEF`. This should not cause any problems as long as person is aware of what he is doing and is not trying to get received from callback bound via c++11 methods. In case of a mistake it should quickly become clear that something is amiss due to very visual value of receiver pointer.