### PR TITLE
Optimize direction billboard vertex buffer

### DIFF
--- a/Source/Urho3D/Graphics/BillboardSet.cpp
+++ b/Source/Urho3D/Graphics/BillboardSet.cpp
@@ -489,7 +489,7 @@ void BillboardSet::UpdateBufferSize()
     {
         if (faceCameraMode_ == FC_DIRECTION)
         {
-            vertexBuffer_->SetSize(numBillboards * 4, MASK_POSITION | MASK_NORMAL | MASK_COLOR | MASK_TEXCOORD1 | MASK_TEXCOORD2 | MASK_TANGENT, true);
+            vertexBuffer_->SetSize(numBillboards * 4, MASK_POSITION | MASK_NORMAL | MASK_COLOR | MASK_TEXCOORD1 | MASK_TEXCOORD2, true);
             geometry_->SetVertexBuffer(0, vertexBuffer_);
 
         }
@@ -653,8 +653,6 @@ void BillboardSet::UpdateVertexBuffer(const FrameInfo& frame)
     }
     else
     {
-        Vector3 cameraWorldPosition = frame.camera_->GetNode()->GetWorldPosition();
-
         for (unsigned i = 0; i < enabledBillboards; ++i)
         {
             Billboard& billboard = *sortedBillboards_[i];
@@ -680,60 +678,44 @@ void BillboardSet::UpdateVertexBuffer(const FrameInfo& frame)
             dest[8] = billboard.uv_.min_.y_;
             dest[9] = -size.x_ * rot2D[0][0] + size.y_ * rot2D[0][1];
             dest[10] = -size.x_ * rot2D[1][0] + size.y_ * rot2D[1][1];
-            dest[11] = cameraWorldPosition.x_;
-            dest[12] = cameraWorldPosition.y_;
-            dest[13] = cameraWorldPosition.z_;
-            dest[14] = 1.0f;
 
-            dest[15] = billboard.position_.x_;
-            dest[16] = billboard.position_.y_;
-            dest[17] = billboard.position_.z_;
-            dest[18] = billboard.direction_.x_;
-            dest[19] = billboard.direction_.y_;
-            dest[20] = billboard.direction_.z_;
-            ((unsigned&)dest[21]) = color;
-            dest[22] = billboard.uv_.max_.x_;
-            dest[23] = billboard.uv_.min_.y_;
-            dest[24] = size.x_ * rot2D[0][0] + size.y_ * rot2D[0][1];
-            dest[25] = size.x_ * rot2D[1][0] + size.y_ * rot2D[1][1];
-            dest[26] = cameraWorldPosition.x_;
-            dest[27] = cameraWorldPosition.y_;
-            dest[28] = cameraWorldPosition.z_;
-            dest[29] = 1.0f;
+            dest[11] = billboard.position_.x_;
+            dest[12] = billboard.position_.y_;
+            dest[13] = billboard.position_.z_;
+            dest[14] = billboard.direction_.x_;
+            dest[15] = billboard.direction_.y_;
+            dest[16] = billboard.direction_.z_;
+            ((unsigned&)dest[17]) = color;
+            dest[18] = billboard.uv_.max_.x_;
+            dest[19] = billboard.uv_.min_.y_;
+            dest[20] = size.x_ * rot2D[0][0] + size.y_ * rot2D[0][1];
+            dest[21] = size.x_ * rot2D[1][0] + size.y_ * rot2D[1][1];
 
-            dest[30] = billboard.position_.x_;
-            dest[31] = billboard.position_.y_;
-            dest[32] = billboard.position_.z_;
-            dest[33] = billboard.direction_.x_;
-            dest[34] = billboard.direction_.y_;
-            dest[35] = billboard.direction_.z_;
-            ((unsigned&)dest[36]) = color;
-            dest[37] = billboard.uv_.max_.x_;
-            dest[38] = billboard.uv_.max_.y_;
-            dest[39] = size.x_ * rot2D[0][0] - size.y_ * rot2D[0][1];
-            dest[40] = size.x_ * rot2D[1][0] - size.y_ * rot2D[1][1];
-            dest[41] = cameraWorldPosition.x_;
-            dest[42] = cameraWorldPosition.y_;
-            dest[43] = cameraWorldPosition.z_;
-            dest[44] = 1.0f;
+            dest[22] = billboard.position_.x_;
+            dest[23] = billboard.position_.y_;
+            dest[24] = billboard.position_.z_;
+            dest[25] = billboard.direction_.x_;
+            dest[26] = billboard.direction_.y_;
+            dest[27] = billboard.direction_.z_;
+            ((unsigned&)dest[28]) = color;
+            dest[29] = billboard.uv_.max_.x_;
+            dest[30] = billboard.uv_.max_.y_;
+            dest[31] = size.x_ * rot2D[0][0] - size.y_ * rot2D[0][1];
+            dest[32] = size.x_ * rot2D[1][0] - size.y_ * rot2D[1][1];
 
-            dest[45] = billboard.position_.x_;
-            dest[46] = billboard.position_.y_;
-            dest[47] = billboard.position_.z_;
-            dest[48] = billboard.direction_.x_;
-            dest[49] = billboard.direction_.y_;
-            dest[50] = billboard.direction_.z_;
-            ((unsigned&)dest[51]) = color;
-            dest[52] = billboard.uv_.min_.x_;
-            dest[53] = billboard.uv_.max_.y_;
-            dest[54] = -size.x_ * rot2D[0][0] - size.y_ * rot2D[0][1];
-            dest[55] = -size.x_ * rot2D[1][0] - size.y_ * rot2D[1][1];
-            dest[56] = cameraWorldPosition.x_;
-            dest[57] = cameraWorldPosition.y_;
-            dest[58] = cameraWorldPosition.z_;
-            dest[59] = 1.0f;
+            dest[33] = billboard.position_.x_;
+            dest[34] = billboard.position_.y_;
+            dest[35] = billboard.position_.z_;
+            dest[36] = billboard.direction_.x_;
+            dest[37] = billboard.direction_.y_;
+            dest[38] = billboard.direction_.z_;
+            ((unsigned&)dest[39]) = color;
+            dest[40] = billboard.uv_.min_.x_;
+            dest[41] = billboard.uv_.max_.y_;
+            dest[42] = -size.x_ * rot2D[0][0] - size.y_ * rot2D[0][1];
+            dest[43] = -size.x_ * rot2D[1][0] - size.y_ * rot2D[1][1];
 
-            dest += 60;
+            dest += 44;
         }
     }
 

