### PR TITLE
Add update invisible parameter to RibbonTrail.

### DIFF
--- a/Source/Samples/44_RibbonTrailDemo/RibbonTrailDemo.cpp
+++ b/Source/Samples/44_RibbonTrailDemo/RibbonTrailDemo.cpp
@@ -109,6 +109,7 @@ void RibbonTrailDemo::CreateScene()
     boxTrail1->SetStartColor(Color(1.0f, 0.5f, 0.0f, 1.0f));
     boxTrail1->SetEndColor(Color(1.0f, 1.0f, 0.0f, 0.0f));
     boxTrail1->SetWidth(0.5f);
+    boxTrail1->SetUpdateInvisible(true);
 
     // Create second box for face camera trail demo with 4 column.
     // This will produce less distortion than first trail.
@@ -122,6 +123,7 @@ void RibbonTrailDemo::CreateScene()
     boxTrail2->SetEndColor(Color(1.0f, 1.0f, 0.0f, 0.0f));
     boxTrail2->SetWidth(0.5f);
     boxTrail2->SetTailColumn(4);
+    boxTrail2->SetUpdateInvisible(true);
 
     // Load ninja animated model for bone trail demo.
     Node* ninjaNode = scene_->CreateChild("Ninja");
@@ -147,6 +149,7 @@ void RibbonTrailDemo::CreateScene()
     swordTrail_->SetStartColor(Color(1.0f, 1.0f, 1.0f, 0.75f));
     swordTrail_->SetEndColor(Color(0.2f, 0.5f, 1.0f, 0.0f));
     swordTrail_->SetTailColumn(4);
+    swordTrail_->SetUpdateInvisible(true);
 
     // Add floating text for info.
     Node* boxTextNode1 = scene_->CreateChild("BoxText1");

--- a/Source/Urho3D/AngelScript/GraphicsAPI.cpp
+++ b/Source/Urho3D/AngelScript/GraphicsAPI.cpp
@@ -1640,6 +1640,8 @@ static void RegisterRibbonTrail(asIScriptEngine* engine)
     engine->RegisterObjectMethod("RibbonTrail", "float get_lifetime() const", asMETHOD(RibbonTrail, GetLifetime), asCALL_THISCALL);
     engine->RegisterObjectMethod("RibbonTrail", "void set_emitting(bool)", asMETHOD(RibbonTrail, SetEmitting), asCALL_THISCALL);
     engine->RegisterObjectMethod("RibbonTrail", "bool get_emitting() const", asMETHOD(RibbonTrail, IsEmitting), asCALL_THISCALL);
+    engine->RegisterObjectMethod("RibbonTrail", "void set_updateInvisible(bool)", asMETHOD(RibbonTrail, SetUpdateInvisible), asCALL_THISCALL);
+    engine->RegisterObjectMethod("RibbonTrail", "bool get_updateInvisible() const", asMETHOD(RibbonTrail, GetUpdateInvisible), asCALL_THISCALL);
     engine->RegisterObjectMethod("RibbonTrail", "void set_tailColumn(uint)", asMETHOD(RibbonTrail, SetTailColumn), asCALL_THISCALL);
     engine->RegisterObjectMethod("RibbonTrail", "uint get_tailColumn() const", asMETHOD(RibbonTrail, GetTailColumn), asCALL_THISCALL);
     engine->RegisterObjectMethod("RibbonTrail", "void set_animationLodBias(float)", asMETHOD(RibbonTrail, SetAnimationLodBias), asCALL_THISCALL);

--- a/Source/Urho3D/Graphics/RibbonTrail.cpp
+++ b/Source/Urho3D/Graphics/RibbonTrail.cpp
@@ -77,6 +77,7 @@ RibbonTrail::RibbonTrail(Context* context) :
     forceUpdate_(false),
     trailType_(TT_FACE_CAMERA),
     tailColumn_(1),
