### PR TITLE
Add new face camera mode to BillboardSet and Text3D.

### DIFF
--- a/Source/Urho3D/AngelScript/GraphicsAPI.cpp
+++ b/Source/Urho3D/AngelScript/GraphicsAPI.cpp
@@ -1448,6 +1448,7 @@ static void RegisterBillboardSet(asIScriptEngine* engine)
     engine->RegisterEnumValue("FaceCameraMode", "FC_ROTATE_Y", FC_ROTATE_Y);
     engine->RegisterEnumValue("FaceCameraMode", "FC_LOOKAT_XYZ", FC_LOOKAT_XYZ);
     engine->RegisterEnumValue("FaceCameraMode", "FC_LOOKAT_Y", FC_LOOKAT_Y);
+    engine->RegisterEnumValue("FaceCameraMode", "FC_LOOKAT_MIXED", FC_LOOKAT_MIXED);
     engine->RegisterEnumValue("FaceCameraMode", "FC_DIRECTION", FC_DIRECTION);
 
     engine->RegisterObjectType("Billboard", 0, asOBJ_REF);

--- a/Source/Urho3D/AngelScript/GraphicsAPI.cpp
+++ b/Source/Urho3D/AngelScript/GraphicsAPI.cpp
@@ -1477,6 +1477,8 @@ static void RegisterBillboardSet(asIScriptEngine* engine)
     engine->RegisterObjectMethod("BillboardSet", "bool get_fixedScreenSize() const", asMETHOD(BillboardSet, IsFixedScreenSize), asCALL_THISCALL);
     engine->RegisterObjectMethod("BillboardSet", "void set_faceCameraMode(FaceCameraMode)", asMETHOD(BillboardSet, SetFaceCameraMode), asCALL_THISCALL);
     engine->RegisterObjectMethod("BillboardSet", "FaceCameraMode get_faceCameraMode() const", asMETHOD(BillboardSet, GetFaceCameraMode), asCALL_THISCALL);
+    engine->RegisterObjectMethod("BillboardSet", "void set_minAngle(float)", asMETHOD(BillboardSet, SetMinAngle), asCALL_THISCALL);
+    engine->RegisterObjectMethod("BillboardSet", "float get_minAngle() const", asMETHOD(BillboardSet, GetMinAngle), asCALL_THISCALL);
     engine->RegisterObjectMethod("BillboardSet", "void set_animationLodBias(float)", asMETHOD(BillboardSet, SetAnimationLodBias), asCALL_THISCALL);
     engine->RegisterObjectMethod("BillboardSet", "float get_animationLodBias() const", asMETHOD(BillboardSet, GetAnimationLodBias), asCALL_THISCALL);
     engine->RegisterObjectMethod("BillboardSet", "Billboard@+ get_billboards(uint)", asMETHOD(BillboardSet, GetBillboard), asCALL_THISCALL);

--- a/Source/Urho3D/Graphics/BillboardSet.cpp
+++ b/Source/Urho3D/Graphics/BillboardSet.cpp
@@ -52,7 +52,7 @@ const char* faceCameraModeNames[] =
     "Rotate Y",
     "LookAt XYZ",
     "LookAt Y",
-    "LookAt Y (Restricted)",
+    "LookAt Mixed",
     "Direction",
     0
 };

--- a/Source/Urho3D/Graphics/BillboardSet.cpp
+++ b/Source/Urho3D/Graphics/BillboardSet.cpp
@@ -52,6 +52,7 @@ const char* faceCameraModeNames[] =
     "Rotate Y",
     "LookAt XYZ",
     "LookAt Y",
+    "LookAt Y (Restricted)",
     "Direction",
     0
 };
@@ -70,6 +71,7 @@ BillboardSet::BillboardSet(Context* context) :
     sorted_(false),
     fixedScreenSize_(false),
     faceCameraMode_(FC_ROTATE_XYZ),
+    minAngle_(0.0f),
     geometry_(new Geometry(context)),
     vertexBuffer_(new VertexBuffer(context_)),
     indexBuffer_(new IndexBuffer(context_)),
