### PR TITLE
Add additional Variant Types For ScriptInstance::Execute()

### DIFF
--- a/Source/Urho3D/AngelScript/ScriptFile.cpp
+++ b/Source/Urho3D/AngelScript/ScriptFile.cpp
@@ -769,6 +769,42 @@ void ScriptFile::SetParameters(asIScriptContext* context, asIScriptFunction* fun
                     context->SetArgObject(i, (void*)&parameters[i].GetString());
                     break;
 
+                case VAR_VARIANTMAP:
+                    context->SetArgObject(i, (void*)&parameters[i].GetVariantMap());
+                    break;
+
+                case VAR_INTRECT:
+                    context->SetArgObject(i, (void*)&parameters[i].GetIntRect());
+                    break;
+
+                case VAR_INTVECTOR2:
+                    context->SetArgObject(i, (void*)&parameters[i].GetIntVector2());
+                    break;
+
+                case VAR_COLOR:
+                    context->SetArgObject(i, (void*)&parameters[i].GetColor());
+                    break;
+
+                case VAR_MATRIX3:
+                    context->SetArgObject(i, (void*)&parameters[i].GetMatrix3());
+                    break;
+
+                case VAR_MATRIX3X4:
+                    context->SetArgObject(i, (void*)&parameters[i].GetMatrix3x4());
+                    break;
+
+                case VAR_MATRIX4:
+                    context->SetArgObject(i, (void*)&parameters[i].GetMatrix4());
+                    break;
+
+                case VAR_RESOURCEREF:
+                    context->SetArgObject(i, (void*)&parameters[i].GetResourceRef());
+                    break;
+
+                case VAR_RESOURCEREFLIST:
+                    context->SetArgObject(i, (void*)&parameters[i].GetResourceRefList());
+                    break;
+
                 case VAR_VOIDPTR:
                     context->SetArgObject(i, parameters[i].GetVoidPtr());
                     break;


### PR DESCRIPTION
I noticed that some variant types that have objects exposed to the AngelScript subsystem are not captured as type of parameters that can be passed when calling an AngelScript function from C++. This implementation rectifies it.