### PR TITLE
Add support of custom per-instance data in batches.

### DIFF
--- a/Source/Urho3D/AngelScript/GraphicsAPI.cpp
+++ b/Source/Urho3D/AngelScript/GraphicsAPI.cpp
@@ -1861,6 +1861,8 @@ static void RegisterRenderer(asIScriptEngine* engine)
     engine->RegisterObjectMethod("Renderer", "bool get_dynamicInstancing() const", asMETHOD(Renderer, GetDynamicInstancing), asCALL_THISCALL);
     engine->RegisterObjectMethod("Renderer", "void set_minInstances(int)", asMETHOD(Renderer, SetMinInstances), asCALL_THISCALL);
     engine->RegisterObjectMethod("Renderer", "int get_minInstances() const", asMETHOD(Renderer, GetMinInstances), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Renderer", "void set_numExtraInstancingBufferElements(int)", asMETHOD(Renderer, SetNumExtraInstancingBufferElements), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Renderer", "int get_numExtraInstancingBufferElements() const", asMETHOD(Renderer, GetNumExtraInstancingBufferElements), asCALL_THISCALL);
     engine->RegisterObjectMethod("Renderer", "void set_maxSortedInstances(int)", asMETHOD(Renderer, SetMaxSortedInstances), asCALL_THISCALL);
     engine->RegisterObjectMethod("Renderer", "int get_maxSortedInstances() const", asMETHOD(Renderer, GetMaxSortedInstances), asCALL_THISCALL);
     engine->RegisterObjectMethod("Renderer", "void set_maxOccluderTriangles(int)", asMETHOD(Renderer, SetMaxOccluderTriangles), asCALL_THISCALL);

--- a/Source/Urho3D/Graphics/Drawable.cpp
+++ b/Source/Urho3D/Graphics/Drawable.cpp
@@ -52,6 +52,7 @@ SourceBatch::SourceBatch() :
     geometry_(0),
     worldTransform_(&Matrix3x4::IDENTITY),
     numWorldTransforms_(1),
+    instancingData_((void*)0),
     geometryType_(GEOM_STATIC)
 {
 }
@@ -72,6 +73,7 @@ SourceBatch& SourceBatch::operator =(const SourceBatch& rhs)
     material_ = rhs.material_;
     worldTransform_ = rhs.worldTransform_;
     numWorldTransforms_ = rhs.numWorldTransforms_;
+    instancingData_ = rhs.instancingData_;
     geometryType_ = rhs.geometryType_;
 
     return *this;

--- a/Source/Urho3D/Graphics/Drawable.h
+++ b/Source/Urho3D/Graphics/Drawable.h
@@ -97,6 +97,8 @@ struct URHO3D_API SourceBatch
     const Matrix3x4* worldTransform_;
     /// Number of world transforms.
     unsigned numWorldTransforms_;
+    /// Per-instance data. If not null, must contain enough data to fill instancing buffer.
+    void* instancingData_;
     /// %Geometry type.
     GeometryType geometryType_;
 };

--- a/Source/Urho3D/Graphics/Renderer.h
+++ b/Source/Urho3D/Graphics/Renderer.h
@@ -220,6 +220,8 @@ public:
     void SetMaxShadowMaps(int shadowMaps);
     /// Set dynamic instancing on/off. When on (default), drawables using the same static-type geometry and material will be automatically combined to an instanced draw call.
     void SetDynamicInstancing(bool enable);
+    /// Set number of extra instancing buffer elements. Default is 0. Extra 4-vectors are available through TEXCOORD7 and further.
+    void SetNumExtraInstancingBufferElements(int elements);
     /// Set minimum number of instances required in a batch group to render as instanced.
     void SetMinInstances(int instances);
     /// Set maximum number of sorted instances per batch group. If exceeded, instances are rendered unsorted.
@@ -295,6 +297,9 @@ public:
 
     /// Return whether dynamic instancing is in use.
     bool GetDynamicInstancing() const { return dynamicInstancing_; }
+
+    /// Return number of extra instancing buffer elements.
+    int GetNumExtraInstancingBufferElements() const { return numExtraInstancingBufferElements_; };
 
     /// Return minimum number of instances required in a batch group to render as instanced.
     int GetMinInstances() const { return minInstances_; }