--- a/bin/CoreData/Shaders/GLSL/Transform.glsl
+++ b/bin/CoreData/Shaders/GLSL/Transform.glsl
@@ -102,15 +102,15 @@ mat3 GetFaceCameraRotation(vec3 cameraPos, vec3 position, vec3 direction)
     );
 }
 
-vec3 GetBillboardPos(vec4 iPos, vec3 iDirection, vec3 iCameraPos, mat4 modelMatrix)
+vec3 GetBillboardPos(vec4 iPos, vec3 iDirection, mat4 modelMatrix)
 {
-    return (iPos * modelMatrix).xyz +
-        vec3(iTexCoord1.x, 0.0, iTexCoord1.y) * GetFaceCameraRotation(iCameraPos, iPos.xyz, iDirection);
+    return (iPos * modelMatrix).xyz + 
+        vec3(iTexCoord1.x, 0.0, iTexCoord1.y) * GetFaceCameraRotation(cCameraPos, iPos.xyz, iDirection);
 }
 
-vec3 GetBillboardNormal(vec4 iPos, vec3 iDirection, vec3 iCameraPos)
+vec3 GetBillboardNormal(vec4 iPos, vec3 iDirection)
 {
-    return vec3(0.0, 1.0, 0.0) * GetFaceCameraRotation(iCameraPos, iPos.xyz, iDirection);
+    return vec3(0.0, 1.0, 0.0) * GetFaceCameraRotation(cCameraPos, iPos.xyz, iDirection);
 }
 #endif
 
@@ -156,7 +156,7 @@ vec3 GetWorldPos(mat4 modelMatrix)
     #if defined(BILLBOARD)
         return GetBillboardPos(iPos, iTexCoord1, modelMatrix);
     #elif defined(DIRBILLBOARD)
-        return GetBillboardPos(iPos, iNormal, iTangent.xyz, modelMatrix);
+        return GetBillboardPos(iPos, iNormal, modelMatrix);
     #elif defined(TRAILFACECAM)
         return GetTrailPos(iPos, iTangent.xyz, iTangent.w, modelMatrix);
     #elif defined(TRAILBONE)
