### PR TITLE
Add int64_t and uint64_t support for Serializer/Deserializer

### DIFF
--- a/Source/Urho3D/IO/Deserializer.cpp
+++ b/Source/Urho3D/IO/Deserializer.cpp
@@ -57,6 +57,13 @@ unsigned Deserializer::GetChecksum()
     return 0;
 }
 
+long long Deserializer::ReadInt64()
+{
+    long long ret;
+    Read(&ret, sizeof ret);
+    return ret;
+}
+
 int Deserializer::ReadInt()
 {
     int ret;
@@ -74,6 +81,13 @@ short Deserializer::ReadShort()
 signed char Deserializer::ReadByte()
 {
     signed char ret;
+    Read(&ret, sizeof ret);
+    return ret;
+}
+
+unsigned long long Deserializer::ReadUInt64()
+{
+    unsigned long long ret;
     Read(&ret, sizeof ret);
     return ret;
 }

--- a/Source/Urho3D/IO/Deserializer.h
+++ b/Source/Urho3D/IO/Deserializer.h
@@ -57,12 +57,16 @@ public:
     /// Return size.
     unsigned GetSize() const { return size_; }
 
+    /// Read a 64-bit integer.
+    long long ReadInt64();
     /// Read a 32-bit integer.
     int ReadInt();
     /// Read a 16-bit integer.
     short ReadShort();
     /// Read an 8-bit integer.
     signed char ReadByte();
+    /// Read a 64-bit unsigned integer.
+    unsigned long long ReadUInt64();
     /// Read a 32-bit unsigned integer.
     unsigned ReadUInt();
     /// Read a 16-bit unsigned integer.

--- a/Source/Urho3D/IO/Serializer.cpp
+++ b/Source/Urho3D/IO/Serializer.cpp
@@ -35,6 +35,11 @@ Serializer::~Serializer()
 {
 }
 
+bool Serializer::WriteInt64(long long value)
+{
+    return Write(&value, sizeof value) == sizeof value;
+}
+
 bool Serializer::WriteInt(int value)
 {
     return Write(&value, sizeof value) == sizeof value;
@@ -46,6 +51,11 @@ bool Serializer::WriteShort(short value)
 }
 
 bool Serializer::WriteByte(signed char value)
+{
+    return Write(&value, sizeof value) == sizeof value;
+}
+
+bool Serializer::WriteUInt64(unsigned long long value)
 {
     return Write(&value, sizeof value) == sizeof value;
 }

--- a/Source/Urho3D/IO/Serializer.h
+++ b/Source/Urho3D/IO/Serializer.h
@@ -49,12 +49,16 @@ public:
     /// Write bytes to the stream. Return number of bytes actually written.
     virtual unsigned Write(const void* data, unsigned size) = 0;
 
+    /// Write a 64-bit integer.
+    bool WriteInt64(long long value);
     /// Write a 32-bit integer.
     bool WriteInt(int value);
     /// Write a 16-bit integer.
     bool WriteShort(short value);
     /// Write an 8-bit integer.
     bool WriteByte(signed char value);
+    /// Write a 64-bit unsigned integer.
+    bool WriteUInt64(unsigned long long value);
     /// Write a 32-bit unsigned integer.
     bool WriteUInt(unsigned value);
     /// Write a 16-bit unsigned integer.


### PR DESCRIPTION
Because int are not always sufficient, support 64b values to Serialisation interface