### PR TITLE
Expose mouse position manipulation api in Input class

### DIFF
--- a/Source/Urho3D/Input/Input.h
+++ b/Source/Urho3D/Input/Input.h
@@ -297,6 +297,11 @@ public:
     /// Return whether application window is minimized.
     bool IsMinimized() const;
 
+    /// Set the mouse cursor position.
+    void SetMousePosition(const IntVector2& position);
+    /// Center the mouse position.
+    void CenterMousePosition();
+
 private:
     /// Initialize when screen mode initially set.
     void Initialize();
@@ -328,10 +333,6 @@ private:
     void SetKey(int key, int scancode, bool newState);
     /// Handle mouse wheel change.
     void SetMouseWheel(int delta);
-    /// Internal function to set the mouse cursor position.
-    void SetMousePosition(const IntVector2& position);
-    /// Center the mouse position.
-    void CenterMousePosition();
     /// Suppress next mouse movement.
     void SuppressNextMouseMove();
     /// Unsuppress mouse movement.


### PR DESCRIPTION
`Input::SetMousePosition()` and `Input::CenterMousePosition()` are moved to public access scope to allow access to these APIs. Sometimes there is need to manually position cursor and there are no other means.

One of such usecases is  having cursor hover UI button when application is opened should button be positioned right in center of the screen. This is more of a problem on mobile platforms where cursor is not visible and it is not clear why one (hovered) button looks differently than the others.