### PR TITLE
Added a check before deleting stuff in hashmap

### DIFF
--- a/Source/Urho3D/Container/HashMap.h
+++ b/Source/Urho3D/Container/HashMap.h
@@ -253,10 +253,13 @@ public:
     /// Destruct.
     ~HashMap()
     {
-        Clear();
-        FreeNode(Tail());
-        AllocatorUninitialize(allocator_);
-        delete[] ptrs_;
+        if (!ptrs_)
+        {
+            Clear();
+            FreeNode(Tail());
+            AllocatorUninitialize(allocator_);
+            delete[] ptrs_;
+        }
     }
 
     /// Assign a hash map.


### PR DESCRIPTION
When a hashmap is being declared and initialized (```m_map()``` in constructor), but not actually used in any way, an NPE will be thrown when closing the app.

This is due to the last line in the destructor, ```delete[] ptrs_;```, which deletes a NULL variable.

Since all other calls inside the destructor are relaying on some data to exists,
and we're checking ptrs_ anyway (assuming the PR is good, that is), there's no reason
not to wrap the other calls as well; At least IMO, correct me if I'm wrong.