### PR TITLE
Optimize Editor work with temporary objects

### DIFF
--- a/Source/Urho3D/AngelScript/APITemplates.h
+++ b/Source/Urho3D/AngelScript/APITemplates.h
@@ -691,7 +691,8 @@ template <class T> void RegisterNode(asIScriptEngine* engine, const char* classN
     engine->RegisterObjectMethod(className, "void Scale(float)", asMETHODPR(T, Scale, (float), void), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "void Scale(const Vector3&in)", asMETHODPR(T, Scale, (const Vector3&), void), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "void Scale2D(const Vector2&in)", asMETHODPR(T, Scale2D, (const Vector2&), void), asCALL_THISCALL);
-    engine->RegisterObjectMethod(className, "Node@+ CreateChild(const String&in name = String(), CreateMode mode = REPLICATED, uint id = 0)", asMETHODPR(T, CreateChild, (const String&, CreateMode, unsigned), Node*), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "Node@+ CreateChild(const String&in name = String(), CreateMode mode = REPLICATED, uint id = 0, bool temporary = false)", asMETHODPR(T, CreateChild, (const String&, CreateMode, unsigned, bool), Node*), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "Node@+ CreateTemporaryChild(const String&in name = String(), CreateMode mode = REPLICATED, uint id = 0)", asMETHODPR(T, CreateTemporaryChild, (const String&, CreateMode, unsigned), Node*), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "void AddChild(Node@+, uint index = M_MAX_UNSIGNED)", asMETHOD(T, AddChild), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "void RemoveChild(Node@+)", asMETHODPR(T, RemoveChild, (Node*), void), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "void RemoveAllChildren()", asMETHOD(T, RemoveAllChildren), asCALL_THISCALL);

--- a/Source/Urho3D/Graphics/Terrain.cpp
+++ b/Source/Urho3D/Graphics/Terrain.cpp
@@ -1039,8 +1039,7 @@ void Terrain::CreateGeometry()
                     {
                         // Create the patch scene node as local and temporary so that it is not unnecessarily serialized to either
                         // file or replicated over the network
-                        patchNode = node_->CreateChild(nodeName, LOCAL);
-                        patchNode->SetTemporary(true);
+                        patchNode = node_->CreateTemporaryChild(nodeName, LOCAL);
                     }
 
                     patchNode->SetPosition(Vector3(patchWorldOrigin_.x_ + (float)x * patchWorldSize_.x_, 0.0f,

--- a/Source/Urho3D/LuaScript/pkgs/Scene/Node.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Scene/Node.pkg
@@ -91,7 +91,8 @@ class Node : public Animatable
     void SetOwner(Connection* owner);
     void MarkDirty();
 
-    Node* CreateChild(const String name = String::EMPTY, CreateMode mode = REPLICATED, unsigned id = 0);
+    Node* CreateChild(const String name = String::EMPTY, CreateMode mode = REPLICATED, unsigned id = 0, bool temporary = false);
+    Node* CreateTemporaryChild(const String name = String::EMPTY, CreateMode mode = REPLICATED, unsigned id = 0);
 
     void AddChild(Node* node, unsigned index = M_MAX_UNSIGNED);
     void RemoveChild(Node* node);
@@ -195,7 +196,7 @@ class Node : public Animatable
     bool LoadXML(const XMLElement& source, SceneResolver& resolver, bool loadChildren = true, bool rewriteIDs = false, CreateMode mode = REPLICATED);
     bool LoadJSON(const JSONValue& source, SceneResolver& resolver, bool loadChildren = true, bool rewriteIDs = false, CreateMode mode = REPLICATED);
 
-    Node* CreateChild(unsigned id, CreateMode mode);
+    Node* CreateChild(unsigned id, CreateMode mode, bool temporary = false);
     void AddComponent(Component* component, unsigned id, CreateMode mode);
 
     bool HasTag(const String tag) const;

--- a/Source/Urho3D/Scene/Node.cpp
+++ b/Source/Urho3D/Scene/Node.cpp
@@ -354,7 +354,7 @@ void Node::AddTag(const String& tag)
     // Check if tag empty or already added
     if (tag.Empty() || HasTag(tag))
         return;
-    
+
     // Add tag
     impl_->tags_.Push(tag);
 
@@ -406,7 +406,7 @@ bool Node::RemoveTag(const String& tag)
         eventData[P_TAG] = tag;
         scene_->SendEvent(E_NODETAGREMOVED, eventData);
     }
-    
+
     // Sync
     MarkNetworkUpdate();
     return true;
@@ -782,11 +782,16 @@ void Node::MarkDirty()
     }
 }
 
-Node* Node::CreateChild(const String& name, CreateMode mode, unsigned id)
+Node* Node::CreateChild(const String& name, CreateMode mode, unsigned id, bool temporary)
 {
-    Node* newNode = CreateChild(id, mode);
+    Node* newNode = CreateChild(id, mode, temporary);
     newNode->SetName(name);
     return newNode;
+}
+
+Node* Node::CreateTemporaryChild(const String& name, CreateMode mode, unsigned id)
+{
+    return CreateChild(name, mode, id, true);
 }
 
 void Node::AddChild(Node* node, unsigned index)