@@ -580,6 +585,8 @@ private:
     bool reuseShadowMaps_;
     /// Dynamic instancing flag.
     bool dynamicInstancing_;
+    /// Number of extra instancing data elements.
+    int numExtraInstancingBufferElements_;
     /// Threaded occlusion rendering flag.
     bool threadedOcclusion_;
     /// Shaders need reloading flag.

--- a/Source/Urho3D/Graphics/View.cpp
+++ b/Source/Urho3D/Graphics/View.cpp
@@ -2898,15 +2898,16 @@ void View::PrepareInstancingBuffer()
     if (!dest)
         return;
 
+    const unsigned stride = instancingBuffer->GetVertexSize();
     for (HashMap<unsigned, BatchQueue>::Iterator i = batchQueues_.Begin(); i != batchQueues_.End(); ++i)
-        i->second_.SetTransforms(dest, freeIndex);
+        i->second_.SetInstancingData(dest, stride, freeIndex);
 
     for (Vector<LightBatchQueue>::Iterator i = lightQueues_.Begin(); i != lightQueues_.End(); ++i)
     {
         for (unsigned j = 0; j < i->shadowSplits_.Size(); ++j)
-            i->shadowSplits_[j].shadowBatches_.SetTransforms(dest, freeIndex);
-        i->litBaseBatches_.SetTransforms(dest, freeIndex);
-        i->litBatches_.SetTransforms(dest, freeIndex);
+            i->shadowSplits_[j].shadowBatches_.SetInstancingData(dest, stride, freeIndex);
+        i->litBaseBatches_.SetInstancingData(dest, stride, freeIndex);
+        i->litBatches_.SetInstancingData(dest, stride, freeIndex);
     }
 
     instancingBuffer->Unlock();

--- a/Source/Urho3D/LuaScript/pkgs/Graphics/Renderer.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Graphics/Renderer.pkg
@@ -21,6 +21,7 @@ class Renderer
     void SetReuseShadowMaps(bool enable);
     void SetMaxShadowMaps(int shadowMaps);
     void SetDynamicInstancing(bool enable);
+    void SetNumExtraInstancingBufferElements(int elements);
     void SetMinInstances(int instances);
     void SetMaxSortedInstances(int instances);
     void SetMaxOccluderTriangles(int triangles);
@@ -50,6 +51,7 @@ class Renderer
     bool GetReuseShadowMaps() const;
     int GetMaxShadowMaps() const;
     bool GetDynamicInstancing() const;
+    int GetNumExtraInstancingBufferElements() const;
     int GetMinInstances() const;
     int GetMaxSortedInstances() const;
     int GetMaxOccluderTriangles() const;
@@ -89,6 +91,7 @@ class Renderer
     tolua_property__get_set bool reuseShadowMaps;
     tolua_property__get_set int maxShadowMaps;
     tolua_property__get_set bool dynamicInstancing;
+    tolua_property__get_set int numExtraInstancingBufferElements;
     tolua_property__get_set int minInstances;
     tolua_property__get_set int maxSortedInstances;
     tolua_property__get_set int maxOccluderTriangles;

--- a/Source/Urho3D/Math/StringHash.h
+++ b/Source/Urho3D/Math/StringHash.h
@@ -76,7 +76,7 @@ public:
         return *this;
     }
 
-    // Test for equality with another hash.
+    /// Test for equality with another hash.
     bool operator ==(const StringHash& rhs) const { return value_ == rhs.value_; }
 
     /// Test for inequality with another hash.


### PR DESCRIPTION
Hi all.

These changes allow to set custom per-instance data in SourceBatch and implement things like smooth LOD switch.
https://github.com/urho3d/Urho3D/issues/1405

For now it it internal feature that can be used from Drawable derived-s.
So it is impossible to set these data from external code with public methods.
I just don't need such use case and have no ideas about good interface for it.

It could be settable property of `Drawable` like `Vector4 instancingData_[MAX]`, as suggested by **cadaver**, or something else.
I am not sure how much MAX should be. Now it is 4. I suppose it is enough for most cases. Is it enough? Is it okay to add extra 64 bytes for each drawable?
Where can I place this constant? Is `GraphicDefs.h` good place?

Custom per-instance data also does not work without instancing. I tried to implement it, but it requires extra uniform in all shaders and related changes, so I decided to do nothing.
I just added possibility to force instancing on for all render-ops. Could it break something?

Let's discuss..