### PR TITLE
fix skydome glsl error

### DIFF
--- a/bin/CoreData/Shaders/GLSL/Skydome.glsl
+++ b/bin/CoreData/Shaders/GLSL/Skydome.glsl
@@ -4,9 +4,6 @@
 
 varying vec2 vTexCoord;
 
-uniform mat4 gl_ModelViewMatrix;
-uniform mat4 gl_ProjectionMatrix;
-
 void VS()
 {
     mat4 modelMatrix = iModelMatrix;
@@ -17,6 +14,6 @@ void VS()
 }
 
 void PS()
-{   
-    gl_FragColor = texture2D(sDiffMap, vTexCoord);       
+{
+    gl_FragColor = texture2D(sDiffMap, vTexCoord);
 }


### PR DESCRIPTION
 in my mac, skydome is not shown and output an error:

ERROR: Failed to compile vertex shader Skydome():
ERROR: 0:516: Identifier name 'gl_ModelViewMatrix' cannot start with 'gl_'
ERROR: 0:517: Identifier name 'gl_ProjectionMatrix' cannot start with 'gl_'
[Sun Sep 11 13:05:23 2016] ERROR: Failed to compile pixel shader Skydome():
ERROR: 0:516: Identifier name 'gl_ModelViewMatrix' cannot start with 'gl_'
ERROR: 0:517: Identifier name 'gl_ProjectionMatrix' cannot start with 'gl_'