### PR TITLE
Avoid special chars in paths in MRI script passed to ar utility

### DIFF
--- a/Source/Urho3D/CMakeLists.txt
+++ b/Source/Urho3D/CMakeLists.txt
@@ -357,7 +357,7 @@ if (NOT XCODE AND NOT MSVC)
                 COMMAND libtool -static $<TARGET_FILE:${TARGET_NAME}>.engine ${ARCHIVES} -o $<TARGET_FILE:${TARGET_NAME}>
                 COMMAND rm $<TARGET_FILE:${TARGET_NAME}>.engine
                 COMMENT "Merging all archives into a single static library using libtool")
-        elseif (EMSCRIPTEN OR CMAKE_BINARY_DIR MATCHES " |\\+|\\*|;|,")
+        elseif (EMSCRIPTEN OR CMAKE_BINARY_DIR MATCHES "[ +*;,]")
             # Do it the hard way by first extracting the object (bitcode) files and appending them to final archive:
             # a) For Emscripten build as Emscripten emar (llvm-ar) neither takes archives directly as input nor supports MRI-style script
             # b) When the build tree path contains special characters for MRI scripts (space, '+', '*', ';', ',') as escaping is not supported

--- a/Source/Urho3D/CMakeLists.txt
+++ b/Source/Urho3D/CMakeLists.txt
@@ -357,10 +357,10 @@ if (NOT XCODE AND NOT MSVC)
                 COMMAND libtool -static $<TARGET_FILE:${TARGET_NAME}>.engine ${ARCHIVES} -o $<TARGET_FILE:${TARGET_NAME}>
                 COMMAND rm $<TARGET_FILE:${TARGET_NAME}>.engine
                 COMMENT "Merging all archives into a single static library using libtool")
-        elseif (EMSCRIPTEN OR CMAKE_BINARY_DIR MATCHES " ")
+        elseif (EMSCRIPTEN OR CMAKE_BINARY_DIR MATCHES " |\\+|\\*|;|,")
             # Do it the hard way by first extracting the object (bitcode) files and appending them to final archive:
             # a) For Emscripten build as Emscripten emar (llvm-ar) neither takes archives directly as input nor supports MRI-style script
-            # b) When the build tree path contains spaces because MRI script does not support spaces in path even with proper escape
+            # b) When the build tree path contains special characters for MRI scripts (space, '+', '*', ';', ',') as escaping is not supported
             get_filename_component (AR ${CMAKE_AR} NAME_WE)
             if (CMAKE_HOST_WIN32)
                 add_custom_command (TARGET ${TARGET_NAME} POST_BUILD


### PR DESCRIPTION
I have run into issue with MRI script special characters when building inside my "projects/c++/" directory.

Seems like not only spaces are problematic and no escaping is available.
https://sourceware.org/binutils/docs/binutils/ar-scripts.html

> The syntax for the ar command language is straightforward:
...
>     comments are allowed; text after either of the characters `*' or `;' is ignored.
...
>     Whenever you use a list of names as part of the argument to an ar command, you can separate the individual names with either commas or blanks. Commas are shown in the explanations below, for clarity.
...
>     `+' is used as a line continuation character; if `+' appears at the end of a line, the text on the following line is considered part of the current command. 

In case I understand it correctly no space, '+', '*', ';' or ',' should be allowed in script passed to ar.