### PR TITLE
Move Texture2D::GetImage and TextureCube::GetImage implementations.

### DIFF
--- a/Source/Urho3D/AngelScript/GraphicsAPI.cpp
+++ b/Source/Urho3D/AngelScript/GraphicsAPI.cpp
@@ -181,18 +181,12 @@ static Viewport* ConstructViewportSceneCameraRect(Scene* scene, Camera* camera, 
 
 static Image* Texture2DGetImage(Texture2D* tex2d)
 {
-    SharedPtr<Image> sharedImage = tex2d->GetImage();
-    Image* image = sharedImage;
-    sharedImage.Detach();
-    return image;
+    return tex2d->GetImage().Detach();
 }
 
 static Image* TextureCubeGetImage(CubeMapFace face, TextureCube* texCube)
 {
-    SharedPtr<Image> sharedImage = texCube->GetImage(face);
-    Image* image = sharedImage;
-    sharedImage.Detach();
-    return image;
+    return texCube->GetImage(face).Detach();
 }
 
 static void ConstructRenderTargetInfo(RenderTargetInfo* ptr)

--- a/Source/Urho3D/AngelScript/GraphicsAPI.cpp
+++ b/Source/Urho3D/AngelScript/GraphicsAPI.cpp
@@ -181,42 +181,18 @@ static Viewport* ConstructViewportSceneCameraRect(Scene* scene, Camera* camera, 
 
 static Image* Texture2DGetImage(Texture2D* tex2d)
 {
-    Image* rawImage = new Image(tex2d->GetContext());
-    const unsigned texSize = tex2d->GetDataSize(tex2d->GetWidth(), tex2d->GetHeight());
-    const unsigned format = tex2d->GetFormat();
-
-    if (format == Graphics::GetRGBAFormat())
-        rawImage->SetSize(tex2d->GetWidth(), tex2d->GetHeight(), 4);
-    else if (format == Graphics::GetRGBFormat())
-        rawImage->SetSize(tex2d->GetWidth(), tex2d->GetHeight(), 3);
-    else
-    {
-        delete rawImage;
-        return 0;
-    }
-
-    tex2d->GetData(0, rawImage->GetData());
-    return rawImage;
+    SharedPtr<Image> sharedImage = tex2d->GetImage();
+    Image* image = sharedImage;
+    sharedImage.Detach();
+    return image;
 }
 
 static Image* TextureCubeGetImage(CubeMapFace face, TextureCube* texCube)
 {
-    Image* rawImage = new Image(texCube->GetContext());
-    const unsigned texSize = texCube->GetDataSize(texCube->GetWidth(), texCube->GetHeight());
-    const unsigned format = texCube->GetFormat();
-
-    if (format == Graphics::GetRGBAFormat())
-        rawImage->SetSize(texCube->GetWidth(), texCube->GetHeight(), 4);
-    else if (format == Graphics::GetRGBFormat())
-        rawImage->SetSize(texCube->GetWidth(), texCube->GetHeight(), 3);
-    else
-    {
-        delete rawImage;
-        return 0;
-    }
-
-    texCube->GetData(face, 0, rawImage->GetData());
-    return rawImage;
+    SharedPtr<Image> sharedImage = texCube->GetImage(face);
+    Image* image = sharedImage;
+    sharedImage.Detach();
+    return image;
 }
 
 static void ConstructRenderTargetInfo(RenderTargetInfo* ptr)

--- a/Source/Urho3D/Container/Ptr.h
+++ b/Source/Urho3D/Container/Ptr.h
@@ -151,8 +151,9 @@ public:
     void Reset() { ReleaseRef(); }
 
     /// Detach without destroying the object even if the refcount goes zero. To be used for scripting language interoperation.
-    void Detach()
+    T* Detach()
     {
+        T* ptr = ptr_;
         if (ptr_)
         {
             RefCount* refCount = RefCountPtr();
@@ -160,6 +161,7 @@ public:
             Reset(); // 1 ref
             --refCount->refs_; // 0 refs
         }
+        return ptr;
     }
 
     /// Perform a static cast from a shared pointer of another type.

--- a/Source/Urho3D/Graphics/Texture2D.cpp
+++ b/Source/Urho3D/Graphics/Texture2D.cpp
@@ -156,6 +156,26 @@ bool Texture2D::SetSize(int width, int height, unsigned format, TextureUsage usa
     return Create();
 }
 
+SharedPtr<Image> Texture2D::GetImage() const
+{
+    if (format_ != Graphics::GetRGBAFormat() && format_ != Graphics::GetRGBFormat())
+    {
+        URHO3D_LOGERROR("Unsupported texture format, can not convert to Image");
+        return SharedPtr<Image>();
+    }
+
+    Image* rawImage = new Image(context_);
+    if (format_ == Graphics::GetRGBAFormat())
+        rawImage->SetSize(width_, height_, 4);
+    else if (format_ == Graphics::GetRGBFormat())
+        rawImage->SetSize(width_, height_, 3);
+    else
+        assert(0);
+
+    GetData(0, rawImage->GetData());
+    return SharedPtr<Image>(rawImage);
+}
+
 void Texture2D::HandleRenderSurfaceUpdate(StringHash eventType, VariantMap& eventData)
 {
     if (renderSurface_ && (renderSurface_->GetUpdateMode() == SURFACE_UPDATEALWAYS || renderSurface_->IsUpdateQueued()))

--- a/Source/Urho3D/Graphics/Texture2D.h
+++ b/Source/Urho3D/Graphics/Texture2D.h
@@ -68,6 +68,8 @@ public:
 
     /// Get data from a mip level. The destination buffer must be big enough. Return true if successful.
     bool GetData(unsigned level, void* dest) const;
+    /// Get image data from zero mip level. Only RGB and RGBA textures are supported.
+    SharedPtr<Image> GetImage() const;
 
     /// Return render surface.
     RenderSurface* GetRenderSurface() const { return renderSurface_; }

--- a/Source/Urho3D/Graphics/TextureCube.cpp
+++ b/Source/Urho3D/Graphics/TextureCube.cpp
@@ -316,6 +316,26 @@ bool TextureCube::SetSize(int size, unsigned format, TextureUsage usage, int mul
     return Create();
 }
 
+SharedPtr<Image> TextureCube::GetImage(CubeMapFace face) const
+{
+    if (format_ != Graphics::GetRGBAFormat() && format_ != Graphics::GetRGBFormat())
+    {
+        URHO3D_LOGERROR("Unsupported texture format, can not convert to Image");
+        return SharedPtr<Image>();
+    }
+
+    Image* rawImage = new Image(context_);
+    if (format_ == Graphics::GetRGBAFormat())
+        rawImage->SetSize(width_, height_, 4);
+    else if (format_ == Graphics::GetRGBFormat())
+        rawImage->SetSize(width_, height_, 3);
+    else
+        assert(0);
+
+    GetData(face, 0, rawImage->GetData());
+    return SharedPtr<Image>(rawImage);
+}
+
 void TextureCube::HandleRenderSurfaceUpdate(StringHash eventType, VariantMap& eventData)
 {
     Renderer* renderer = GetSubsystem<Renderer>();

--- a/Source/Urho3D/Graphics/TextureCube.h
+++ b/Source/Urho3D/Graphics/TextureCube.h
@@ -67,6 +67,8 @@ public:
 
     /// Get data from a face's mip level. The destination buffer must be big enough. Return true if successful.
     bool GetData(CubeMapFace face, unsigned level, void* dest) const;
+    /// Get image data from a face's zero mip level. Only RGB and RGBA textures are supported.
+    SharedPtr<Image> GetImage(CubeMapFace face) const;
 
     /// Return render surface for one face.
     RenderSurface* GetRenderSurface(CubeMapFace face) const { return renderSurfaces_[face]; }

--- a/Source/Urho3D/LuaScript/pkgs/Graphics/Animation.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Graphics/Animation.pkg
@@ -89,10 +89,6 @@ static Animation* AnimationClone(const Animation* animation, const String& clone
     if (!animation)
         return 0;
         
-    SharedPtr<Animation> clonedAnimationPtr = animation->Clone(cloneName);
-    Animation* clonedAnimation = clonedAnimationPtr.Get();
-    clonedAnimationPtr.Detach();
-    
-    return clonedAnimation;
+    return animation->Clone(cloneName).Detach();
 }
 $}

--- a/Source/Urho3D/LuaScript/pkgs/Graphics/Material.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Graphics/Material.pkg
@@ -91,11 +91,7 @@ static Material* MaterialClone(const Material* material, const String& cloneName
 {
     if (!material)
         return 0;
-        
-    SharedPtr<Material> clonedMaterialPtr = material->Clone(cloneName);
-    Material* clonedMaterial = clonedMaterialPtr.Get();
-    clonedMaterialPtr.Detach();
-    
-    return clonedMaterial;
+
+    return material->Clone(cloneName).Detach();
 }
 $}

--- a/Source/Urho3D/LuaScript/pkgs/Graphics/Model.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Graphics/Model.pkg
@@ -49,11 +49,7 @@ static Model* ModelClone(const Model* model, const String& cloneName = String::E
 {
     if (!model)
         return 0;
-        
-    SharedPtr<Model> clonedModelPtr = model->Clone(cloneName);
-    Model* clonedModel = clonedModelPtr.Get();
-    clonedModelPtr.Detach();
-    
-    return clonedModel;
+
+    return model->Clone(cloneName).Detach();
 }
 $}

--- a/Source/Urho3D/LuaScript/pkgs/Graphics/ParticleEffect.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Graphics/ParticleEffect.pkg
@@ -164,11 +164,7 @@ static ParticleEffect* ParticleEffectClone(const ParticleEffect* effect, const S
 {
     if (!effect)
         return 0;
-        
-    SharedPtr<ParticleEffect> clonedEffectPtr = effect->Clone(cloneName);
-    ParticleEffect* clonedEffect = clonedEffectPtr.Get();
-    clonedEffectPtr.Detach();
-    
-    return clonedEffect;
+
+    return effect->Clone(cloneName).Detach();
 }
 $}

--- a/Source/Urho3D/LuaScript/pkgs/Graphics/RenderPath.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Graphics/RenderPath.pkg
@@ -124,11 +124,7 @@ static RenderPath* RenderPathClone(RenderPath* renderPath)
 {
     if (!renderPath)
         return 0;
-    
-    SharedPtr<RenderPath> clonedRenderPathPtr = renderPath->Clone();
-    RenderPath* clonedRenderPath = clonedRenderPathPtr.Get();
-    clonedRenderPathPtr.Detach();
-    
-    return clonedRenderPath;
+
+    return renderPath->Clone().Detach();
 }
 $}

--- a/Source/Urho3D/LuaScript/pkgs/Graphics/Texture2D.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Graphics/Texture2D.pkg
@@ -10,6 +10,8 @@ class Texture2D : public Texture
     bool SetSize(int width, int height, unsigned format, TextureUsage usage = TEXTURE_STATIC, int multiSample = 1, bool autoResolve = true);
     bool SetData(Image* image, bool useAlpha = false);
 
+    Image* GetImage() const;
+
     RenderSurface* GetRenderSurface() const;
     
     tolua_readonly tolua_property__get_set RenderSurface* renderSurface;

--- a/Source/Urho3D/LuaScript/pkgs/Graphics/Texture2D.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Graphics/Texture2D.pkg
@@ -10,7 +10,7 @@ class Texture2D : public Texture
     bool SetSize(int width, int height, unsigned format, TextureUsage usage = TEXTURE_STATIC, int multiSample = 1, bool autoResolve = true);
     bool SetData(Image* image, bool useAlpha = false);
 
-    Image* GetImage() const;
+    tolua_outside Image* Texture2DGetImage @ GetImage() const;
 
     RenderSurface* GetRenderSurface() const;
     
@@ -28,5 +28,13 @@ static int tolua_GraphicsLuaAPI_Texture2D_new00(lua_State* tolua_S)
 static int tolua_GraphicsLuaAPI_Texture2D_new00_local(lua_State* tolua_S)
 {
     return ToluaNewObjectGC<Texture2D>(tolua_S);
+}
+
+static Image* Texture2DGetImage(const Texture2D* texture2D)
+{
+    if (!texture2D)
+        return 0;
+
+    return texture2D->GetImage().Detach();
 }
 $}

--- a/Source/Urho3D/LuaScript/pkgs/Graphics/TextureCube.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Graphics/TextureCube.pkg
@@ -8,7 +8,7 @@ class TextureCube : public Texture
     bool SetSize(int size, unsigned format, TextureUsage usage = TEXTURE_STATIC, int multiSample = 1);
     bool SetData(CubeMapFace face, Image* image, bool useAlpha = false);
 
-    Image* GetImage(CubeMapFace face) const;
+    tolua_outside Image* TextureCubeGetImage @ GetImage(CubeMapFace face) const;
 
     RenderSurface* GetRenderSurface(CubeMapFace face) const;
 };
