### PR TITLE
Add an emplace back method to the vector class when C++11 is enabled.

### DIFF
--- a/Source/Urho3D/Container/Vector.h
+++ b/Source/Urho3D/Container/Vector.h
@@ -218,6 +218,7 @@ public:
     void Push(const Vector<T>& vector) { InsertElements(size_, vector.Begin(), vector.End()); }
 
 #if URHO3D_CXX11
+    /// Create another element at the end.
     template <typename... Args> T & EmplaceBack(Args&&... args)
     {
         if (size_ < capacity_)
@@ -761,6 +762,7 @@ public:
     }
 
 #if URHO3D_CXX11
+    /// Create another element at the end.
     template <typename... Args> T & EmplaceBack(Args&&... args)
     {
         if (size_ < capacity_)

--- a/Source/Urho3D/Container/Vector.h
+++ b/Source/Urho3D/Container/Vector.h
@@ -217,6 +217,18 @@ public:
     /// Add another vector at the end.
     void Push(const Vector<T>& vector) { InsertElements(size_, vector.Begin(), vector.End()); }
 
+#if URHO3D_CXX11
+    template <typename... Args> T & EmplaceBack(Args&&... args)
+    {
+        if (size_ < capacity_)
+            ++size_;
+        else
+            Resize(size_ + 1);
+        T * ptr = new (&Back()) T(std::forward<Args>(args)...);
+        return *ptr;
+    }
+#endif
+
     /// Remove the last element.
     void Pop()
     {
@@ -747,6 +759,18 @@ public:
         Resize(size_ + vector.size_);
         CopyElements(Buffer() + oldSize, vector.Buffer(), vector.size_);
     }
+
+#if URHO3D_CXX11
+    template <typename... Args> T & EmplaceBack(Args&&... args)
+    {
+        if (size_ < capacity_)
+            ++size_;
+        else
+            Resize(size_ + 1);
+        T * ptr = new (&Back()) T(std::forward<Args>(args)...);
+        return *ptr;
+    }
+#endif
 
     /// Remove the last element.
     void Pop()


### PR DESCRIPTION
However, following the style of C++17 by returning a reference to the created instance.