### PR TITLE
Add b2Contact ptr to E_PHYSICSBEGINCONTACT2D and E_PHYSICSENDCONTACT2…

### DIFF
--- a/Source/Urho3D/Urho2D/PhysicsEvents2D.h
+++ b/Source/Urho3D/Urho2D/PhysicsEvents2D.h
@@ -39,6 +39,7 @@ URHO3D_EVENT(E_PHYSICSBEGINCONTACT2D, PhysicsBeginContact2D)
     URHO3D_PARAM(P_BODYB, BodyB);                  // RigidBody2D pointer
     URHO3D_PARAM(P_NODEA, NodeA);                  // Node pointer
     URHO3D_PARAM(P_NODEB, NodeB);                  // Node pointer
+    URHO3D_PARAM(P_CONTACT, Contact);              // b2Contact pointer
 }
 
 /// Physics end contact.
@@ -49,6 +50,7 @@ URHO3D_EVENT(E_PHYSICSENDCONTACT2D, PhysicsEndContact2D)
     URHO3D_PARAM(P_BODYB, BodyB);                  // RigidBody2D pointer
     URHO3D_PARAM(P_NODEA, NodeA);                  // Node pointer
     URHO3D_PARAM(P_NODEB, NodeB);                  // Node pointer
+    URHO3D_PARAM(P_CONTACT, Contact);              // b2Contact pointer
 }
 
 }

--- a/Source/Urho3D/Urho2D/PhysicsWorld2D.cpp
+++ b/Source/Urho3D/Urho2D/PhysicsWorld2D.cpp
@@ -684,6 +684,7 @@ void PhysicsWorld2D::SendBeginContactEvents()
         eventData[P_BODYB] = contactInfo.bodyB_.Get();
         eventData[P_NODEA] = contactInfo.nodeA_.Get();
         eventData[P_NODEB] = contactInfo.nodeB_.Get();
+        eventData[P_CONTACT] = (void*)contactInfo.contact_;
 
         SendEvent(E_PHYSICSBEGINCONTACT2D, eventData);
     }
@@ -707,6 +708,7 @@ void PhysicsWorld2D::SendEndContactEvents()
         eventData[P_BODYB] = contactInfo.bodyB_.Get();
         eventData[P_NODEA] = contactInfo.nodeA_.Get();
         eventData[P_NODEB] = contactInfo.nodeB_.Get();
+        eventData[P_CONTACT] = (void*)contactInfo.contact_;
 
         SendEvent(E_PHYSICSENDCONTACT2D, eventData);
     }
@@ -726,13 +728,15 @@ PhysicsWorld2D::ContactInfo::ContactInfo(b2Contact* contact)
     bodyB_ = (RigidBody2D*)(fixtureB->GetBody()->GetUserData());
     nodeA_ = bodyA_->GetNode();
     nodeB_ = bodyB_->GetNode();
+    contact_ = contact;
 }
 
 PhysicsWorld2D::ContactInfo::ContactInfo(const ContactInfo& other) :
     bodyA_(other.bodyA_),
     bodyB_(other.bodyB_),
     nodeA_(other.nodeA_),
-    nodeB_(other.nodeB_)
+    nodeB_(other.nodeB_),
+    contact_(other.contact_)
 {
 }
 

--- a/Source/Urho3D/Urho2D/PhysicsWorld2D.h
+++ b/Source/Urho3D/Urho2D/PhysicsWorld2D.h
@@ -262,6 +262,8 @@ private:
         SharedPtr<Node> nodeA_;
         /// Node B.
         SharedPtr<Node> nodeB_;
+        /// Box2D Contact
+        b2Contact* contact_;
     };
     /// Begin contact infos.
     Vector<ContactInfo> beginContactInfos_;


### PR DESCRIPTION
…D events.

Contact 2D events does not return direct b2Fixture in contact but Node or RigidBody2D instead. 
But it is usefull to get direct b2Fixture in contact on a 2D body that have many fixtures.

case of use when trying to implement that : http://www.iforce2d.net/b2dtut/jumpability


```
void Urho2DPlatformer::HandleCollisionBegin(StringHash eventType, VariantMap& eventData)
{

    b2Contact* contact = static_cast<b2Contact*>(eventData[PhysicsBeginContact2D::P_CONTACT].GetVoidPtr());
    //check if fixture A was the foot sensor
    int valueA = (intptr_t)contact->GetFixtureA()->GetUserData();
    if ( valueA == 3 )
        hero->numFootContacts++;
    //check if fixture B was the foot sensor
    int valueB = (intptr_t)contact->GetFixtureB()->GetUserData();
    if ( valueB == 3 )
        hero->numFootContacts++;
...
}
```


