### PR TITLE
Rename Resource::Load and Resource::Save filename overloads to Resour…

### DIFF
--- a/Source/Urho3D/AngelScript/APITemplates.h
+++ b/Source/Urho3D/AngelScript/APITemplates.h
@@ -791,7 +791,7 @@ static bool ResourceLoadVectorBuffer(VectorBuffer& buffer, Resource* ptr)
 
 static bool ResourceLoadByName(const String& fileName, Resource* ptr)
 {
-    return ptr->Load(fileName);
+    return ptr->LoadFile(fileName);
 }
 
 static bool ResourceSave(File* file, Resource* ptr)
@@ -806,7 +806,7 @@ static bool ResourceSaveVectorBuffer(VectorBuffer& buffer, Resource* ptr)
 
 static bool ResourceSaveByName(const String& fileName, Resource* ptr)
 {
-    return ptr->Save(fileName);
+    return ptr->SaveFile(fileName);
 }
 
 /// Template function for registering a class derived from Resource.

--- a/Source/Urho3D/LuaScript/pkgs/Resource/Resource.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Resource/Resource.pkg
@@ -4,14 +4,26 @@ class Resource
 {
     bool Load(Deserializer& source);
     bool Save(Serializer& dest) const;
-    bool Load(const String& fileName);
-    bool Save(const String& fileName) const;
-    
+    tolua_outside bool ResourceLoad @ Load(const String& fileName);
+    tolua_outside bool ResourceSave @ Save(const String& fileName) const;
+
     const String GetName() const;
     StringHash GetNameHash() const;
     unsigned GetMemoryUse() const;
-    
+
     tolua_readonly tolua_property__get_set String name;
     tolua_readonly tolua_property__get_set StringHash nameHash;
     tolua_readonly tolua_property__get_set unsigned memoryUse;
 };
+
+${
+static bool ResourceLoad(Resource* resource, const String& fileName)
+{
+    return resource->LoadFile(fileName);
+}
+
+static bool ResourceSave(const Resource* resource, const String& fileName)
+{
+    return resource->SaveFile(fileName);
+}
+$}

--- a/Source/Urho3D/Resource/Image.cpp
+++ b/Source/Urho3D/Resource/Image.cpp
@@ -775,7 +775,7 @@ bool Image::Save(Serializer& dest) const
     return success;
 }
 
-bool Image::Save(const String& fileName) const
+bool Image::SaveFile(const String& fileName) const
 {
     if (fileName.EndsWith(".dds", false))
         return SaveDDS(fileName);

--- a/Source/Urho3D/Resource/Image.h
+++ b/Source/Urho3D/Resource/Image.h
@@ -105,7 +105,7 @@ public:
     /// Save the image to a stream. Regardless of original format, the image is saved as png. Compressed image data is not supported. Return true if successful.
     virtual bool Save(Serializer& dest) const;
     /// Save the image to a file. Format of the image is determined by file extension. JPG is saved with maximum quality.
-    virtual bool Save(const String& fileName) const;
+    virtual bool SaveFile(const String& fileName) const;
 
     /// Set 2D size and number of color components. Old image data will be destroyed and new data is undefined. Return true if successful.
     bool SetSize(int width, int height, unsigned components);

--- a/Source/Urho3D/Resource/Resource.cpp
+++ b/Source/Urho3D/Resource/Resource.cpp
@@ -83,13 +83,13 @@ bool Resource::Save(Serializer& dest) const
     return false;
 }
 
-bool Resource::Load(const String& fileName)
+bool Resource::LoadFile(const String& fileName)
 {
     File file(context_);
     return file.Open(fileName, FILE_READ) && Load(file);
 }
 
-bool Resource::Save(const String& fileName) const
+bool Resource::SaveFile(const String& fileName) const
 {
     File file(context_);
     return file.Open(fileName, FILE_WRITE) && Save(file);

--- a/Source/Urho3D/Resource/Resource.h
+++ b/Source/Urho3D/Resource/Resource.h
@@ -65,9 +65,9 @@ public:
     virtual bool Save(Serializer& dest) const;
 
     /// Load resource from file.
-    bool Load(const String& fileName);
+    bool LoadFile(const String& fileName);
     /// Save resource to file.
-    virtual bool Save(const String& fileName) const;
+    virtual bool SaveFile(const String& fileName) const;
 
     /// Set name.
     void SetName(const String& name);


### PR DESCRIPTION
…ce::LoadFile and Resource::SaveFile to prevent Resource::Save shadowing.

I noticed this annoying behaviour with my new Resource functions.
When some resource overrides Resource::Save(Serializer&), Resource::Save(String) became shadowed and inaccessible. So I renamed these functions in C++ API. Script APIs remain untouched because such functions are quite old and scripts don't have shadowing problems.