### PR TITLE
Fixed an issue for SQLite queries where String::Trimmed was being corrupted

### DIFF
--- a/Source/Urho3D/Database/SQLite/SQLiteConnection.cpp
+++ b/Source/Urho3D/Database/SQLite/SQLiteConnection.cpp
@@ -64,7 +64,12 @@ DbResult DbConnection::Execute(const String& sql, bool useCursorEvent)
     const char* zLeftover = 0;
     sqlite3_stmt* pStmt = 0;
     assert(connectionImpl_);
-    int rc = sqlite3_prepare_v2(connectionImpl_, sql.Trimmed().CString(), -1, &pStmt, &zLeftover);
+
+    // 2016-10-09: Prevent string corruption when trimmed is returned.
+    String trimmedSqlStr = sql.Trimmed();
+    const char* cSqlStr = trimmedSqlStr.CString();
+
+    int rc = sqlite3_prepare_v2(connectionImpl_, cSqlStr, -1, &pStmt, &zLeftover);
     if (rc != SQLITE_OK)
     {
         URHO3D_LOGERRORF("Could not execute: %s", sqlite3_errmsg(connectionImpl_));

--- a/Source/Urho3D/Database/SQLite/SQLiteConnection.cpp
+++ b/Source/Urho3D/Database/SQLite/SQLiteConnection.cpp
@@ -67,9 +67,8 @@ DbResult DbConnection::Execute(const String& sql, bool useCursorEvent)
 
     // 2016-10-09: Prevent string corruption when trimmed is returned.
     String trimmedSqlStr = sql.Trimmed();
-    const char* cSqlStr = trimmedSqlStr.CString();
 
-    int rc = sqlite3_prepare_v2(connectionImpl_, cSqlStr, -1, &pStmt, &zLeftover);
+    int rc = sqlite3_prepare_v2(connectionImpl_, trimmedSqlStr.CString(), -1, &pStmt, &zLeftover);
     if (rc != SQLITE_OK)
     {
         URHO3D_LOGERRORF("Could not execute: %s", sqlite3_errmsg(connectionImpl_));


### PR DESCRIPTION
This should allow sql queries to run properly when DbConnection::Execute is provided a string. This fix is only for SQLite queries.