### PR TITLE
IntVector2::ToHash()

### DIFF
--- a/Source/Urho3D/Math/Vector2.h
+++ b/Source/Urho3D/Math/Vector2.h
@@ -323,6 +323,9 @@ public:
     /// Return as string.
     String ToString() const;
 
+    /// Return hash value for HashSet & HashMap.
+    unsigned ToHash() const { return x_ * 15485863 + y_ * 32452843; }
+
     /// X coordinate.
     int x_;
     /// Y coordinate.

--- a/Source/Urho3D/Math/Vector2.h
+++ b/Source/Urho3D/Math/Vector2.h
@@ -324,7 +324,7 @@ public:
     String ToString() const;
 
     /// Return hash value for HashSet & HashMap.
-    unsigned ToHash() const { return x_ * 15485863 + y_ * 32452843; }
+    unsigned ToHash() const { return (unsigned)x_ * 31 + (unsigned)y_; }
 
     /// X coordinate.
     int x_;


### PR DESCRIPTION
Hello

I think it's common in games that IntVector2 is used as a key in set or map. For example, I use it to keep track of tiles that need updating. I think it needs to be hashable, so I can use it in HashSet. Hope I understood the HashSet correctly and hope you agree with me :)

About the hashing function. Why does it have two random numbers? Honestly, I don't know. I just made a wild guess that if I put two big prime numbers there, it's hard for hash numbers to make a collision.