@@ -171,7 +171,7 @@ vec3 GetWorldNormal(mat4 modelMatrix)
     #if defined(BILLBOARD)
         return GetBillboardNormal();
     #elif defined(DIRBILLBOARD)
-        return GetBillboardNormal(iPos, iNormal, iTangent.xyz);
+        return GetBillboardNormal(iPos, iNormal);
     #elif defined(TRAILFACECAM)
         return GetTrailNormal(iPos);
     #elif defined(TRAILBONE)

--- a/bin/CoreData/Shaders/HLSL/Basic.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Basic.hlsl
@@ -22,7 +22,7 @@ void VS(float4 iPos : POSITION,
     #if defined(DIRBILLBOARD) || defined(TRAILBONE)
         float3 iNormal : NORMAL,
     #endif
-    #if defined(DIRBILLBOARD) || defined(TRAILFACECAM) || defined(TRAILBONE)
+    #if defined(TRAILFACECAM) || defined(TRAILBONE)
         float4 iTangent : TANGENT,
     #endif
     #ifdef DIFFMAP

--- a/bin/CoreData/Shaders/HLSL/LitParticle.hlsl
+++ b/bin/CoreData/Shaders/HLSL/LitParticle.hlsl
@@ -24,7 +24,7 @@ void VS(float4 iPos : POSITION,
     #if defined(BILLBOARD) || defined(DIRBILLBOARD)
         float2 iSize : TEXCOORD1,
     #endif
-    #if defined(DIRBILLBOARD) || defined(TRAILFACECAM) || defined(TRAILBONE)
+    #if defined(TRAILFACECAM) || defined(TRAILBONE)
         float4 iTangent : TANGENT,
     #endif
     out float2 oTexCoord : TEXCOORD0,

--- a/bin/CoreData/Shaders/HLSL/LitSolid.hlsl
+++ b/bin/CoreData/Shaders/HLSL/LitSolid.hlsl
@@ -18,7 +18,7 @@ void VS(float4 iPos : POSITION,
     #if defined(LIGHTMAP) || defined(AO)
         float2 iTexCoord2 : TEXCOORD1,
     #endif
-    #if defined(NORMALMAP) || defined(DIRBILLBOARD) || defined(TRAILFACECAM) || defined(TRAILBONE)
+    #if defined(NORMALMAP) || defined(TRAILFACECAM) || defined(TRAILBONE)
         float4 iTangent : TANGENT,
     #endif
     #ifdef SKINNED

--- a/bin/CoreData/Shaders/HLSL/PBRLitSolid.hlsl
+++ b/bin/CoreData/Shaders/HLSL/PBRLitSolid.hlsl
@@ -21,7 +21,7 @@ void VS(float4 iPos : POSITION,
     #if defined(LIGHTMAP) || defined(AO)
         float2 iTexCoord2 : TEXCOORD1,
     #endif
-    #if defined(NORMALMAP) || defined(DIRBILLBOARD) || defined(IBL) || defined(TRAILFACECAM) || defined(TRAILBONE)
+    #if defined(NORMALMAP) || defined(IBL) || defined(TRAILFACECAM) || defined(TRAILBONE)
         float4 iTangent : TANGENT,
     #endif
     #ifdef SKINNED

--- a/bin/CoreData/Shaders/HLSL/TerrainBlend.hlsl
+++ b/bin/CoreData/Shaders/HLSL/TerrainBlend.hlsl
@@ -51,7 +51,7 @@ void VS(float4 iPos : POSITION,
     #if defined(BILLBOARD) || defined(DIRBILLBOARD)
         float2 iSize : TEXCOORD1,
     #endif
-    #if defined(DIRBILLBOARD) || defined(TRAILFACECAM) || defined(TRAILBONE)
+    #if defined(TRAILFACECAM) || defined(TRAILBONE)
         float4 iTangent : TANGENT,
     #endif
     out float2 oTexCoord : TEXCOORD0,

--- a/bin/CoreData/Shaders/HLSL/Transform.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Transform.hlsl
@@ -49,9 +49,9 @@ float3 GetBillboardNormal()
 #endif
 
 #ifdef DIRBILLBOARD
-float3x3 GetFaceCameraRotation(float3 cameraPos, float3 position, float3 direction)
+float3x3 GetFaceCameraRotation(float3 position, float3 direction)
 {
-    float3 cameraDir = normalize(position - cameraPos);
+    float3 cameraDir = normalize(position - cCameraPos);
     float3 front = normalize(direction);
     float3 right = normalize(cross(front, cameraDir));
     float3 up = normalize(cross(front, right));
@@ -63,15 +63,15 @@ float3x3 GetFaceCameraRotation(float3 cameraPos, float3 position, float3 directi
     );
 }
 
-float3 GetBillboardPos(float4 iPos, float2 iSize, float3 iDirection, float3 iCameraPos, float4x3 modelMatrix)
+float3 GetBillboardPos(float4 iPos, float2 iSize, float3 iDirection, float4x3 modelMatrix)
 {
     return mul(iPos, modelMatrix) + 
-        mul(float3(iSize.x, 0.0, iSize.y), GetFaceCameraRotation(iCameraPos, iPos.xyz, iDirection));
+        mul(float3(iSize.x, 0.0, iSize.y), GetFaceCameraRotation(iPos.xyz, iDirection));
 }
 
-float3 GetBillboardNormal(float4 iPos, float3 iDirection, float3 iCameraPos)
+float3 GetBillboardNormal(float4 iPos, float3 iDirection)
 {
-    return mul(float3(0.0, 1.0, 0.0), GetFaceCameraRotation(iCameraPos, iPos.xyz, iDirection));
+    return mul(float3(0.0, 1.0, 0.0), GetFaceCameraRotation(iPos.xyz, iDirection));
 }
 #endif
 
@@ -115,7 +115,7 @@ float3 GetTrailNormal(float4 iPos, float3 iParentPos, float3 iForward)
 #if defined(BILLBOARD)
     #define GetWorldPos(modelMatrix) GetBillboardPos(iPos, iSize, modelMatrix)
 #elif defined(DIRBILLBOARD)
-    #define GetWorldPos(modelMatrix) GetBillboardPos(iPos, iSize, iNormal, iTangent.xyz, modelMatrix)
+    #define GetWorldPos(modelMatrix) GetBillboardPos(iPos, iSize, iNormal, modelMatrix)
 #elif defined(TRAILFACECAM)
     #define GetWorldPos(modelMatrix) GetTrailPos(iPos, iTangent.xyz, iTangent.w, modelMatrix)
 #elif defined(TRAILBONE)
@@ -127,7 +127,7 @@ float3 GetTrailNormal(float4 iPos, float3 iParentPos, float3 iForward)
 #if defined(BILLBOARD)
     #define GetWorldNormal(modelMatrix) GetBillboardNormal()
 #elif defined(DIRBILLBOARD)
-    #define GetWorldNormal(modelMatrix) GetBillboardNormal(iPos, iNormal, iTangent.xyz)
+    #define GetWorldNormal(modelMatrix) GetBillboardNormal(iPos, iNormal)
 #elif defined(TRAILFACECAM)
     #define GetWorldNormal(modelMatrix) GetTrailNormal(iPos)
 #elif defined(TRAILBONE)

--- a/bin/CoreData/Shaders/HLSL/Unlit.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Unlit.hlsl
@@ -23,7 +23,7 @@ void VS(float4 iPos : POSITION,
     #if defined(DIRBILLBOARD) || defined(TRAILBONE)
         float3 iNormal : NORMAL,
     #endif
-    #if defined(DIRBILLBOARD) || defined(TRAILFACECAM) || defined(TRAILBONE)
+    #if defined(TRAILFACECAM) || defined(TRAILBONE)
         float4 iTangent : TANGENT,
     #endif
     out float2 oTexCoord : TEXCOORD0,

--- a/bin/CoreData/Shaders/HLSL/Vegetation.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Vegetation.hlsl
@@ -39,7 +39,7 @@ void VS(float4 iPos : POSITION,
     #if defined(LIGHTMAP) || defined(AO)
         float2 iTexCoord2 : TEXCOORD1,
     #endif
-    #if defined(NORMALMAP) || defined(DIRBILLBOARD) || defined(TRAILFACECAM) || defined(TRAILBONE)
+    #if defined(NORMALMAP) || defined(TRAILFACECAM) || defined(TRAILBONE)
         float4 iTangent : TANGENT,
     #endif
     #ifdef SKINNED


### PR DESCRIPTION
After developing RibbonTrail feature, I realized it's no longer need to passing camera position to direction billboard vertex buffer because Urho3D already has default uniform to do the job.