### PR TITLE
Don't save line repetitions in the console's history

### DIFF
--- a/Source/Urho3D/Engine/Console.cpp
+++ b/Source/Urho3D/Engine/Console.cpp
@@ -344,11 +344,15 @@ void Console::HandleTextFinished(StringHash eventType, VariantMap& eventData)
         SendEvent(E_CONSOLECOMMAND, newEventData);
 #endif
 
-        // Store to history, then clear the lineedit
-        history_.Push(line);
-        if (history_.Size() > historyRows_)
-            history_.Erase(history_.Begin());
-        historyPosition_ = history_.Size();
+        // Make sure the line isn't the same as the last one
+        if (history_.Empty() || line != history_.Back())
+        {
+            // Store to history, then clear the lineedit
+            history_.Push(line);
+            if (history_.Size() > historyRows_)
+                history_.Erase(history_.Begin());
+            historyPosition_ = history_.Size();
+        }
 
         currentRow_.Clear();
         lineEdit_->SetText(currentRow_);


### PR DESCRIPTION
Not saving repetitive lines since it's redundant and makes it longer to navigate to not-the-same previous lines.