### PR TITLE
CMAKE_SOURCE_DIR -> Urho3D_SOURCE_DIR

### DIFF
--- a/CMake/Modules/Urho3D-CMake-common.cmake
+++ b/CMake/Modules/Urho3D-CMake-common.cmake
@@ -810,7 +810,7 @@ macro (create_symlink SOURCE DESTINATION)
     if (IS_ABSOLUTE ${SOURCE})
         set (ABS_SOURCE ${SOURCE})
     else ()
-        set (ABS_SOURCE ${CMAKE_SOURCE_DIR}/${SOURCE})
+        set (ABS_SOURCE ${Urho3D_SOURCE_DIR}/${SOURCE})
     endif ()
     if (IS_ABSOLUTE ${DESTINATION})
         set (ABS_DESTINATION ${DESTINATION})
@@ -1270,7 +1270,7 @@ macro (setup_main_executable)
     # Define resources
     if (NOT RESOURCE_DIRS)
         # If the macro caller has not defined the resource dirs then set them based on Urho3D project convention
-        foreach (DIR ${CMAKE_SOURCE_DIR}/bin/CoreData ${CMAKE_SOURCE_DIR}/bin/Data)
+        foreach (DIR ${Urho3D_SOURCE_DIR}/bin/CoreData ${Urho3D_SOURCE_DIR}/bin/Data)
             # Do not assume downstream project always follows Urho3D project convention, so double check if this directory exists before using it
             if (IS_DIRECTORY ${DIR})
                 list (APPEND RESOURCE_DIRS ${DIR})
@@ -1335,10 +1335,10 @@ macro (setup_main_executable)
     if (XCODE)
         if (NOT RESOURCE_FILES)
             # Default app bundle icon
-            set (RESOURCE_FILES ${CMAKE_SOURCE_DIR}/bin/Data/Textures/UrhoIcon.icns)
+            set (RESOURCE_FILES ${Urho3D_SOURCE_DIR}/bin/Data/Textures/UrhoIcon.icns)
             if (IOS)
                 # Default app icon on the iOS home screen
-                list (APPEND RESOURCE_FILES ${CMAKE_SOURCE_DIR}/bin/Data/Textures/UrhoIcon.png)
+                list (APPEND RESOURCE_FILES ${Urho3D_SOURCE_DIR}/bin/Data/Textures/UrhoIcon.png)
             endif ()
         endif ()
         # Group them together under 'Resources' in Xcode IDE
@@ -1355,7 +1355,7 @@ macro (setup_main_executable)
     if (ANDROID)
         # Add SDL native init function, SDL_Main() entry point must be defined by one of the source files in ${SOURCE_FILES}
         find_Urho3D_file (ANDROID_MAIN_C_PATH SDL_android_main.c
-            HINTS ${URHO3D_HOME}/include/Urho3D/ThirdParty/SDL/android ${CMAKE_SOURCE_DIR}/Source/ThirdParty/SDL/src/main/android
+            HINTS ${URHO3D_HOME}/include/Urho3D/ThirdParty/SDL/android ${Urho3D_SOURCE_DIR}/Source/ThirdParty/SDL/src/main/android
             DOC "Path to SDL_android_main.c" MSG_MODE FATAL_ERROR)
         list (APPEND SOURCE_FILES ${ANDROID_MAIN_C_PATH})
         # Setup shared library output path
@@ -1802,14 +1802,14 @@ if (ANDROID)
     file (MAKE_DIRECTORY ${CMAKE_SOURCE_DIR}/Android/assets)
     if (NOT URHO3D_PACKAGING)
         foreach (I CoreData Data)
-            if (NOT EXISTS ${CMAKE_SOURCE_DIR}/Android/assets/${I})
-                create_symlink (${CMAKE_SOURCE_DIR}/bin/${I} ${CMAKE_SOURCE_DIR}/Android/assets/${I} FALLBACK_TO_COPY)
+            if (NOT EXISTS ${Urho3D_SOURCE_DIR}/Android/assets/${I})
+                create_symlink (${Urho3D_SOURCE_DIR}/bin/${I} ${Urho3D_SOURCE_DIR}/Android/assets/${I} FALLBACK_TO_COPY)
             endif ()
         endforeach ()
     endif ()
     foreach (I AndroidManifest.xml build.xml custom_rules.xml project.properties src res assets jni)
         if (EXISTS ${CMAKE_SOURCE_DIR}/Android/${I} AND NOT EXISTS ${CMAKE_BINARY_DIR}/${I})    # No-ops when 'Android' is used as build tree