@@ -1769,9 +1774,10 @@ void Node::MarkReplicationDirty()
     }
 }
 
-Node* Node::CreateChild(unsigned id, CreateMode mode)
+Node* Node::CreateChild(unsigned id, CreateMode mode, bool temporary)
 {
     SharedPtr<Node> newNode(new Node(context_));
+    newNode->SetTemporary(temporary);
 
     // If zero ID specified, or the ID is already taken, let the scene assign
     if (scene_)

--- a/Source/Urho3D/Scene/Node.h
+++ b/Source/Urho3D/Scene/Node.h
@@ -282,7 +282,9 @@ public:
     /// Mark node and child nodes to need world transform recalculation. Notify listener components.
     void MarkDirty();
     /// Create a child scene node (with specified ID if provided).
-    Node* CreateChild(const String& name = String::EMPTY, CreateMode mode = REPLICATED, unsigned id = 0);
+    Node* CreateChild(const String& name = String::EMPTY, CreateMode mode = REPLICATED, unsigned id = 0, bool temporary = false);
+    /// Create a temporary child scene node (with specified ID if provided).
+    Node* CreateTemporaryChild(const String& name = String::EMPTY, CreateMode mode = REPLICATED, unsigned id = 0);
     /// Add a child scene node at a specific index. If index is not explicitly specified or is greater than current children size, append the new child at the end.
     void AddChild(Node* node, unsigned index = M_MAX_UNSIGNED);
     /// Remove a child scene node.
@@ -599,7 +601,7 @@ public:
     /// Mark node dirty in scene replication states.
     void MarkReplicationDirty();
     /// Create a child node with specific ID.
-    Node* CreateChild(unsigned id, CreateMode mode);
+    Node* CreateChild(unsigned id, CreateMode mode, bool temporary = false);
     /// Add a pre-created component. Using this function from application code is discouraged, as component operation without an owner node may not be well-defined in all cases. Prefer CreateComponent() instead.
     void AddComponent(Component* component, unsigned id, CreateMode mode);
     /// Calculate number of non-temporary child nodes.

--- a/Source/Urho3D/Urho2D/TileMap2D.cpp
+++ b/Source/Urho3D/Urho2D/TileMap2D.cpp
@@ -129,8 +129,7 @@ void TileMap2D::SetTmxFile(TmxFile2D* tmxFile)
 
     if (!rootNode_)
     {
-        rootNode_ = GetNode()->CreateChild("_root_", LOCAL);
-        rootNode_->SetTemporary(true);
+        rootNode_ = GetNode()->CreateTemporaryChild("_root_", LOCAL);
     }
 
     unsigned numLayers = tmxFile_->GetNumLayers();
@@ -140,8 +139,7 @@ void TileMap2D::SetTmxFile(TmxFile2D* tmxFile)
     {
         const TmxLayer2D* tmxLayer = tmxFile_->GetLayer(i);
 
-        Node* layerNode(rootNode_->CreateChild(tmxLayer->GetName(), LOCAL));
-        layerNode->SetTemporary(true);
+        Node* layerNode(rootNode_->CreateTemporaryChild(tmxLayer->GetName(), LOCAL));
 
         TileMapLayer2D* layer = layerNode->CreateComponent<TileMapLayer2D>();
         layer->Initialize(this, tmxLayer);

--- a/Source/Urho3D/Urho2D/TileMapLayer2D.cpp
+++ b/Source/Urho3D/Urho2D/TileMapLayer2D.cpp
@@ -300,8 +300,7 @@ void TileMapLayer2D::SetTileLayer(const TmxTileLayer2D* tileLayer)
             if (!tile)
                 continue;
 
-            SharedPtr<Node> tileNode(GetNode()->CreateChild("Tile"));
-            tileNode->SetTemporary(true);
+            SharedPtr<Node> tileNode(GetNode()->CreateTemporaryChild("Tile"));
             tileNode->SetPosition(info.TileIndexToPosition(x, y));
 
             StaticSprite2D* staticSprite = tileNode->CreateComponent<StaticSprite2D>();
@@ -326,8 +325,7 @@ void TileMapLayer2D::SetObjectGroup(const TmxObjectGroup2D* objectGroup)
         const TileMapObject2D* object = objectGroup->GetObject(i);
 
         // Create dummy node for all object
-        SharedPtr<Node> objectNode(GetNode()->CreateChild("Object"));
-        objectNode->SetTemporary(true);
+        SharedPtr<Node> objectNode(GetNode()->CreateTemporaryChild("Object"));
         objectNode->SetPosition(object->GetPosition());
 
         // If object is tile, create static sprite component
@@ -356,8 +354,7 @@ void TileMapLayer2D::SetImageLayer(const TmxImageLayer2D* imageLayer)
     if (!imageLayer->GetSprite())
         return;
 
-    SharedPtr<Node> imageNode(GetNode()->CreateChild("Tile"));
-    imageNode->SetTemporary(true);
+    SharedPtr<Node> imageNode(GetNode()->CreateTemporaryChild("Tile"));
     imageNode->SetPosition(imageLayer->GetPosition());
 
     StaticSprite2D* staticSprite = imageNode->CreateComponent<StaticSprite2D>();

--- a/bin/Data/Scripts/Editor/EditorHierarchyWindow.as
+++ b/bin/Data/Scripts/Editor/EditorHierarchyWindow.as
@@ -1398,8 +1398,8 @@ void HandleNodeRemoved(StringHash eventType, VariantMap& eventData)
         return;
 
     Node@ node = eventData["Node"].GetPtr();
-    uint index = GetListIndex(node);
-    UpdateHierarchyItem(index, null, null);
+    if (showTemporaryObject || !node.temporary)
+        UpdateHierarchyItem(GetListIndex(node), null, null);
 }
 
 void HandleComponentAdded(StringHash eventType, VariantMap& eventData)
@@ -1410,7 +1410,7 @@ void HandleComponentAdded(StringHash eventType, VariantMap& eventData)
     // Insert the newly added component at last component position but before the first child node position of the parent node
     Node@ node = eventData["Node"].GetPtr();
     Component@ component = eventData["Component"].GetPtr();
-    if (showTemporaryObject || !component.temporary)
+    if (showTemporaryObject || (!node.temporary && !component.temporary))
     {
         uint nodeIndex = GetListIndex(node);
         if (nodeIndex != NO_ITEM)
@@ -1426,10 +1426,14 @@ void HandleComponentRemoved(StringHash eventType, VariantMap& eventData)
     if (suppressSceneChanges)
         return;
 
+    Node@ node = eventData["Node"].GetPtr();
     Component@ component = eventData["Component"].GetPtr();
-    uint index = GetComponentListIndex(component);
-    if (index != NO_ITEM)
-        hierarchyList.RemoveItem(index);
+    if (showTemporaryObject || (!node.temporary && !component.temporary))
+    {
+        uint index = GetComponentListIndex(component);
+        if (index != NO_ITEM)
+            hierarchyList.RemoveItem(index);
+    }
 }
 
 void HandleNodeNameChanged(StringHash eventType, VariantMap& eventData)

--- a/bin/Data/Scripts/Editor/EditorHierarchyWindow.as
+++ b/bin/Data/Scripts/Editor/EditorHierarchyWindow.as
@@ -1442,7 +1442,8 @@ void HandleNodeNameChanged(StringHash eventType, VariantMap& eventData)
         return;
 
     Node@ node = eventData["Node"].GetPtr();
-    UpdateHierarchyItemText(GetListIndex(node), node.enabled, GetNodeTitle(node));
+    if (showTemporaryObject || !node.temporary)
+        UpdateHierarchyItemText(GetListIndex(node), node.enabled, GetNodeTitle(node));
 }
 
 void HandleNodeEnabledChanged(StringHash eventType, VariantMap& eventData)