@@ -24,5 +24,13 @@ static int tolua_GraphicsLuaAPI_TextureCube_new00(lua_State* tolua_S)
 static int tolua_GraphicsLuaAPI_TextureCube_new00_local(lua_State* tolua_S)
 {
     return ToluaNewObjectGC<TextureCube>(tolua_S);
+}
+
+static Image* TextureCubeGetImage(const TextureCube* textureCube, CubeMapFace face)
+{
+    if (!textureCube)
+        return 0;
+
+    return textureCube->GetImage(face).Detach();
 }
 $}

--- a/Source/Urho3D/LuaScript/pkgs/Graphics/TextureCube.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Graphics/TextureCube.pkg
@@ -8,6 +8,8 @@ class TextureCube : public Texture
     bool SetSize(int size, unsigned format, TextureUsage usage = TEXTURE_STATIC, int multiSample = 1);
     bool SetData(CubeMapFace face, Image* image, bool useAlpha = false);
 
+    Image* GetImage(CubeMapFace face) const;
+
     RenderSurface* GetRenderSurface(CubeMapFace face) const;
 };
 

--- a/Source/Urho3D/LuaScript/pkgs/Network/Network.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Network/Network.pkg
@@ -72,10 +72,6 @@ static HttpRequest* NetworkMakeHttpRequest(Network* network, const String& url, 
     if (!network)
         return 0;
 
-    SharedPtr<HttpRequest> httpRequestPtr = network->MakeHttpRequest(url, verb, headers, postData);
-    HttpRequest* httpRequest = httpRequestPtr.Get();
-    httpRequestPtr.Detach();
-
-    return httpRequest;
+    return network->MakeHttpRequest(url, verb, headers, postData).Detach();
 }
 $}

