### PR TITLE
08 Decals now draws debug geometry

### DIFF
--- a/Source/Samples/08_Decals/Decals.cpp
+++ b/Source/Samples/08_Decals/Decals.cpp
@@ -319,5 +319,5 @@ void Decals::HandlePostRenderUpdate(StringHash eventType, VariantMap& eventData)
 {
     // If draw debug mode is enabled, draw viewport debug geometry. Disable depth test so that we can see the effect of occlusion
     if (drawDebug_)
-        GetSubsystem<Renderer>()->DrawDebugGeometry(false);
+        GetSubsystem<Renderer>()->DrawDebugGeometry(drawDebug_);
 }


### PR DESCRIPTION
`false` was being passed into the call do `drawDebugGeometry`, now
it's actually using the variable `drawDebug_`.