### PR TITLE
Input events

### DIFF
--- a/Docs/Reference.dox
+++ b/Docs/Reference.dox
@@ -1813,6 +1813,9 @@ The input events include:
 - E_INPUTFOCUS : application input focus or window minimization state changed.
 - E_MOUSEVISIBLECHANGED : the visibility of the operating system mouse cursor was changed.
 - E_EXITREQUESTED : application exit was requested (eg. with the window close button.)
+- E_INPUTBEGIN : input handling starts.
+- E_INPUTEND : input handling ends.
+- E_SDLRAWINPUT : raw SDL event is sent for customized event processing.
 
 \section InputKeyboard Keyboard and mouse input
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Urho3D development, contributions and bugfixes by:
 - Yusuf Umar
 - Daniel Wiberg
 - Steven Zhang
+- Rokas Kupstys
 - AGreatFish
 - BlueMagnificent
 - Enhex
@@ -99,7 +100,6 @@ Urho3D development, contributions and bugfixes by:
 - reattiva
 - rifai
 - rikorin
-- r-ku
 - skaiware
 - ssinai1
 - svifylabs

--- a/Source/Urho3D/Input/Input.cpp
+++ b/Source/Urho3D/Input/Input.cpp
@@ -1837,6 +1837,14 @@ void Input::HandleSDLEvent(void* sdlEvent)
             return;
     }
 
+    VariantMap eventData;
+    eventData[SdlRawInput::P_SDL_EVENT] = &evt;
+    eventData[SdlRawInput::P_CONSUMED] = false;
+    SendEvent(E_SDLRAWINPUT, eventData);
+
+    if (eventData[SdlRawInput::P_CONSUMED].GetBool())
+        return;
+
     switch (evt.type)
     {
         case SDL_KEYDOWN:
@@ -2364,7 +2372,9 @@ void Input::HandleScreenMode(StringHash eventType, VariantMap& eventData)
 void Input::HandleBeginFrame(StringHash eventType, VariantMap& eventData)
 {
     // Update input right at the beginning of the frame
+    SendEvent(E_INPUTBEGIN);
     Update();
+    SendEvent(E_INPUTEND);
 }
 
 #ifdef __EMSCRIPTEN__

--- a/Source/Urho3D/Input/InputEvents.h
+++ b/Source/Urho3D/Input/InputEvents.h
@@ -221,6 +221,23 @@ URHO3D_EVENT(E_EXITREQUESTED, ExitRequested)
 {
 }
 
+/// Raw SDL input event.
+URHO3D_EVENT(E_SDLRAWINPUT, SdlRawInput)
+{
+    URHO3D_PARAM(P_SDL_EVENT, SdlEvent);           // SDL_Event*
+    URHO3D_PARAM(P_CONSUMED, Consumed);            // bool
+}
+
+/// Input handling begins.
+URHO3D_EVENT(E_INPUTBEGIN, InputBegin)
+{
+}
+
+/// Input handling ends.
+URHO3D_EVENT(E_INPUTEND, InputEnd)
+{
+}
+
 static const int MOUSEB_LEFT = SDL_BUTTON_LMASK;
 static const int MOUSEB_MIDDLE = SDL_BUTTON_MMASK;
 static const int MOUSEB_RIGHT = SDL_BUTTON_RMASK;


### PR DESCRIPTION
Added three input-related events:

* E_INPUTBEGIN : input handling starts.
* E_INPUTEND : input handling ends.
* E_SDLRAWINPUT : raw SDL event is sent for customized event processing.

`E_SDLRAWINPUT` additionally checks `P_CONSUMED` value (which is `false` by default) and if it is set to true event is discarded. This is for libraries that would like to take over input handling completely.

Need for other two events arose from handling nuklear UI events. It requires to do some things before and after input handling. Without these events doing those tasks took bit of improper hackery abusing other events and their order which is not good at all.