--- a/Source/Urho3D/LuaScript/pkgs/Resource/ResourceCache.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Resource/ResourceCache.pkg
@@ -61,20 +61,11 @@ static int tolua_ResourceLuaAPI_GetCache00(lua_State* tolua_S)
 
 static File* ResourceCacheGetFile(ResourceCache* cache, const String& fileName)
 {
-    SharedPtr<File> filePtr = cache->GetFile(fileName);
-    if (!filePtr)
-        return 0;
-
-    File* file = filePtr.Get();
-    filePtr.Detach();
-
-    return file;
+    return cache->GetFile(fileName).Detach();
 }
 
 static bool ResourceCacheBackgroundLoadResource(ResourceCache* cache, StringHash type, const String& fileName, bool sendEventOnFailure)
 {
     return cache->BackgroundLoadResource(type, fileName, sendEventOnFailure);
 }
-
-
 $}

--- a/Source/Urho3D/LuaScript/pkgs/UI/UI.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/UI/UI.pkg
@@ -87,14 +87,7 @@ static UIElement* UILoadLayout(UI* ui, File* source, XMLFile* styleFile)
     if (!source)
         return 0;
 
-    SharedPtr<UIElement> elementPtr = ui->LoadLayout(*source, styleFile);
-    if (!elementPtr)
-        return 0;
-
-    UIElement* element = elementPtr.Get();
-    elementPtr.Detach();
-
-    return element;
+    return ui->LoadLayout(*source, styleFile).Detach();
 }
 
 static UIElement* UILoadLayout(UI* ui, const String& fileName, XMLFile* styleFile)
