### PR TITLE
CMake fixes for compiling on Ubuntu 16.04

### DIFF
--- a/Source/ThirdParty/STB/CMakeLists.txt
+++ b/Source/ThirdParty/STB/CMakeLists.txt
@@ -26,6 +26,5 @@ set (TARGET_NAME STB)
 # Setup target
 add_custom_target (${TARGET_NAME} ALL)   # Dummy target just so that its post-build step can install headers to the build tree
 set (STATIC_LIBRARY_TARGETS ${STATIC_LIBRARY_TARGETS} ${TARGET_NAME} PARENT_SCOPE)
-
 # Install headers for building the Urho3D library
-install_header_files (DIRECTORY ./ DESTINATION ${DEST_INCLUDE_DIR}/ThirdParty/STB FILES_MATCHING PATTERN *.h USE_FILE_SYMLINK BUILD_TREE_ONLY)  # Note: the trailing slash is significant
+install_header_files (DIRECTORY ./ DESTINATION ${DEST_INCLUDE_DIR}/ThirdParty/STB FILES_MATCHING PATTERN *.h BUILD_TREE_ONLY)  # Note: the trailing slash is significant

--- a/Source/ThirdParty/rapidjson/CMakeLists.txt
+++ b/Source/ThirdParty/rapidjson/CMakeLists.txt
@@ -28,4 +28,4 @@ add_custom_target (${TARGET_NAME} ALL)   # Dummy target just so that its post-bu
 set (STATIC_LIBRARY_TARGETS ${STATIC_LIBRARY_TARGETS} ${TARGET_NAME} PARENT_SCOPE)
 
 # Install headers for building the Urho3D library
-install_header_files (DIRECTORY include/rapidjson/ DESTINATION ${DEST_INCLUDE_DIR}/ThirdParty/rapidjson FILES_MATCHING PATTERN *.h USE_FILE_SYMLINK BUILD_TREE_ONLY)  # Note: the trailing slash is significant
+install_header_files (DIRECTORY include/rapidjson/ DESTINATION ${DEST_INCLUDE_DIR}/ThirdParty/rapidjson FILES_MATCHING PATTERN *.h BUILD_TREE_ONLY)  # Note: the trailing slash is significant

--- a/Source/ThirdParty/toluapp/src/bin/CMakeLists.txt
+++ b/Source/ThirdParty/toluapp/src/bin/CMakeLists.txt
@@ -64,6 +64,7 @@ if (URHO3D_UPDATE_SOURCE_TREE)
 endif ()
 file (GLOB TOLUA lua/*.lua)
 add_custom_command (OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/generated/toluabind.c
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/generated
     COMMAND ${CMAKE_BINARY_DIR}/bin/tool/tolua++ -o ${CMAKE_CURRENT_BINARY_DIR}/generated/toluabind.c -H ${CMAKE_CURRENT_BINARY_DIR}/generated/toluabind.h -n tolua tolua_scons.pkg 2>${NULL_DEVICE} || ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/toluabind.c ${CMAKE_CURRENT_BINARY_DIR}/generated/toluabind.c
     ${UPDATE_COMMAND}
     DEPENDS ${TOLUA} tolua_scons.pkg

--- a/Source/Urho3D/CMakeLists.txt
+++ b/Source/Urho3D/CMakeLists.txt
@@ -419,6 +419,10 @@ endif ()
 # Use PIC on platforms that support it (shared library type has this property set to true by default, so we only have to deal with those static ones that the shared library links against)
 if (URHO3D_LIB_TYPE STREQUAL SHARED)
     set_target_properties (${STATIC_LIBRARY_TARGETS} PROPERTIES POSITION_INDEPENDENT_CODE true)
+    if (CMAKE_COMPILER_IS_GNUCXX)
+        # Required for Ubuntu 16.04 to use STB library: https://github.com/nothings/stb/issues/280
+        target_link_libraries(${TARGET_NAME} gcc_s gcc)
+    endif ()
     if (NOT MSVC AND NOT (MINGW AND CMAKE_CROSSCOMPILING) AND CMAKE_VERSION VERSION_LESS 2.8.9)  # todo: Remove this when CMake minimum version is 2.8.9
         set_property (TARGET ${STATIC_LIBRARY_TARGETS} APPEND PROPERTY COMPILE_FLAGS -fPIC)
     endif ()

--- a/Source/Urho3D/CMakeLists.txt
+++ b/Source/Urho3D/CMakeLists.txt
@@ -419,7 +419,7 @@ endif ()
 # Use PIC on platforms that support it (shared library type has this property set to true by default, so we only have to deal with those static ones that the shared library links against)
 if (URHO3D_LIB_TYPE STREQUAL SHARED)
     set_target_properties (${STATIC_LIBRARY_TARGETS} PROPERTIES POSITION_INDEPENDENT_CODE true)
-    if (CMAKE_COMPILER_IS_GNUCXX)
+    if (NOT WIN32 AND CMAKE_COMPILER_IS_GNUCXX)
         # Required for Ubuntu 16.04 to use STB library: https://github.com/nothings/stb/issues/280
         target_link_libraries(${TARGET_NAME} gcc_s gcc)
     endif ()


### PR DESCRIPTION
* rapidjson and STB CMake `install_header_files` call using `USE_FILE_SYMLINK` causes "Too many levels of symbolic links" error.
* Ensure necessary folder required for tolua++ to build.
* Link `gcc_s` and `gcc` to work around GCC 5.4 issue with STB in shared libraries (known issue https://github.com/nothings/stb/issues/280).

This is as much a bug report as pull request - there may be better ways to solve these issues.  Especially the symbolic links issue - the fix doesn't address the underlying cause, just disables symlinks.