@@ -109,6 +111,7 @@ void BillboardSet::RegisterObject(Context* context)
     URHO3D_ACCESSOR_ATTRIBUTE("Can Be Occluded", IsOccludee, SetOccludee, bool, true, AM_DEFAULT);
     URHO3D_ATTRIBUTE("Cast Shadows", bool, castShadows_, false, AM_DEFAULT);
     URHO3D_ENUM_ACCESSOR_ATTRIBUTE("Face Camera Mode", GetFaceCameraMode, SetFaceCameraMode, FaceCameraMode, faceCameraModeNames, FC_ROTATE_XYZ, AM_DEFAULT);
+    URHO3D_ACCESSOR_ATTRIBUTE("Min Angle", GetMinAngle, SetMinAngle, float, 0.0f, AM_DEFAULT);
     URHO3D_ACCESSOR_ATTRIBUTE("Draw Distance", GetDrawDistance, SetDrawDistance, float, 0.0f, AM_DEFAULT);
     URHO3D_ACCESSOR_ATTRIBUTE("Shadow Distance", GetShadowDistance, SetShadowDistance, float, 0.0f, AM_DEFAULT);
     URHO3D_ACCESSOR_ATTRIBUTE("Animation LOD Bias", GetAnimationLodBias, SetAnimationLodBias, float, 1.0f, AM_DEFAULT);
@@ -206,7 +209,7 @@ void BillboardSet::UpdateBatches(const FrameInfo& frame)
     transforms_[0] = relative_ ? node_->GetWorldTransform() : Matrix3x4::IDENTITY;
     // Billboard rotation
     transforms_[1] = Matrix3x4(Vector3::ZERO, faceCameraMode_ != FC_NONE ? frame.camera_->GetFaceCameraRotation(
-        node_->GetWorldPosition(), node_->GetWorldRotation(), faceCameraMode_) : node_->GetWorldRotation(), Vector3::ONE);
+        node_->GetWorldPosition(), node_->GetWorldRotation(), faceCameraMode_, minAngle_) : node_->GetWorldRotation(), Vector3::ONE);
 }
 
 void BillboardSet::UpdateGeometry(const FrameInfo& frame)
@@ -219,7 +222,7 @@ void BillboardSet::UpdateGeometry(const FrameInfo& frame)
     if (faceCameraMode_ != FC_NONE)
     {
         transforms_[1] = Matrix3x4(Vector3::ZERO, frame.camera_->GetFaceCameraRotation(node_->GetWorldPosition(),
-            node_->GetWorldRotation(), faceCameraMode_), Vector3::ONE);
+            node_->GetWorldRotation(), faceCameraMode_, minAngle_), Vector3::ONE);
     }
 
     if (bufferSizeDirty_ || indexBuffer_->IsDataLost())
@@ -318,6 +321,12 @@ void BillboardSet::SetFaceCameraMode(FaceCameraMode mode)
         faceCameraMode_ = mode;
         MarkNetworkUpdate();
     }
+}
+
+void BillboardSet::SetMinAngle(float angle)
+{
+    minAngle_ = angle;
+    MarkNetworkUpdate();
 }
 
 void BillboardSet::SetAnimationLodBias(float bias)

--- a/Source/Urho3D/Graphics/BillboardSet.h
+++ b/Source/Urho3D/Graphics/BillboardSet.h
@@ -95,6 +95,8 @@ public:
     void SetFixedScreenSize(bool enable);
     /// Set how the billboards should rotate in relation to the camera. Default is to follow camera rotation on all axes (FC_ROTATE_XYZ.)
     void SetFaceCameraMode(FaceCameraMode mode);
+    /// Set minimal angle between billboard normal and look-at direction.
+    void SetMinAngle(float angle);
     /// Set animation LOD bias.
     void SetAnimationLodBias(float bias);
     /// Mark for bounding box and vertex buffer update. Call after modifying the billboards.
@@ -126,6 +128,9 @@ public:
 
     /// Return how the billboards rotate in relation to the camera.
     FaceCameraMode GetFaceCameraMode() const { return faceCameraMode_; }
+
+    /// Return minimal angle between billboard normal and look-at direction.
+    float GetMinAngle() const { return minAngle_; }
 
     /// Return animation LOD bias.
     float GetAnimationLodBias() const { return animationLodBias_; }