+    updateInvisible_(false),
     emitting_(true)
 {
     geometry_->SetVertexBuffer(0, vertexBuffer_);
@@ -103,6 +104,7 @@ void RibbonTrail::RegisterObject(Context* context)
     URHO3D_COPY_BASE_ATTRIBUTES(Drawable);
     URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Material", GetMaterialAttr, SetMaterialAttr, ResourceRef, ResourceRef(Material::GetTypeStatic()), AM_DEFAULT);
     URHO3D_ACCESSOR_ATTRIBUTE("Emitting", IsEmitting, SetEmitting, bool, true, AM_DEFAULT);
+    URHO3D_ACCESSOR_ATTRIBUTE("Update Invisible", GetUpdateInvisible, SetUpdateInvisible, bool, false, AM_DEFAULT);
     URHO3D_ENUM_ACCESSOR_ATTRIBUTE("Trail Type", GetTrailType, SetTrailType, TrailType, trailTypeNames, TT_FACE_CAMERA, AM_DEFAULT);
     URHO3D_ACCESSOR_ATTRIBUTE("Tail Lifetime", GetLifetime, SetLifetime, float, 1.0f, AM_DEFAULT);
     URHO3D_ACCESSOR_ATTRIBUTE("Tail Column", GetTailColumn, SetTailColumn, unsigned, 0, AM_DEFAULT);
@@ -174,7 +176,7 @@ void RibbonTrail::HandleScenePostUpdate(StringHash eventType, VariantMap& eventD
     lastTimeStep_ = eventData[P_TIMESTEP].GetFloat();
 
     // Update if frame has changed
-    if (viewFrameNumber_ != lastUpdateFrameNumber_)
+    if (updateInvisible_ || viewFrameNumber_ != lastUpdateFrameNumber_)
     {
         // Reset if ribbon trail is too small and too much difference in frame
         if (points_.Size() < 3 && viewFrameNumber_ - lastUpdateFrameNumber_ > 1)
@@ -869,6 +871,11 @@ void RibbonTrail::SetAnimationLodBias(float bias)
 {
     animationLodBias_ = Max(bias, 0.0f);
     MarkNetworkUpdate();
+}
+
+void RibbonTrail::SetUpdateInvisible(bool enable)
+{
+    updateInvisible_ = enable;
 }
 
 void RibbonTrail::Commit()

--- a/Source/Urho3D/Graphics/RibbonTrail.h
+++ b/Source/Urho3D/Graphics/RibbonTrail.h
@@ -104,6 +104,8 @@ public:
     void SetLifetime(float time);
     /// Set whether trail should be emitting.
     void SetEmitting(bool emitting);
+    /// Set whether to update when trail emiiter are not visible.
+    void SetUpdateInvisible(bool enable);
     /// Set number of column for every tails. Can be useful for fixing distortion at high angle.
     void SetTailColumn(unsigned tailColumn);
     /// Set animation LOD bias.
@@ -152,6 +154,9 @@ public:
 
     /// Return whether is currently emitting.
     bool IsEmitting() const { return emitting_ ; }
+
+    /// Return whether to update when trail emitter are not visible.
+    bool GetUpdateInvisible() const { return updateInvisible_; }
 
 protected:
     /// Handle node being assigned.
@@ -227,6 +232,8 @@ private:
     bool forceUpdate_;
     /// Currently emitting flag.
     bool emitting_;
+    /// Update when invisible flag.
+    bool updateInvisible_;
 
     /// End of trail point for smoother tail disappearance.
     TrailPoint endTail_;

--- a/Source/Urho3D/LuaScript/pkgs/Graphics/RibbonTrail.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Graphics/RibbonTrail.pkg
@@ -19,6 +19,7 @@ class RibbonTrail : public Drawable
     void SetSorted(bool enable);
     void SetLifetime(float time);
     void SetEmitting(bool emitting);
+    void SetUpdateInvisible(bool updateInvisible);
     void SetTailColumn(unsigned tailColumn);
     void SetAnimationLodBias(float bias);
 
@@ -36,6 +37,7 @@ class RibbonTrail : public Drawable
     float GetLifetime() const;
     unsigned GetTailColumn() const;
     bool IsEmitting() const;
+    bool GetUpdateInvisible() const;
     float GetAnimationLodBias() const;
 
     tolua_property__get_set Material* material;
@@ -50,5 +52,6 @@ class RibbonTrail : public Drawable
     tolua_property__get_set float lifetime;
     tolua_property__get_set unsigned tailColumn;
     tolua_property__is_set bool emitting;
+    tolua_property__get_set bool updateInvisible;
     tolua_property__get_set float animationLodBias;
 }

--- a/bin/Data/LuaScripts/44_RibbonTrailDemo.lua
+++ b/bin/Data/LuaScripts/44_RibbonTrailDemo.lua
@@ -64,6 +64,7 @@ function CreateScene()
     boxTrail1.startColor = Color(1.0, 0.5, 0.0, 1.0)
     boxTrail1.endColor = Color(1.0, 1.0, 0.0, 0.0)
     boxTrail1.width = 0.5
+    boxTrail1.updateInvisible = true
 
     -- Create second box for face camera trail demo with 4 column.
     -- This will produce less distortion than first trail.
@@ -77,6 +78,7 @@ function CreateScene()
     boxTrail2.endColor = Color(1.0, 1.0, 0.0, 0.0)
     boxTrail2.width = 0.5
     boxTrail2.tailColumn = 4
+    boxTrail2.updateInvisible = true
 
     -- Load ninja animated model for bone trail demo.
     local ninjaNode = scene_:CreateChild("Ninja")
@@ -102,6 +104,7 @@ function CreateScene()
     swordTrail.startColor = Color(1.0, 1.0, 1.0, 0.75)
     swordTrail.endColor = Color(0.2, 0.5, 1.0, 0.0)
     swordTrail.tailColumn = 4
+    swordTrail.updateInvisible = true
 
     -- Add floating text for info.
     local boxTextNode1 = scene_:CreateChild("BoxText1")

--- a/bin/Data/Scripts/44_RibbonTrailDemo.as
+++ b/bin/Data/Scripts/44_RibbonTrailDemo.as
@@ -66,6 +66,7 @@ void CreateScene()
     boxTrail1.startColor = Color(1.0f, 0.5f, 0.0f, 1.0f);
     boxTrail1.endColor = Color(1.0f, 1.0f, 0.0f, 0.0f);
     boxTrail1.width = 0.5f;
+    boxTrail1.updateInvisible = true;
     
     // Create second box for face camera trail demo with 4 column.
     // This will produce less distortion than first trail.
@@ -79,6 +80,7 @@ void CreateScene()
     boxTrail2.endColor = Color(1.0f, 1.0f, 0.0f, 0.0f);
     boxTrail2.width = 0.5f;
     boxTrail2.tailColumn = 4;
+    boxTrail2.updateInvisible = true;
     
     // Load ninja animated model for bone trail demo.
     Node@ ninjaNode = scene_.CreateChild("Ninja");
@@ -104,6 +106,7 @@ void CreateScene()
     swordTrail.startColor = Color(1.0f, 1.0f, 1.0f, 0.75f);
     swordTrail.endColor = Color(0.2, 0.5f, 1.0f, 0.0f);
     swordTrail.tailColumn = 4;
+    swordTrail.updateInvisible = true;
     
     // Add floating text for info.
     Node@ boxTextNode1 = scene_.CreateChild("BoxText1");


### PR DESCRIPTION
I'm adding update invisible parameter to Ribbon Trail so node can still emit trail even if it isn't visible to the camera. The default is off for optimization, but all trail on the samples are using it.