-            create_symlink (${CMAKE_SOURCE_DIR}/Android/${I} ${CMAKE_BINARY_DIR}/${I} FALLBACK_TO_COPY)
+            create_symlink (${Urho3D_SOURCE_DIR}/Android/${I} ${CMAKE_BINARY_DIR}/${I} FALLBACK_TO_COPY)
         endif ()
     endforeach ()
 elseif (WEB)
@@ -1828,7 +1828,7 @@ else ()
     # Create symbolic links in the build tree
     foreach (I Autoload CoreData Data)
         if (NOT EXISTS ${CMAKE_BINARY_DIR}/bin/${I})
-            create_symlink (${CMAKE_SOURCE_DIR}/bin/${I} ${CMAKE_BINARY_DIR}/bin/${I} FALLBACK_TO_COPY)
+            create_symlink (${Urho3D_SOURCE_DIR}/bin/${I} ${CMAKE_BINARY_DIR}/bin/${I} FALLBACK_TO_COPY)
         endif ()
     endforeach ()
     # Warn user if PATH environment variable has not been correctly set for using ccache

--- a/CMake/Toolchains/android.toolchain.cmake
+++ b/CMake/Toolchains/android.toolchain.cmake
@@ -1605,11 +1605,11 @@ endif()
 
 # Urho3D: Bug fix - not sure what was the original intention as it always tries to overwrite when it is user defined?
 #if( DEFINED LIBRARY_OUTPUT_PATH_ROOT
-#      OR EXISTS "${CMAKE_SOURCE_DIR}/AndroidManifest.xml"
-#      OR (EXISTS "${CMAKE_SOURCE_DIR}/../AndroidManifest.xml" AND EXISTS "${CMAKE_SOURCE_DIR}/../jni/") )
-#  set( LIBRARY_OUTPUT_PATH_ROOT ${CMAKE_SOURCE_DIR} CACHE PATH "Root for binaries output, set this to change where Android libs are installed to" )
+#      OR EXISTS "${Urho3D_SOURCE_DIR}/AndroidManifest.xml"
+#      OR (EXISTS "${Urho3D_SOURCE_DIR}/../AndroidManifest.xml" AND EXISTS "${Urho3D_SOURCE_DIR}/../jni/") )
+#  set( LIBRARY_OUTPUT_PATH_ROOT ${Urho3D_SOURCE_DIR} CACHE PATH "Root for binaries output, set this to change where Android libs are installed to" )
   if( NOT _CMAKE_IN_TRY_COMPILE )