@@ -165,6 +170,8 @@ protected:
     bool fixedScreenSize_;
     /// Billboard rotation mode in relation to the camera.
     FaceCameraMode faceCameraMode_;
+    /// Minimal angle between billboard normal and look-at direction.
+    float minAngle_;
 
 private:
     /// Resize billboard vertex and index buffers.

--- a/Source/Urho3D/Graphics/Camera.cpp
+++ b/Source/Urho3D/Graphics/Camera.cpp
@@ -562,7 +562,7 @@ Quaternion Camera::GetFaceCameraRotation(const Vector3& position, const Quaterni
             return Quaternion(euler.x_, euler.y_, euler.z_);
         }
 
-    case FC_LOOKAT_Y_RESTRICTED:
+    case FC_LOOKAT_MIXED:
         {
             // Make the Y-only lookat happen on an XZ plane to make sure there are no unwanted transitions
             // or singularities

--- a/Source/Urho3D/Graphics/Camera.h
+++ b/Source/Urho3D/Graphics/Camera.h
@@ -191,7 +191,7 @@ public:
     /// Return a scene node's LOD scaled distance.
     float GetLodDistance(float distance, float scale, float bias) const;
     /// Return a world rotation for facing a camera on certain axes based on the existing world rotation.
-    Quaternion GetFaceCameraRotation(const Vector3& position, const Quaternion& rotation, FaceCameraMode mode);
+    Quaternion GetFaceCameraRotation(const Vector3& position, const Quaternion& rotation, FaceCameraMode mode, float minAngle = 0.0f);
     /// Get effective world transform for matrix and frustum calculations including reflection but excluding node scaling.
     Matrix3x4 GetEffectiveWorldTransform() const;
     /// Return if projection parameters are valid for rendering and raycasting.

--- a/Source/Urho3D/Graphics/GraphicsDefs.h
+++ b/Source/Urho3D/Graphics/GraphicsDefs.h
@@ -352,7 +352,8 @@ enum FaceCameraMode
     FC_ROTATE_Y,
     FC_LOOKAT_XYZ,
     FC_LOOKAT_Y,
-    FC_DIRECTION
+    FC_LOOKAT_Y_RESTRICTED,
+    FC_DIRECTION,
 };
 
 /// Shadow type

--- a/Source/Urho3D/Graphics/GraphicsDefs.h
+++ b/Source/Urho3D/Graphics/GraphicsDefs.h
@@ -352,7 +352,7 @@ enum FaceCameraMode
     FC_ROTATE_Y,
     FC_LOOKAT_XYZ,
     FC_LOOKAT_Y,
-    FC_LOOKAT_Y_RESTRICTED,
+    FC_LOOKAT_MIXED,
     FC_DIRECTION,
 };
 

--- a/Source/Urho3D/LuaScript/pkgs/Graphics/BillboardSet.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Graphics/BillboardSet.pkg
@@ -19,6 +19,7 @@ class BillboardSet : public Drawable
     void SetSorted(bool enable);
     void SetFixedScreenSize(bool enable);
     void SetFaceCameraMode(FaceCameraMode mode);
+    void SetMinAngle(float angle);
     void SetAnimationLodBias(float bias);
 
     void Commit();
@@ -31,6 +32,7 @@ class BillboardSet : public Drawable
     bool IsSorted() const;
     bool IsFixedScreenSize() const;
     FaceCameraMode GetFaceCameraMode() const;
+    float GetMinAngle() const;
     float GetAnimationLodBias() const;
     
     tolua_property__get_set Material* material;
@@ -40,5 +42,6 @@ class BillboardSet : public Drawable
     tolua_property__is_set bool sorted;
     tolua_property__is_set bool fixedScreenSize;
     tolua_property__get_set FaceCameraMode faceCameraMode;
+    tolua_property__get_set float minAngle;
     tolua_property__get_set float animationLodBias;
 };

--- a/Source/Urho3D/LuaScript/pkgs/Graphics/GraphicsDefs.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Graphics/GraphicsDefs.pkg
@@ -201,6 +201,7 @@ enum FaceCameraMode
     FC_ROTATE_Y,
     FC_LOOKAT_XYZ,
     FC_LOOKAT_Y,
