### PR TITLE
Alllow override of internal physics configuration and custom collision shapes

### DIFF
--- a/Source/Urho3D/Physics/CollisionShape.cpp
+++ b/Source/Urho3D/Physics/CollisionShape.cpp
@@ -1159,6 +1159,7 @@ void CollisionShape::UpdateShape()
             break;
 
         default:
+        	shape_ = this->UpdateDerivedShape(shapeType_, newWorldScale);
             break;
         }
 
@@ -1177,6 +1178,13 @@ void CollisionShape::UpdateShape()
     recreateShape_ = false;
     retryCreation_ = false;
 }
+
+btCollisionShape* CollisionShape::UpdateDerivedShape(int shapeType, const Vector3& newWorldScale)
+{
+    // To be overridden in derived classes.
+	return NULL;
+}
+
 
 void CollisionShape::HandleTerrainCreated(StringHash eventType, VariantMap& eventData)
 {

--- a/Source/Urho3D/Physics/CollisionShape.h
+++ b/Source/Urho3D/Physics/CollisionShape.h
@@ -244,6 +244,14 @@ protected:
     virtual void OnSceneSet(Scene* scene);
     /// Handle node transform being dirtied.
     virtual void OnMarkedDirty(Node* node);
+    /**
+     * Called when instantiating a collision shape that is not one of ShapeType (default no-op).
+     *
+     * Useful for custom shape types that subclass CollisionShape and use a non-standard underlying
+     * btCollisionShape. UpdateDerivedShape can then be overridden to create the required
+     * btCollisionShape subclass.
+     */
+    virtual btCollisionShape* UpdateDerivedShape(int shapeType, const Vector3& newWorldScale);
 
 private:
     /// Find the parent rigid body component and return its compound collision shape.

--- a/Source/Urho3D/Physics/PhysicsWorld.cpp
+++ b/Source/Urho3D/Physics/PhysicsWorld.cpp
@@ -58,6 +58,8 @@ static const int MAX_SOLVER_ITERATIONS = 256;
 static const int DEFAULT_FPS = 60;
 static const Vector3 DEFAULT_GRAVITY = Vector3(0.0f, -9.81f, 0.0f);
 
+PhysicsWorldConfig PhysicsWorld::config;
+
 static bool CompareRaycastResults(const PhysicsRaycastResult& lhs, const PhysicsRaycastResult& rhs)
 {
     return lhs.distance_ < rhs.distance_;
@@ -114,6 +116,7 @@ struct PhysicsQueryCallback : public btCollisionWorld::ContactResultCallback
     unsigned collisionMask_;
 };
 
+
 PhysicsWorld::PhysicsWorld(Context* context) :
     Component(context),
     collisionConfiguration_(0),
@@ -135,7 +138,11 @@ PhysicsWorld::PhysicsWorld(Context* context) :
 {
     gContactAddedCallback = CustomMaterialCombinerCallback;
 
-    collisionConfiguration_ = new btDefaultCollisionConfiguration();
+    if (PhysicsWorld::config.collisionConfig)
+        collisionConfiguration_ = PhysicsWorld::config.collisionConfig;
+    else
+        collisionConfiguration_ = new btDefaultCollisionConfiguration();
+
     collisionDispatcher_ = new btCollisionDispatcher(collisionConfiguration_);
     broadphase_ = new btDbvtBroadphase();
     solver_ = new btSequentialImpulseConstraintSolver();
@@ -148,6 +155,7 @@ PhysicsWorld::PhysicsWorld(Context* context) :
     world_->setInternalTickCallback(InternalPreTickCallback, static_cast<void*>(this), true);
     world_->setInternalTickCallback(InternalTickCallback, static_cast<void*>(this), false);
 }
+
 
 PhysicsWorld::~PhysicsWorld()
 {

--- a/Source/Urho3D/Physics/PhysicsWorld.h
+++ b/Source/Urho3D/Physics/PhysicsWorld.h
@@ -96,6 +96,19 @@ struct DelayedWorldTransform
     Quaternion worldRotation_;
 };
 
+/**
+ * Custom overrides of physics internals.
+ *
+ * Must be modified before the physics component is created.
+ */
+struct PhysicsWorldConfig
+{
+    /// Override for the collision configuration (default btDefaultCollisionConfiguration).
+    btCollisionConfiguration*    collisionConfig;
+
+    PhysicsWorldConfig() : collisionConfig(NULL) {}
+};
+
 static const float DEFAULT_MAX_NETWORK_ANGULAR_VELOCITY = 100.0f;
 
 /// Physics simulation world component. Should be added only to the root scene node.
@@ -107,6 +120,9 @@ class URHO3D_API PhysicsWorld : public Component, public btIDebugDraw
     friend void InternalTickCallback(btDynamicsWorld* world, btScalar timeStep);
 
 public:
+    /// Allow overrides of the internal configuration.
+    static struct PhysicsWorldConfig config;
+
     /// Construct.
     PhysicsWorld(Context* scontext);
     /// Destruct.

--- a/Source/Urho3D/Physics/PhysicsWorld.h
+++ b/Source/Urho3D/Physics/PhysicsWorld.h
@@ -106,7 +106,7 @@ struct PhysicsWorldConfig
     /// Override for the collision configuration (default btDefaultCollisionConfiguration).
     btCollisionConfiguration*    collisionConfig;
 
-    PhysicsWorldConfig() : collisionConfig(NULL) {}
+    PhysicsWorldConfig() : collisionConfig(0) {}
 };
 
 static const float DEFAULT_MAX_NETWORK_ANGULAR_VELOCITY = 100.0f;


### PR DESCRIPTION
* Add static `config` variable to `PhysicsWorld`, allowing overrides to be set prior to construction - currently just for the `btCollisionConfiguration`.
* Add protected member function to `CollisionShape` to allow for configuring custom collision shapes.

Example usage (from my own code):

Somewhere before creating the physics component
```
PhysicsWorld::config.collisionConfig = new btFeltCollisionConfiguration();
```
I can then use my override of the collision configuration to deal with my custom shape
```
btCollisionAlgorithmCreateFunc* btFeltCollisionConfiguration::getCollisionAlgorithmCreateFunc(
	int proxyType0, int proxyType1
) {
	if (btBroadphaseProxy::isConvex(proxyType0) && (proxyType1 == CUSTOM_CONCAVE_SHAPE_TYPE))
	{
		return m_convexSurfaceCF;
	}

	if (btBroadphaseProxy::isConvex(proxyType1) && (proxyType0 == CUSTOM_CONCAVE_SHAPE_TYPE))
	{
		return m_surfaceConvexCF;
	}

	return btDefaultCollisionConfiguration::getCollisionAlgorithmCreateFunc(proxyType0, proxyType1);
}
```
Then for my custom `CollisionShape`
```
class URHO3D_API FeltCollisionShape : public Urho3D::CollisionShape
. . .
```
```
btCollisionShape* FeltCollisionShape::UpdateDerivedShape(
	 int shapeType, const Urho3D::Vector3& newWorldScale
) {
	btCollisionShape* pshape = new btSurfaceShape(m_psurface, m_pos_child);
	pshape->setLocalScaling(Urho3D::ToBtVector3(newWorldScale));
	return pshape;
}
```