### PR TITLE
Fix memory leak in Dictionary.

### DIFF
--- a/Source/Urho3D/AngelScript/Addons.cpp
+++ b/Source/Urho3D/AngelScript/Addons.cpp
@@ -2086,7 +2086,6 @@ bool CScriptDictValue::Get(asIScriptEngine *engine, void *value, int typeId) con
         if ((m_typeId & asTYPEID_MASK_OBJECT) &&
             engine->RefCastObject(m_valueObj, engine->GetObjectTypeById(m_typeId), engine->GetObjectTypeById(typeId), &cast) >= 0)
         {
-            engine->AddRefScriptObject(m_valueObj, engine->GetObjectTypeById(m_typeId));
             *(void**)value = m_valueObj;
 
             return true;


### PR DESCRIPTION
RefCastObject adds one ref by itself. So extra AddRefScriptObject call cause memory leak when Dictionary.Get is called from script.

I'm not 100% sure in this solution. However, I've smoke-tested Editor and my project - no crashes, no leaks.

Closes #1582 