-    if( EXISTS "${CMAKE_SOURCE_DIR}/jni/CMakeLists.txt" )
+    if( EXISTS "${Urho3D_SOURCE_DIR}/jni/CMakeLists.txt" )
       set( EXECUTABLE_OUTPUT_PATH "${LIBRARY_OUTPUT_PATH_ROOT}/bin/${ANDROID_NDK_ABI_NAME}" CACHE PATH "Output directory for applications" )
     else()
       set( EXECUTABLE_OUTPUT_PATH "${LIBRARY_OUTPUT_PATH_ROOT}/bin" CACHE PATH "Output directory for applications" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ endif ()
 project (Urho3D)
 
 # Set CMake modules search path
-set (CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/CMake/Modules)
+set (CMAKE_MODULE_PATH ${Urho3D_SOURCE_DIR}/CMake/Modules)
 
 # Include Urho3D Cmake common module
 include (Urho3D-CMake-common)
@@ -80,14 +80,14 @@ set (DEST_LIBRARY_DIR lib${LIB_SUFFIX}/${PATH_SUFFIX})
 set (SYSROOT ${ANDROID_SYSROOT} ${RPI_SYSROOT} ${ARM_SYSROOT} ${MINGW_SYSROOT} ${IOS_SYSROOT} ${EMSCRIPTEN_SYSROOT} CACHE INTERNAL "Path to system root of the cross-compiling target")  # SYSROOT is empty for native build
 set (DEST_PKGCONFIG_DIR lib${LIB_SUFFIX}/pkgconfig)
 # Install application launcher scripts
-file (GLOB APP_SCRIPTS ${CMAKE_SOURCE_DIR}/bin/*${SCRIPT_EXT})
+file (GLOB APP_SCRIPTS ${Urho3D_SOURCE_DIR}/bin/*${SCRIPT_EXT})
 install (PROGRAMS ${APP_SCRIPTS} DESTINATION ${DEST_RUNTIME_DIR})   # DEST_RUNTIME_DIR variable is set by the set_output_directories() macro call in the Urho3D-CMake-common module
 # Install resource directories required by applications built with Urho3D library
-install (DIRECTORY ${CMAKE_SOURCE_DIR}/bin/Autoload ${CMAKE_SOURCE_DIR}/bin/CoreData ${CMAKE_SOURCE_DIR}/bin/Data DESTINATION ${DEST_SHARE_DIR}/Resources)
+install (DIRECTORY ${Urho3D_SOURCE_DIR}/bin/Autoload ${Urho3D_SOURCE_DIR}/bin/CoreData ${Urho3D_SOURCE_DIR}/bin/Data DESTINATION ${DEST_SHARE_DIR}/Resources)
 # Install CMake modules and toolchains provided by and for Urho3D
-install (DIRECTORY ${CMAKE_SOURCE_DIR}/CMake/ DESTINATION ${DEST_SHARE_DIR}/CMake)    # Note: the trailing slash is significant
+install (DIRECTORY ${Urho3D_SOURCE_DIR}/CMake/ DESTINATION ${DEST_SHARE_DIR}/CMake)    # Note: the trailing slash is significant
 # Install CMake build scripts
-file (GLOB CMAKE_SCRIPTS ${CMAKE_SOURCE_DIR}/*${SCRIPT_EXT})
+file (GLOB CMAKE_SCRIPTS ${Urho3D_SOURCE_DIR}/*${SCRIPT_EXT})
 install (PROGRAMS ${CMAKE_SCRIPTS} DESTINATION ${DEST_SHARE_DIR}/Scripts)
 
 # Setup package variables
@@ -96,7 +96,7 @@ set (CPACK_PACKAGE_DESCRIPTION_SUMMARY ${URHO3D_DESCRIPTION})
 set (URHO3D_URL "https://github.com/urho3d/Urho3D")
 set (CPACK_PACKAGE_VENDOR ${URHO3D_URL})
 set (CPACK_PACKAGE_CONTACT ${URHO3D_URL})
-execute_process (COMMAND ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/CMake/Modules/GetUrho3DRevision.cmake WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} OUTPUT_VARIABLE URHO3D_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process (COMMAND ${CMAKE_COMMAND} -P ${Urho3D_SOURCE_DIR}/CMake/Modules/GetUrho3DRevision.cmake WORKING_DIRECTORY ${Urho3D_SOURCE_DIR} OUTPUT_VARIABLE URHO3D_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
 set (CPACK_PACKAGE_VERSION ${URHO3D_VERSION})
 string (REGEX MATCH "([^.]+)\\.([^.]+)\\.(.+)" MATCHED ${URHO3D_VERSION})
 if (MATCHED)
@@ -104,7 +104,7 @@ if (MATCHED)
     set (CPACK_PACKAGE_VERSION_MINOR ${CMAKE_MATCH_2})
     set (CPACK_PACKAGE_VERSION_PATCH ${CMAKE_MATCH_3})
 endif ()
-set (CPACK_RESOURCE_FILE_LICENSE ${CMAKE_SOURCE_DIR}/License.txt)
+set (CPACK_RESOURCE_FILE_LICENSE ${Urho3D_SOURCE_DIR}/License.txt)
 set (CPACK_SYSTEM_NAME ${CMAKE_SYSTEM_NAME})
 set (CPACK_GENERATOR TGZ)
 if (ANDROID)

--- a/Docs/CMakeLists.txt
+++ b/Docs/CMakeLists.txt
@@ -77,7 +77,7 @@ if (DOXYGEN_FOUND)
     # Dump AngelScript and LuaScript API to Doxygen file if the corresponding host tool is available
     if (TARGET ScriptCompiler AND NOT CMAKE_CROSSCOMPILING)
         add_custom_command (OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/generated/ScriptAPI.dox ${CMAKE_CURRENT_BINARY_DIR}/generated/AngelScriptAPI.h
-            COMMAND ${CMAKE_BINARY_DIR}/bin/tool/ScriptCompiler -dumpapi ${CMAKE_SOURCE_DIR} ScriptAPI.dox AngelScriptAPI.h
+            COMMAND ${CMAKE_BINARY_DIR}/bin/tool/ScriptCompiler -dumpapi ${Urho3D_SOURCE_DIR} ScriptAPI.dox AngelScriptAPI.h
             DEPENDS ScriptCompiler     # ScriptCompiler implicitly depends on Urho3D already
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/generated
             COMMENT "Dumping AngelScript API to ScriptAPI.dox")
@@ -88,7 +88,7 @@ if (DOXYGEN_FOUND)
             DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/ScriptAPI.dox ${CMAKE_CURRENT_SOURCE_DIR}/AngelScriptAPI.h)
     endif ()
     if (TARGET tolua++ AND NOT CMAKE_CROSSCOMPILING)
-        file (GLOB PKGS RELATIVE ${CMAKE_SOURCE_DIR}/Source/Urho3D/LuaScript/pkgs ${CMAKE_SOURCE_DIR}/Source/Urho3D/LuaScript/pkgs/*.pkg)
+        file (GLOB PKGS RELATIVE ${Urho3D_SOURCE_DIR}/Source/Urho3D/LuaScript/pkgs ${Urho3D_SOURCE_DIR}/Source/Urho3D/LuaScript/pkgs/*.pkg)
         list (SORT PKGS)
         set (PKGLIST "// This is a generated file. DO NOT EDIT!\n\n")
         foreach (PKG ${PKGS})
@@ -97,11 +97,11 @@ if (DOXYGEN_FOUND)
         file (WRITE ${CMAKE_CURRENT_BINARY_DIR}/generated/LuaPkgToDox.txt.new ${PKGLIST})
         execute_process (COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/generated/LuaPkgToDox.txt.new ${CMAKE_CURRENT_BINARY_DIR}/generated/LuaPkgToDox.txt)
         execute_process (COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_CURRENT_BINARY_DIR}/generated/LuaPkgToDox.txt.new)
-        file (GLOB_RECURSE API_PKG_FILES ${CMAKE_SOURCE_DIR}/Source/Urho3D/LuaScript/pkgs/*.pkg)
+        file (GLOB_RECURSE API_PKG_FILES ${Urho3D_SOURCE_DIR}/Source/Urho3D/LuaScript/pkgs/*.pkg)
         add_custom_command (OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/generated/LuaScriptAPI.dox
             COMMAND ${CMAKE_BINARY_DIR}/bin/tool/tolua++ -L ToDoxHook.lua -P -o ${CMAKE_CURRENT_BINARY_DIR}/generated/LuaScriptAPI.dox ${CMAKE_CURRENT_BINARY_DIR}/generated/LuaPkgToDox.txt
-            DEPENDS tolua++ ${API_PKG_FILES} ${CMAKE_CURRENT_BINARY_DIR}/generated/LuaPkgToDox.txt ${CMAKE_SOURCE_DIR}/Source/Urho3D/LuaScript/pkgs/ToDoxHook.lua
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/Source/Urho3D/LuaScript/pkgs
+            DEPENDS tolua++ ${API_PKG_FILES} ${CMAKE_CURRENT_BINARY_DIR}/generated/LuaPkgToDox.txt ${Urho3D_SOURCE_DIR}/Source/Urho3D/LuaScript/pkgs/ToDoxHook.lua
+            WORKING_DIRECTORY ${Urho3D_SOURCE_DIR}/Source/Urho3D/LuaScript/pkgs
             COMMENT "Dumping LuaScript API to LuaScriptAPI.dox")
     else ()
         add_custom_command (OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/generated/LuaScriptAPI.dox

--- a/Docs/GettingStarted.dox
+++ b/Docs/GettingStarted.dox
@@ -555,7 +555,7 @@ endif ()
 project (MyProjectName)
 
 # Set CMake modules search path
-set (CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/CMake/Modules)
+set (CMAKE_MODULE_PATH ${Urho3D_SOURCE_DIR}/CMake/Modules)
 
 # Include Urho3D Cmake common module
 include (Urho3D-CMake-common)

--- a/Source/Clang-Tools/CMakeLists.txt
+++ b/Source/Clang-Tools/CMakeLists.txt
@@ -92,7 +92,7 @@ else ()
     get_target_property (SOURCES Urho3D SOURCES)
     string (REGEX REPLACE "[^;]+\\.h" "" SOURCES "${SOURCES}")   # Stringify to preserve the semicolons
     string (REGEX REPLACE "[^;]+generated[^;]+\\.cpp" "" SOURCES "${SOURCES}")
-    file (GLOB BINDING_SOURCES RELATIVE ${CMAKE_SOURCE_DIR}/Source/Urho3D ${CMAKE_SOURCE_DIR}/Source/Urho3D/Script/*API.cpp)
+    file (GLOB BINDING_SOURCES RELATIVE ${Urho3D_SOURCE_DIR}/Source/Urho3D ${Urho3D_SOURCE_DIR}/Source/Urho3D/Script/*API.cpp)
     string (REGEX REPLACE "[^;]+API\\.cpp" "" ANNOTATED_SOURCES "${SOURCES}")
 
     # List of tools
@@ -104,46 +104,46 @@ else ()
         add_custom_target (ast-query
             COMMAND ${CMAKE_COMMAND} -E echo "Building AST for query, please be patient..."
             COMMAND ${LLVM_BINDIR}/clang-query -p ${CMAKE_BINARY_DIR} $$option ${SOURCES}
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/Source/Urho3D
+            WORKING_DIRECTORY ${Urho3D_SOURCE_DIR}/Source/Urho3D
             COMMENT "Executing clang-query on Urho3D library source files")
     endif ()
     add_custom_target (ast
         COMMAND ${CMAKE_COMMAND} -E echo "Usage: option=-help make ast"
         COMMAND ${LLVM_BINDIR}/clang-check -p ${CMAKE_BINARY_DIR} $$option ${SOURCES}
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/Source/Urho3D
+        WORKING_DIRECTORY ${Urho3D_SOURCE_DIR}/Source/Urho3D
         COMMENT "Executing clang-check on Urho3D library source files")
     add_custom_target (binding-ast
         COMMAND ${CMAKE_COMMAND} -E echo "Usage: option=-help make binding-ast"
         COMMAND ${LLVM_BINDIR}/clang-check -p ${CMAKE_BINARY_DIR} $$option ${BINDING_SOURCES}
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/Source/Urho3D
+        WORKING_DIRECTORY ${Urho3D_SOURCE_DIR}/Source/Urho3D
         COMMENT "Executing clang-check on (existing) AngelScript API bindings source files")
     add_custom_target (annotate
         COMMAND ${CMAKE_BINARY_DIR}/bin/tool/clang/Annotator -p ${CMAKE_BINARY_DIR} ${SOURCES}
         DEPENDS Annotator
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/Source/Urho3D
+        WORKING_DIRECTORY ${Urho3D_SOURCE_DIR}/Source/Urho3D
         COMMENT "Annotating Urho3D library source files")
     add_custom_target (autobinder
         COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/Source/Urho3D/generated
         COMMAND ${CMAKE_BINARY_DIR}/bin/tool/clang/AutoBinder -p ${CMAKE_BINARY_DIR} -t ${CMAKE_CURRENT_SOURCE_DIR}/AutoBinder/Templates -o ${CMAKE_BINARY_DIR}/Source/Urho3D/generated -s AngelScript -s LuaScript -s JavaScript ${ANNOTATED_SOURCES}
         DEPENDS AutoBinder
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/Source/Urho3D
+        WORKING_DIRECTORY ${Urho3D_SOURCE_DIR}/Source/Urho3D
         COMMENT "Auto-binding for all script subsystems")
     add_custom_target (autobinder-angelscript
         COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/Source/Urho3D/generated
         COMMAND ${CMAKE_BINARY_DIR}/bin/tool/clang/AutoBinder -p ${CMAKE_BINARY_DIR} -t ${CMAKE_CURRENT_SOURCE_DIR}/AutoBinder/Templates -o ${CMAKE_BINARY_DIR}/Source/Urho3D/generated -s AngelScript ${ANNOTATED_SOURCES}
         DEPENDS AutoBinder
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/Source/Urho3D
+        WORKING_DIRECTORY ${Urho3D_SOURCE_DIR}/Source/Urho3D
         COMMENT "Auto-binding for AngelScript")
     add_custom_target (autobinder-luascript
         COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/Source/Urho3D/generated
         COMMAND ${CMAKE_BINARY_DIR}/bin/tool/clang/AutoBinder -p ${CMAKE_BINARY_DIR} -t ${CMAKE_CURRENT_SOURCE_DIR}/AutoBinder/Templates -o ${CMAKE_BINARY_DIR}/Source/Urho3D/generated -s LuaScript ${ANNOTATED_SOURCES}
         DEPENDS AutoBinder
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/Source/Urho3D
+        WORKING_DIRECTORY ${Urho3D_SOURCE_DIR}/Source/Urho3D
         COMMENT "Auto-binding for LuaScript")
     add_custom_target (autobinder-javascript
         COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/Source/Urho3D/generated
         COMMAND ${CMAKE_BINARY_DIR}/bin/tool/clang/AutoBinder -p ${CMAKE_BINARY_DIR} -t ${CMAKE_CURRENT_SOURCE_DIR}/AutoBinder/Templates -o ${CMAKE_BINARY_DIR}/Source/Urho3D/generated -s JavaScript ${ANNOTATED_SOURCES}
         DEPENDS AutoBinder
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/Source/Urho3D
+        WORKING_DIRECTORY ${Urho3D_SOURCE_DIR}/Source/Urho3D
         COMMENT "Auto-binding for JavaScript")
 endif ()

--- a/Source/Tools/CMakeLists.txt
+++ b/Source/Tools/CMakeLists.txt
@@ -45,8 +45,8 @@ if (CMAKE_CROSSCOMPILING AND URHO3D_PACKAGING)
         set (IOS_FIX CMAKE_COMMAND /usr/bin/env -i PATH=$ENV{PATH} ${CMAKE_COMMAND} BUILD_COMMAND bash -c "sed -i '' 's/EFFECTIVE_PLATFORM_NAME//g' CMakeScripts/install_postBuildPhase.make*")
     endif ()
     ExternalProject_Add (PackageTool
-        SOURCE_DIR ${CMAKE_SOURCE_DIR}/Source/Tools/PackageTool
-        CMAKE_ARGS -DDEST_RUNTIME_DIR=${CMAKE_BINARY_DIR}/bin/tool -DBAKED_CMAKE_SOURCE_DIR=${CMAKE_SOURCE_DIR} -DBAKED_CMAKE_BINARY_DIR=${CMAKE_BINARY_DIR} ${IOS_FIX})
+        SOURCE_DIR ${Urho3D_SOURCE_DIR}/Source/Tools/PackageTool
+        CMAKE_ARGS -DDEST_RUNTIME_DIR=${CMAKE_BINARY_DIR}/bin/tool -DBAKED_CMAKE_SOURCE_DIR=${Urho3D_SOURCE_DIR} -DBAKED_CMAKE_BINARY_DIR=${CMAKE_BINARY_DIR} ${IOS_FIX})
     if (CMAKE_HOST_WIN32 AND NOT URHO3D_MKLINK)
         add_dependencies (PackageTool Urho3D)   # Ensure Urho3D headers are fresh when building PackageTool externally on Windows host system without MKLINK
     endif ()

--- a/Source/Tools/Urho3DPlayer/CMakeLists.txt
+++ b/Source/Tools/Urho3DPlayer/CMakeLists.txt
@@ -40,10 +40,10 @@ if (URHO3D_LUA)
 endif ()
 
 # Symlink/copy helper shell scripts or batch files to invoke Urho3DPlayer
-if (NOT IOS AND NOT ANDROID AND NOT WEB AND NOT CMAKE_BINARY_DIR STREQUAL CMAKE_SOURCE_DIR)
+if (NOT IOS AND NOT ANDROID AND NOT WEB AND NOT CMAKE_BINARY_DIR STREQUAL URHO3D_SOURCE_DIR)
     # Ensure the output directory exist before creating the symlinks
     file (MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
     foreach (FILE Editor NinjaSnowWar PBRDemo)
-        create_symlink (${CMAKE_SOURCE_DIR}/bin/${FILE}${SCRIPT_EXT} ${CMAKE_BINARY_DIR}/bin/${FILE}${SCRIPT_EXT} FALLBACK_TO_COPY)
+        create_symlink (${Urho3D_SOURCE_DIR}/bin/${FILE}${SCRIPT_EXT} ${CMAKE_BINARY_DIR}/bin/${FILE}${SCRIPT_EXT} FALLBACK_TO_COPY)
     endforeach ()
 endif ()

--- a/Source/Urho3D/CMakeLists.txt
+++ b/Source/Urho3D/CMakeLists.txt
@@ -109,7 +109,7 @@ define_source_files (EXCLUDE_PATTERNS ${EXCLUDE_PATTERNS} GLOB_CPP_PATTERNS *.cp
 # Define generated source files
 if (NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/librevision.h)
     execute_process (COMMAND ${CMAKE_COMMAND} -DFILENAME=${CMAKE_CURRENT_BINARY_DIR}/librevision.h -P CMake/Modules/GetUrho3DRevision.cmake
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} OUTPUT_QUIET ERROR_QUIET)
+        WORKING_DIRECTORY ${Urho3D_SOURCE_DIR} OUTPUT_QUIET ERROR_QUIET)
 endif ()
 set (URHO3D_DEPS ${STATIC_LIBRARY_TARGETS})
 if (TARGET LuaJIT_universal)
@@ -122,8 +122,8 @@ if (TARGET LuaJIT_universal)
 endif ()
 add_custom_command (OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/librevision.h
     COMMAND ${CMAKE_COMMAND} -DFILENAME=${CMAKE_CURRENT_BINARY_DIR}/librevision.h -P CMake/Modules/GetUrho3DRevision.cmake
-    DEPENDS ${URHO3D_DEPS} ${CMAKE_SOURCE_DIR}/CMake/Modules/GetUrho3DRevision.cmake
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    DEPENDS ${URHO3D_DEPS} ${Urho3D_SOURCE_DIR}/CMake/Modules/GetUrho3DRevision.cmake
+    WORKING_DIRECTORY ${Urho3D_SOURCE_DIR}
     COMMENT "Generating GIT revision number (tag + last commit SHA-1)")
 if (EMSCRIPTEN)
     # Emscripten will attempt to generate system libraries in LLVM bitcode (libcxxabi, gl, libc, and dlmalloc) when linking for the very first time
@@ -146,8 +146,8 @@ if (URHO3D_BINDINGS)
         set (IOS_FIX CMAKE_COMMAND /usr/bin/env -i PATH=$ENV{PATH} ${CMAKE_COMMAND} BUILD_COMMAND bash -c "sed -i '' 's/EFFECTIVE_PLATFORM_NAME//g' CMakeScripts/install_postBuildPhase.make*")
     endif ()
     ExternalProject_Add (AutoBinder
-            SOURCE_DIR ${CMAKE_SOURCE_DIR}/Source/Clang-Tools
-            CMAKE_ARGS -DURHO3D_CLANG_TOOLS=AutoBinder -DDEST_RUNTIME_DIR=${CMAKE_BINARY_DIR}/bin/tool/clang -DDEST_INCLUDE_DIR=${DEST_INCLUDE_DIR} -DBAKED_CMAKE_SOURCE_DIR=${CMAKE_SOURCE_DIR} ${IOS_FIX})
+            SOURCE_DIR ${Urho3D_SOURCE_DIR}/Source/Clang-Tools
+            CMAKE_ARGS -DURHO3D_CLANG_TOOLS=AutoBinder -DDEST_RUNTIME_DIR=${CMAKE_BINARY_DIR}/bin/tool/clang -DDEST_INCLUDE_DIR=${DEST_INCLUDE_DIR} -DBAKED_CMAKE_SOURCE_DIR=${Urho3D_SOURCE_DIR} ${IOS_FIX})
     file (MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/generated/generated)
     foreach (SCRIPT AngelScript LuaScript JavaScript)
         string (TOUPPER URHO3D_${SCRIPT} OPT)
@@ -173,8 +173,8 @@ if (URHO3D_LUA)
             set (IOS_FIX CMAKE_COMMAND /usr/bin/env -i PATH=$ENV{PATH} ${CMAKE_COMMAND} BUILD_COMMAND bash -c "sed -i '' 's/EFFECTIVE_PLATFORM_NAME//g' CMakeScripts/install_postBuildPhase.make*")
         endif ()
         ExternalProject_Add (tolua++
-            SOURCE_DIR ${CMAKE_SOURCE_DIR}/Source/ThirdParty/toluapp/src/bin
-            CMAKE_ARGS -DDEST_RUNTIME_DIR=${CMAKE_BINARY_DIR}/bin/tool -DBAKED_CMAKE_SOURCE_DIR=${CMAKE_SOURCE_DIR} -DURHO3D_UPDATE_SOURCE_TREE=${URHO3D_UPDATE_SOURCE_TREE} ${IOS_FIX})
+            SOURCE_DIR ${Urho3D_SOURCE_DIR}/Source/ThirdParty/toluapp/src/bin
+            CMAKE_ARGS -DDEST_RUNTIME_DIR=${CMAKE_BINARY_DIR}/bin/tool -DBAKED_CMAKE_SOURCE_DIR=${Urho3D_SOURCE_DIR} -DURHO3D_UPDATE_SOURCE_TREE=${URHO3D_UPDATE_SOURCE_TREE} ${IOS_FIX})
     else ()
         # Otherwise, build it internally as per normal
         add_subdirectory (../ThirdParty/toluapp/src/bin ../ThirdParty/toluapp/src/bin)
@@ -456,7 +456,7 @@ else ()
     string (REPLACE ";" " -l" URHO3D_LIBS "-l${LIB_NAME};${LIBS}")
 endif ()
 string (REPLACE ";" " ${DASH}D" URHO3D_COMPILE_DEFINITIONS "${DASH}D${URHO3D_COMPILE_DEFINITIONS}")
-get_directory_property (GLOBAL_INCLUDE_DIRS DIRECTORY ${CMAKE_SOURCE_DIR} INCLUDE_DIRECTORIES)
+get_directory_property (GLOBAL_INCLUDE_DIRS DIRECTORY ${Urho3D_SOURCE_DIR} INCLUDE_DIRECTORIES)
 if (GLOBAL_INCLUDE_DIRS)
     string (REPLACE ";" "\" ${DASH}I\"" GLOBAL_INCLUDE_DIRS "${DASH}I\"${GLOBAL_INCLUDE_DIRS}\"")
     string (REPLACE "${SYSROOT}" "" GLOBAL_INCLUDE_DIRS ${GLOBAL_INCLUDE_DIRS})
@@ -477,7 +477,7 @@ string (REGEX REPLACE " -fvisibility[^ ]+" "" CLEANED_CMAKE_CXX_FLAGS "${CMAKE_C
 string (REGEX REPLACE " -include \"[^\"]+\"" "" CLEANED_CMAKE_CXX_FLAGS "${CLEANED_CMAKE_CXX_FLAGS}")
 configure_file (${CMAKE_CURRENT_SOURCE_DIR}/Urho3D.pc.in ${CMAKE_CURRENT_BINARY_DIR}/Urho3D.pc${PC_SUFFIX} @ONLY)
 if (MSVC)
-    add_custom_command (TARGET ${TARGET_NAME} POST_BUILD COMMAND ${CMAKE_COMMAND} -DLIB_NAME=$<TARGET_LINKER_FILE_NAME:${TARGET_NAME}> -P ${CMAKE_SOURCE_DIR}/CMake/Modules/AdjustPkgConfigForMSVC.cmake)
+    add_custom_command (TARGET ${TARGET_NAME} POST_BUILD COMMAND ${CMAKE_COMMAND} -DLIB_NAME=$<TARGET_LINKER_FILE_NAME:${TARGET_NAME}> -P ${Urho3D_SOURCE_DIR}/CMake/Modules/AdjustPkgConfigForMSVC.cmake)
 endif ()
 if (ANDROID)
     set (RENAME RENAME Urho3D-${ANDROID_NDK_ABI_NAME}.pc)


### PR DESCRIPTION
This change makes Urho3D no longer assume it "owns the world". While `CMAKE_SOURCE_DIR` always points to directory of root project, `Urho3D_SOURCE_DIR` always points to directory of Urho3D project. Under normal circumstances these both values are equal so it has no impact on build at all. However it paves a way for using Urho3D with `add_subdirectory()` as a child of other project in the future.