@@ -103,14 +96,7 @@ static UIElement* UILoadLayout(UI* ui, const String& fileName, XMLFile* styleFil
     if (!file.IsOpen())
         return 0;
 
-    SharedPtr<UIElement> elementPtr = ui->LoadLayout(file, styleFile);
-    if (!elementPtr)
-        return 0;
-
-    UIElement* element = elementPtr.Get();
-    elementPtr.Detach();
-
-    return element;
+    return ui->LoadLayout(file, styleFile).Detach();
 }
 
 static UIElement* UILoadLayout(UI* ui, XMLFile* source, XMLFile* styleFile)
@@ -118,14 +104,7 @@ static UIElement* UILoadLayout(UI* ui, XMLFile* source, XMLFile* styleFile)
     if (!source)
         return 0;
 
-    SharedPtr<UIElement> elementPtr = ui->LoadLayout(source, styleFile);
-    if (!elementPtr)
-        return 0;
-
-    UIElement* element = elementPtr.Get();
-    elementPtr.Detach();
-
-    return element;
+    return ui->LoadLayout(source, styleFile).Detach();
 }
 
 #define TOLUA_DISABLE_tolua_UILuaAPI_GetUI00

--- a/Source/Urho3D/LuaScript/pkgs/Urho2D/ParticleEffect2D.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Urho2D/ParticleEffect2D.pkg
@@ -18,11 +18,7 @@ static ParticleEffect2D* ParticleEffect2DClone(const ParticleEffect2D* effect, c
 {
     if (!effect)
         return 0;
-        
-    SharedPtr<ParticleEffect2D> clonedEffectPtr = effect->Clone(cloneName);
-    ParticleEffect2D* clonedEffect = clonedEffectPtr.Get();
-    clonedEffectPtr.Detach();
 
-    return clonedEffect;
+    return effect->Clone(cloneName).Detach();
 }
 $}


### PR DESCRIPTION
I needed Texture2D::GetImage for last months and today I've found out that Urho already has such function in AS binding. So I've moved it to C++ class and updated Lua pkgs. I've also added some error messages and simplified some Lua bindings around Detach.