### PR TITLE
Shader animation bug.

### DIFF
--- a/Source/Urho3D/Graphics/Material.cpp
+++ b/Source/Urho3D/Graphics/Material.cpp
@@ -1235,7 +1235,7 @@ void Material::UpdateEventSubscription()
             SubscribeToEvent(E_UPDATE, URHO3D_HANDLER(Material, HandleAttributeAnimationUpdate));
         subscribed_ = true;
     }
-    else if (subscribed_)
+    else if (subscribed_ && shaderParameterAnimationInfos_.Empty())
     {
         UnsubscribeFromEvent(E_UPDATE);
         UnsubscribeFromEvent(E_ATTRIBUTEANIMATIONUPDATE);


### PR DESCRIPTION
Changed the conditions when unsubscribes the shader animation events.
Or it will unsubcribe all the events if you call SetShaderParameterAnimation function twice. (For example, you need to animate texture U and V )