### PR TITLE
ScrollBar base class from UIElement to BorderImage

### DIFF
--- a/Source/Urho3D/LuaScript/pkgs/UI/ScrollBar.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/UI/ScrollBar.pkg
@@ -1,6 +1,6 @@
 $#include "UI/ScrollBar.h"
 
-class ScrollBar : public UIElement
+class ScrollBar : public BorderImage
 {
     ScrollBar();
     virtual ~ScrollBar();

--- a/Source/Urho3D/UI/ScrollBar.cpp
+++ b/Source/Urho3D/UI/ScrollBar.cpp
@@ -40,7 +40,7 @@ extern const char* orientations[];
 extern const char* UI_CATEGORY;
 
 ScrollBar::ScrollBar(Context* context) :
-    UIElement(context),
+    BorderImage(context),
     scrollStep_(DEFAULT_SCROLL_STEP),
     stepFactor_(1.0f),
     leftRect_(IntRect::ZERO),
@@ -62,6 +62,9 @@ ScrollBar::ScrollBar(Context* context) :
     forwardButton_->SetRepeat(DEFAULT_REPEAT_DELAY, DEFAULT_REPEAT_RATE);
     forwardButton_->SetFocusMode(FM_NOTFOCUSABLE);
 
+    // For backward compatibility
+    SetColor(Color(0.0f, 0.0f, 0.0f, 0.0f));
+
     SubscribeToEvent(backButton_, E_PRESSED, URHO3D_HANDLER(ScrollBar, HandleBackButtonPressed));
     SubscribeToEvent(forwardButton_, E_PRESSED, URHO3D_HANDLER(ScrollBar, HandleForwardButtonPressed));
     SubscribeToEvent(slider_, E_SLIDERCHANGED, URHO3D_HANDLER(ScrollBar, HandleSliderChanged));
@@ -79,7 +82,7 @@ void ScrollBar::RegisterObject(Context* context)
 {
     context->RegisterFactory<ScrollBar>(UI_CATEGORY);
 
-    URHO3D_COPY_BASE_ATTRIBUTES(UIElement);
+    URHO3D_COPY_BASE_ATTRIBUTES(BorderImage);
     URHO3D_UPDATE_ATTRIBUTE_DEFAULT_VALUE("Is Enabled", true);
     URHO3D_ENUM_ACCESSOR_ATTRIBUTE("Orientation", GetOrientation, SetOrientation, Orientation, orientations, O_HORIZONTAL, AM_FILE);
     URHO3D_ACCESSOR_ATTRIBUTE("Range", GetRange, SetRange, float, 1.0f, AM_FILE);
@@ -94,7 +97,7 @@ void ScrollBar::RegisterObject(Context* context)
 
 void ScrollBar::ApplyAttributes()
 {
-    UIElement::ApplyAttributes();
+    BorderImage::ApplyAttributes();
 
     // Reapply orientation to the button images
     if (slider_->GetOrientation() == O_HORIZONTAL)
@@ -219,7 +222,7 @@ float ScrollBar::GetEffectiveScrollStep() const
 
 bool ScrollBar::FilterImplicitAttributes(XMLElement& dest) const
 {
-    if (!UIElement::FilterImplicitAttributes(dest))
+    if (!BorderImage::FilterImplicitAttributes(dest))
         return false;
 
     if (!RemoveChildXML(dest, "Layout Mode"))

--- a/Source/Urho3D/UI/ScrollBar.h
+++ b/Source/Urho3D/UI/ScrollBar.h
@@ -31,9 +31,9 @@ class Button;
 class Slider;
 
 /// Scroll bar %UI element with forward and back buttons.
-class URHO3D_API ScrollBar : public UIElement
+class URHO3D_API ScrollBar : public BorderImage
 {
-    URHO3D_OBJECT(ScrollBar, UIElement);
+    URHO3D_OBJECT(ScrollBar, BorderImage);
 
 public:
     /// Construct.


### PR DESCRIPTION
Allow set background for ScrollBar

Old:
![uiold](https://cloud.githubusercontent.com/assets/13021826/15428420/ed2c5c3a-1ea3-11e6-9bd1-e98b32aa433f.png)

New:
```
    listView->GetVerticalScrollBar()->SetColor(Color(1.0f, 1.0f, 1.0f, 1.0f));
    listView->GetVerticalScrollBar()->SetStyle("ScrollBar");
    listView->GetVerticalScrollBar()->GetSlider()->SetColor(Color(0.0f, 0.0f, 0.0f, 0.0f));
```
![uinew](https://cloud.githubusercontent.com/assets/13021826/15428423/f45fade0-1ea3-11e6-9b52-a470e4bacffc.png)
