### PR TITLE
Fix minor Terrain bugs.

### DIFF
--- a/Source/Urho3D/Graphics/Terrain.cpp
+++ b/Source/Urho3D/Graphics/Terrain.cpp
@@ -724,7 +724,7 @@ void Terrain::CreatePatchGeometry(TerrainPatch* patch)
                 *vertexData++ = normal.z_;
 
                 // Texture coordinate
-                Vector2 texCoord((float)xPos / (float)numVertices_.x_, 1.0f - (float)zPos / (float)numVertices_.y_);
+                Vector2 texCoord((float)xPos / (float)(numVertices_.x_ - 1), 1.0f - (float)zPos / (float)(numVertices_.y_ - 1));
                 *vertexData++ = texCoord.x_;
                 *vertexData++ = texCoord.y_;
 

--- a/Source/Urho3D/Graphics/Terrain.h
+++ b/Source/Urho3D/Graphics/Terrain.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "../Scene/Component.h"
+#include "../Container/ArrayPtr.h"
 
 namespace Urho3D
 {


### PR DESCRIPTION
- Missing include added.
- Terrain UV coordinates fixed.

The image below shows how UV coordinates currently go in the place where one Terrain object changes to another. This PR fixes it.

![terrain fix](https://cloud.githubusercontent.com/assets/3167494/21484533/ca8e9ade-cb9c-11e6-9021-90bb7f46eb55.jpg)
