### PR TITLE
Add O_HEXAGONAL type of 2D Map

### DIFF
--- a/Source/Urho3D/AngelScript/Urho2DAPI.cpp
+++ b/Source/Urho3D/AngelScript/Urho2DAPI.cpp
@@ -196,6 +196,7 @@ static void RegisterTileMapDefs2D(asIScriptEngine* engine)
     engine->RegisterEnumValue("Orientation2D", "O_ORTHOGONAL", O_ORTHOGONAL);
     engine->RegisterEnumValue("Orientation2D", "O_ISOMETRIC", O_ISOMETRIC);
     engine->RegisterEnumValue("Orientation2D", "O_STAGGERED", O_STAGGERED);
+    engine->RegisterEnumValue("Orientation2D", "O_HEXAGONAL", O_HEXAGONAL);
 
     engine->RegisterObjectType("TileMapInfo2D", 0, asOBJ_REF);
     engine->RegisterObjectBehaviour("TileMapInfo2D", asBEHAVE_ADDREF, "void f()", asFUNCTION(FakeAddRef), asCALL_CDECL_OBJLAST);

--- a/Source/Urho3D/Urho2D/TileMap2D.cpp
+++ b/Source/Urho3D/Urho2D/TileMap2D.cpp
@@ -85,6 +85,13 @@ void TileMap2D::DrawDebugGeometry(DebugRenderer* debug, bool depthTest)
         debug->AddLine(Vector2(mapW, mapH), Vector2(0.0f, mapH), color);
         debug->AddLine(Vector2(0.0f, mapH), Vector2(0.0f, 0.0f), color);
         break;
+
+    case O_HEXAGONAL:
+        debug->AddLine(Vector2(0.0f, 0.0f), Vector2(mapW, 0.0f), color);
+        debug->AddLine(Vector2(mapW, 0.0f), Vector2(mapW, mapH), color);
+        debug->AddLine(Vector2(mapW, mapH), Vector2(0.0f, mapH), color);
+        debug->AddLine(Vector2(0.0f, mapH), Vector2(0.0f, 0.0f), color);
+        break;
     }
 
     for (unsigned i = 0; i < layers_.Size(); ++i)

--- a/Source/Urho3D/Urho2D/TileMapDefs2D.cpp
+++ b/Source/Urho3D/Urho2D/TileMapDefs2D.cpp
@@ -41,6 +41,8 @@ float TileMapInfo2D::GetMapHeight() const
 {
     if (orientation_ == O_STAGGERED)
         return (height_ + 1) * 0.5f * tileHeight_;
+    else if (orientation_ == O_HEXAGONAL)
+        return (height_) * 0.5f * (tileHeight_ + tileHeight_ * 0.5f);
     else
         return height_ * tileHeight_;
 }
@@ -59,6 +61,7 @@ Vector2 TileMapInfo2D::ConvertPosition(const Vector2& position) const
     case O_STAGGERED:
         return Vector2(position.x_ * PIXEL_SIZE, GetMapHeight() - position.y_ * PIXEL_SIZE);
 
+    case O_HEXAGONAL:
     case O_ORTHOGONAL:
     default:
         return Vector2(position.x_ * PIXEL_SIZE, GetMapHeight() - position.y_ * PIXEL_SIZE);
@@ -79,6 +82,12 @@ Vector2 TileMapInfo2D::TileIndexToPosition(int x, int y) const
             return Vector2(x * tileWidth_, (height_ - 1 - y) * 0.5f * tileHeight_);
         else
             return Vector2((x + 0.5f) * tileWidth_, (height_ - 1 - y) * 0.5f * tileHeight_);
+
+    case O_HEXAGONAL:
+        if (y % 2 == 0)
+            return Vector2(x * tileWidth_, (height_ - 1 - y) * 0.75f * tileHeight_);
+        else
+            return Vector2((x + 0.5f) * tileWidth_, (height_ - 1 - y)  * 0.75f * tileHeight_);
 
     case O_ORTHOGONAL:
     default:
@@ -108,6 +117,14 @@ bool TileMapInfo2D::PositionToTileIndex(int& x, int& y, const Vector2& position)
         else
             x = (int)(position.x_ / tileWidth_ - 0.5f);
 
+        break;
+
+    case O_HEXAGONAL:
+        y = (int)(height_ - 1 - position.y_ / 0.75f / tileHeight_);
+        if (y % 2 == 0)
+            x = (int)(position.x_ / tileWidth_);
+        else
+            x = (int)(position.x_ / tileWidth_ - 0.75f);
         break;
 
     case O_ORTHOGONAL:

--- a/Source/Urho3D/Urho2D/TileMapDefs2D.h
+++ b/Source/Urho3D/Urho2D/TileMapDefs2D.h
@@ -38,7 +38,9 @@ enum Orientation2D
     /// Isometric.
     O_ISOMETRIC,
     /// Staggered.
-    O_STAGGERED
+    O_STAGGERED,
+    /// Hexagonal
+    O_HEXAGONAL
 };
 
 /// Tile map information.

--- a/Source/Urho3D/Urho2D/TmxFile2D.cpp
+++ b/Source/Urho3D/Urho2D/TmxFile2D.cpp
@@ -385,6 +385,8 @@ bool TmxFile2D::EndLoad()
         info_.orientation_ = O_ISOMETRIC;
     else if (orientation == "staggered")
         info_.orientation_ = O_STAGGERED;
+    else if (orientation == "hexagonal")
+        info_.orientation_ = O_HEXAGONAL;
     else
     {
         URHO3D_LOGERROR("Unsupported orientation type " + orientation);


### PR DESCRIPTION
This patch implements hexagonal type of 2D Map, so that it provides possibility to work with the hexagonal maps from Tiled Map Editor.