+    FC_LOOKAT_MIXED,
     FC_DIRECTION
 };
 

--- a/Source/Urho3D/LuaScript/pkgs/UI/Text3D.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/UI/Text3D.pkg
@@ -7,7 +7,8 @@ enum FaceCameraMode
     FC_ROTATE_XYZ,
     FC_ROTATE_Y,
     FC_LOOKAT_XYZ,
-    FC_LOOKAT_Y
+    FC_LOOKAT_Y,
+    FC_LOOKAT_MIXED
 };
 
 class Text3D : public Drawable

--- a/Source/Urho3D/UI/Text3D.cpp
+++ b/Source/Urho3D/UI/Text3D.cpp
@@ -53,6 +53,7 @@ Text3D::Text3D(Context* context) :
     vertexBuffer_(new VertexBuffer(context_)),
     customWorldTransform_(Matrix3x4::IDENTITY),
     faceCameraMode_(FC_NONE),
+    minAngle_(0.0f),
     fixedScreenSize_(false),
     textDirty_(true),
     geometryDirty_(true),
@@ -82,6 +83,7 @@ void Text3D::RegisterObject(Context* context)
     URHO3D_ACCESSOR_ATTRIBUTE("Can Be Occluded", IsOccludee, SetOccludee, bool, true, AM_DEFAULT);
     URHO3D_ACCESSOR_ATTRIBUTE("Fixed Screen Size", IsFixedScreenSize, SetFixedScreenSize, bool, false, AM_DEFAULT);
     URHO3D_ENUM_ATTRIBUTE("Face Camera Mode", faceCameraMode_, faceCameraModeNames, FC_NONE, AM_DEFAULT);
+    URHO3D_ATTRIBUTE("Min Angle", float, minAngle_, 0.0f, AM_DEFAULT);
     URHO3D_ACCESSOR_ATTRIBUTE("Draw Distance", GetDrawDistance, SetDrawDistance, float, 0.0f, AM_DEFAULT);
     URHO3D_ACCESSOR_ATTRIBUTE("Width", GetWidth, SetWidth, int, 0, AM_DEFAULT);
     URHO3D_ENUM_ACCESSOR_ATTRIBUTE("Horiz Alignment", GetHorizontalAlignment, SetHorizontalAlignment, HorizontalAlignment,
@@ -722,7 +724,7 @@ void Text3D::CalculateFixedScreenSize(const FrameInfo& frame)
     }
 
     customWorldTransform_ = Matrix3x4(worldPosition, frame.camera_->GetFaceCameraRotation(
-        worldPosition, node_->GetWorldRotation(), faceCameraMode_), worldScale);
+        worldPosition, node_->GetWorldRotation(), faceCameraMode_, minAngle_), worldScale);
     worldBoundingBoxDirty_ = true;
 }
 

--- a/Source/Urho3D/UI/Text3D.h
+++ b/Source/Urho3D/UI/Text3D.h
@@ -200,6 +200,8 @@ protected:
     Matrix3x4 customWorldTransform_;
     /// Text rotation mode in relation to the camera.
     FaceCameraMode faceCameraMode_;
+    /// Minimal angle between text normal and look-at direction.
+    float minAngle_;
     /// Fixed screen size flag.
     bool fixedScreenSize_;
     /// Text needs update flag.


### PR DESCRIPTION
This PR is a small improvement of Urho's billboard system.

**LookAt Y** and **Rotate Y** modes are useful for rendering some grounded objects like grass or trees that shouldn't be freely rotated. Such billboards degrade when camera looks downside and this case is often unwanted.

This PR introduces new mode called **LookAt Mixed** that is a hybrid of **LookAt XYZ** and **LookAt Y**. New attribute **minAngle** controls minimum angle between billboard normal and look-at direction. 0 is **LookAt Y** mode, 90 is **LookAt XYZ**. Small values of **minAngle** allow user to have almost-lookat-Y billboards that don't degrade when looking downside. See screenshot.

Unfortunatelly, implementation for **Rotate Y**/**Rotate XYZ** looks much more difficult. But maybe it will be implemented at some point.

![image](https://cloud.githubusercontent.com/assets/8576192/18288612/e29c4924-7484-11e6-9e2b-46fbe93fee40.png)