### PR TITLE
SendEvent new renderpath command

### DIFF
--- a/Source/Urho3D/Graphics/GraphicsEvents.h
+++ b/Source/Urho3D/Graphics/GraphicsEvents.h
@@ -100,6 +100,12 @@ URHO3D_EVENT(E_ENDVIEWRENDER, EndViewRender)
     URHO3D_PARAM(P_CAMERA, Camera);                // Camera pointer
 }
 
+/// A render path event has occured.
+URHO3D_EVENT(E_RENDERPATHEVENT, RenderPathEvent)
+{
+    URHO3D_PARAM(P_NAME, Name);                    // String
+}
+
 /// Graphics context has been lost. Some or all (depending on the API) GPU objects have lost their contents.
 URHO3D_EVENT(E_DEVICELOST, DeviceLost)
 {

--- a/Source/Urho3D/Graphics/RenderPath.cpp
+++ b/Source/Urho3D/Graphics/RenderPath.cpp
@@ -46,6 +46,7 @@ static const char* commandTypeNames[] =
     "forwardlights",
     "lightvolumes",
     "renderui",
+    "sendevent",
     0
 };
 
@@ -178,6 +179,10 @@ void RenderPathCommand::Load(const XMLElement& element)
                 parameterElem = parameterElem.GetNext("parameter");
             }
         }
+        break;
+
+    case CMD_SENDEVENT:
+        eventName_ = element.GetAttribute("name");
         break;
 
     default:

--- a/Source/Urho3D/Graphics/RenderPath.h
+++ b/Source/Urho3D/Graphics/RenderPath.h
@@ -43,7 +43,8 @@ enum RenderCommandType
     CMD_QUAD,
     CMD_FORWARDLIGHTS,
     CMD_LIGHTVOLUMES,
-    CMD_RENDERUI
+    CMD_RENDERUI,
+    CMD_SENDEVENT
 };
 
 /// Rendering path sorting modes.
@@ -199,6 +200,8 @@ struct URHO3D_API RenderPathCommand
     bool useLitBase_;
     /// Vertex lights flag.
     bool vertexLights_;
+    /// Event name
+    String eventName_;
 };
 
 /// Rendering path definition. A sequence of commands (e.g. clear screen, draw objects with specific pass) that yields the scene rendering result.

--- a/Source/Urho3D/Graphics/View.cpp
+++ b/Source/Urho3D/Graphics/View.cpp
@@ -1661,6 +1661,16 @@ void View::ExecuteRenderPathCommands()
                 }
                 break;
 
+            case CMD_SENDEVENT:
+                {
+                    using namespace RenderPathEvent;
+
+                    VariantMap& eventData = GetEventDataMap();
+                    eventData[P_NAME] = command.eventName_;
+                    renderer_->SendEvent(E_RENDERPATHEVENT, eventData);
+                }
+                break;
+
             default:
                 break;
             }


### PR DESCRIPTION
A new "sendevent" render path command can now be added. This render path command will send an E_RENDERPATHEVENT event with the specified name. This can be used to execute some code at a specific point during the rendering.

_<command type="sendevent" name="MyCustomName"/>_

Feel free to suggest me some changes to the names that i have used. Since English is not my native language some names may not be nice :)