### PR TITLE
UIElement::CreateChildXML() returns child instead of bool

### DIFF
--- a/Source/Urho3D/AngelScript/APITemplates.h
+++ b/Source/Urho3D/AngelScript/APITemplates.h
@@ -950,15 +950,14 @@ static bool UIElementLoadXML(XMLFile* file, XMLFile* styleFile, UIElement* ptr)
         return false;
 }
 
-static bool UIElementLoadChildXML(XMLFile* file, XMLFile* styleFile, UIElement* ptr)
+static UIElement* UIElementLoadChildXML(XMLFile* file, XMLFile* styleFile, UIElement* ptr)
 {
-    if (file)
-    {
-        XMLElement rootElem = file->GetRoot("element");
-        return rootElem && ptr->LoadChildXML(rootElem, styleFile);
-    }
-    else
-        return false;
+    if (file == NULL)
+        return NULL;
+
+    XMLElement rootElem = file->GetRoot("element");
+    if (rootElem)
+        return ptr->LoadChildXML(rootElem, styleFile);
 }
 
 static bool UIElementSaveXML(File* file, const String& indentation, UIElement* ptr)
@@ -1053,8 +1052,8 @@ template <class T> void RegisterUIElement(asIScriptEngine* engine, const char* c
     engine->RegisterObjectMethod(className, "bool LoadXML(File@+)", asFUNCTIONPR(UIElementLoadXML, (File*, UIElement*), bool), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod(className, "bool LoadXML(VectorBuffer&)", asFUNCTIONPR(UIElementLoadXMLVectorBuffer, (VectorBuffer&, UIElement*), bool), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod(className, "bool LoadXML(XMLFile@+, XMLFile@+)", asFUNCTIONPR(UIElementLoadXML, (XMLFile*, XMLFile*, UIElement*), bool), asCALL_CDECL_OBJLAST);
-    engine->RegisterObjectMethod(className, "bool LoadChildXML(const XMLElement&in, XMLFile@+ arg1 = null, bool arg2 = false)", asMETHOD(T, LoadChildXML), asCALL_THISCALL);
-    engine->RegisterObjectMethod(className, "bool LoadChildXML(XMLFile@+, XMLFile@+ arg1 = null)", asFUNCTION(UIElementLoadChildXML), asCALL_CDECL_OBJLAST);
+    engine->RegisterObjectMethod(className, "UIElement@+ LoadChildXML(const XMLElement&in, XMLFile@+ arg1 = null, bool arg2 = false)", asMETHOD(T, LoadChildXML), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "UIElement@+ LoadChildXML(XMLFile@+, XMLFile@+ arg1 = null)", asFUNCTION(UIElementLoadChildXML), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod(className, "bool SaveXML(File@+, const String&in indentation = \"\t\")", asFUNCTION(UIElementSaveXML), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod(className, "bool SaveXML(VectorBuffer&, const String&in indentation = \"\t\")", asFUNCTION(UIElementSaveXMLVectorBuffer), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod(className, "bool SetStyle(const XMLElement&in)", asMETHODPR(T, SetStyle, (const XMLElement&), bool), asCALL_THISCALL);

--- a/Source/Urho3D/UI/UIElement.cpp
+++ b/Source/Urho3D/UI/UIElement.cpp
@@ -304,13 +304,13 @@ bool UIElement::LoadXML(const XMLElement& source, XMLFile* styleFile, bool setIn
     return true;
 }
 
-bool UIElement::LoadChildXML(const XMLElement& childElem, XMLFile* styleFile, bool setInstanceDefault)
+UIElement* UIElement::LoadChildXML(const XMLElement& childElem, XMLFile* styleFile, bool setInstanceDefault)
 {
     bool internalElem = childElem.GetBool("internal");
     if (internalElem)
     {
         URHO3D_LOGERROR("Loading internal child element is not supported");
-        return false;
+        return NULL;
     }
 
     String typeName = childElem.GetAttribute("type");
@@ -324,10 +324,13 @@ bool UIElement::LoadChildXML(const XMLElement& childElem, XMLFile* styleFile, bo
         if (!styleFile)
             styleFile = GetDefaultStyle();
         if (!child->LoadXML(childElem, styleFile, setInstanceDefault))
-            return false;
+        {
+            RemoveChild(child, index);
+            return NULL;
+        }
     }
 
-    return true;
+    return child;
 }
 
 bool UIElement::SaveXML(XMLElement& dest) const
@@ -886,7 +889,7 @@ void UIElement::SetPriority(int priority)
 {
     if (priority_ == priority)
         return;
-    
+
     priority_ = priority;
     if (parent_)
         parent_->sortOrderDirty_ = true;
@@ -1587,14 +1590,14 @@ bool UIElement::IsVisibleEffective() const
 {
     bool visible = visible_;
     const UIElement* element = parent_;
-    
+
     // Traverse the parent chain
     while (visible && element)
     {
         visible &= element->visible_;
         element = element->parent_;
     }
-    
+
     return visible;
 }
 

--- a/Source/Urho3D/UI/UIElement.h
+++ b/Source/Urho3D/UI/UIElement.h
@@ -129,8 +129,8 @@ public:
     virtual bool LoadXML(const XMLElement& source, bool setInstanceDefault = false);
     /// Load from XML data with style. Return true if successful.
     virtual bool LoadXML(const XMLElement& source, XMLFile* styleFile, bool setInstanceDefault = false);
-    /// Create a child by loading from XML data with style. Return true if successful.
-    virtual bool LoadChildXML(const XMLElement& childElem, XMLFile* styleFile = 0, bool setInstanceDefault = false);
+    /// Create a child by loading from XML data with style. Returns the child element if successful, NULL if otherwise.
+    virtual UIElement* LoadChildXML(const XMLElement& childElem, XMLFile* styleFile = 0, bool setInstanceDefault = false);
     /// Save as XML data. Return true if successful.
     virtual bool SaveXML(XMLElement& dest) const;
 

--- a/bin/Data/Scripts/Editor/EditorActions.as
+++ b/bin/Data/Scripts/Editor/EditorActions.as
@@ -732,7 +732,7 @@ class CreateUIElementAction : EditAction
             // Have to update manually because the element ID var is not set yet when the E_ELEMENTADDED event is sent
             suppressUIElementChanges = true;
 
-            if (parent.LoadChildXML(elementData.root, styleFile))
+            if (parent.LoadChildXML(elementData.root, styleFile) !is null)
             {
                 UIElement@ element = parent.children[parent.numChildren - 1];
                 UpdateHierarchyItem(element);
@@ -773,7 +773,7 @@ class DeleteUIElementAction : EditAction
             // Have to update manually because the element ID var is not set yet when the E_ELEMENTADDED event is sent
             suppressUIElementChanges = true;
 
-            if (parent.LoadChildXML(elementData.root, styleFile))
+            if (parent.LoadChildXML(elementData.root, styleFile) !is null)
             {
                 XMLElement rootElem = elementData.root;
                 uint index = rootElem.GetUInt("index");
@@ -908,7 +908,7 @@ class ApplyUIElementStyleAction : EditAction
             suppressUIElementChanges = true;
 
             parent.RemoveChild(element);
-            if (parent.LoadChildXML(elementData.root, styleFile))
+            if (parent.LoadChildXML(elementData.root, styleFile) !is null)
             {
                 XMLElement rootElem = elementData.root;
                 uint index = rootElem.GetUInt("index");

--- a/bin/Data/Scripts/Editor/EditorUIElement.as
+++ b/bin/Data/Scripts/Editor/EditorUIElement.as
@@ -316,7 +316,7 @@ void LoadChildUIElement(const String&in fileName)
 
     suppressUIElementChanges = true;
 
-    if (editUIElement.LoadChildXML(xmlFile, uiElementDefaultStyle !is null ? uiElementDefaultStyle : uiStyle))
+    if (editUIElement.LoadChildXML(xmlFile, uiElementDefaultStyle !is null ? uiElementDefaultStyle : uiStyle) !is null)
     {
         XMLElement rootElem = xmlFile.root;
         uint index = rootElem.HasAttribute("index") ? rootElem.GetUInt("index") : editUIElement.numChildren - 1;
@@ -361,7 +361,7 @@ bool SaveChildUIElement(const String&in fileName)
     XMLElement rootElem = elementData.CreateRoot("element");
     bool success = editUIElement.SaveXML(rootElem);
     RemoveBackup(success, fileName);
-    
+
     if (success)
     {
         FilterInternalVars(rootElem);
@@ -559,7 +559,7 @@ bool UIElementPaste(bool duplication = false)
                 pasteElement = editUIElement;
         }
 
-        if (pasteElement.LoadChildXML(rootElem, null))
+        if (pasteElement.LoadChildXML(rootElem, null) !is null)
         {
             UIElement@ element = pasteElement.children[pasteElement.numChildren - 1];
 


### PR DESCRIPTION
As discussed on the forum: http://urho3d.prophpbb.com/topic2437.html

 + The return value of LoadChildXML() is now a pointer to the new child (or NULL if it fails)
 + The child is destroyed if loading fails, instead of keeping an empty child around