@@ -1451,8 +1452,11 @@ void HandleNodeEnabledChanged(StringHash eventType, VariantMap& eventData)
         return;
 
     Node@ node = eventData["Node"].GetPtr();
-    UpdateHierarchyItemText(GetListIndex(node), node.enabled);
-    attributesDirty = true;
+    if (showTemporaryObject || !node.temporary)
+    {
+        UpdateHierarchyItemText(GetListIndex(node), node.enabled);
+        attributesDirty = true;
+    }
 }
 
 void HandleComponentEnabledChanged(StringHash eventType, VariantMap& eventData)
@@ -1460,9 +1464,13 @@ void HandleComponentEnabledChanged(StringHash eventType, VariantMap& eventData)
     if (suppressSceneChanges)
         return;
 
+    Node@ node = eventData["Node"].GetPtr();
     Component@ component = eventData["Component"].GetPtr();
-    UpdateHierarchyItemText(GetComponentListIndex(component), component.enabledEffective);
-    attributesDirty = true;
+    if (showTemporaryObject || (!node.temporary && !component.temporary))
+    {
+        UpdateHierarchyItemText(GetComponentListIndex(component), component.enabledEffective);
+        attributesDirty = true;
+    }
 }
 
 void HandleUIElementAdded(StringHash eventType, VariantMap& eventData)


### PR DESCRIPTION
Related to #1664 
I'ven't managed to fix bottleneck in Hierarchy View. However, I've optimized temorary nodes and how Editor deal with them. Since procedural nodes like terrain pathces are temporary, these changes are pretty good workaround for my issue.
Please, review changes in **EditorHierarchyWindow.as** for possible unwanted side effects.
