### PR TITLE
Allow define of variant vector structs attributes

### DIFF
--- a/Source/Urho3D/AngelScript/CoreAPI.cpp
+++ b/Source/Urho3D/AngelScript/CoreAPI.cpp
@@ -824,6 +824,15 @@ static CScriptArray* AttributeInfoGetEnumNames(AttributeInfo* ptr)
     return VectorToArray<String>(enumNames, "Array<String>");
 }
 
+static CScriptArray* AttributeInfoGetVariantStructureElementsNames(AttributeInfo* ptr)
+{
+    Vector<String> variantStructureElementsNames;
+    const char** variantStructureElementsNamesPtrs = ptr->variantStructureElementsNames_;
+    while (variantStructureElementsNamesPtrs && *variantStructureElementsNamesPtrs)
+        variantStructureElementsNames.Push(*variantStructureElementsNamesPtrs++);
+    return VectorToArray<String>(variantStructureElementsNames, "Array<String>");
+}
+
 static void SendEvent(const String& eventType, VariantMap& eventData)
 {
     Object* sender = GetScriptContextEventListenerObject();
@@ -957,6 +966,7 @@ void RegisterObject(asIScriptEngine* engine)
     engine->RegisterObjectBehaviour("AttributeInfo", asBEHAVE_DESTRUCT, "void f()", asFUNCTION(DestructAttributeInfo), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod("AttributeInfo", "AttributeInfo& opAssign(const AttributeInfo&in)", asMETHODPR(AttributeInfo, operator =, (const AttributeInfo&), AttributeInfo&), asCALL_THISCALL);
     engine->RegisterObjectMethod("AttributeInfo", "Array<String>@ get_enumNames() const", asFUNCTION(AttributeInfoGetEnumNames), asCALL_CDECL_OBJLAST);
+    engine->RegisterObjectMethod("AttributeInfo", "Array<String>@ get_variantStructureElementsNames() const", asFUNCTION(AttributeInfoGetVariantStructureElementsNames), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectProperty("AttributeInfo", "VariantType type", offsetof(AttributeInfo, type_));
     engine->RegisterObjectProperty("AttributeInfo", "String name", offsetof(AttributeInfo, name_));
     engine->RegisterObjectProperty("AttributeInfo", "Variant defaultValue", offsetof(AttributeInfo, defaultValue_));

--- a/Source/Urho3D/AngelScript/SceneAPI.cpp
+++ b/Source/Urho3D/AngelScript/SceneAPI.cpp
@@ -286,7 +286,7 @@ static CScriptArray* GetObjectsByCategory(const String& category)
     return VectorToArray<String>(components, "Array<String>");
 }
 
-static CScriptArray* GetObjectsAttriuteInfos(const String& objectType)
+static CScriptArray* GetObjectsAttributeInfos(const String& objectType)
 {
     const Vector<AttributeInfo>* attributes = GetScriptContext()->GetAttributes(Urho3D::StringHash(objectType));
     Vector<AttributeInfo> copiedAttributes;
@@ -419,7 +419,7 @@ static void RegisterScene(asIScriptEngine* engine)
 
     engine->RegisterGlobalFunction("Array<String>@ GetObjectCategories()", asFUNCTION(GetObjectCategories), asCALL_CDECL);
     engine->RegisterGlobalFunction("Array<String>@ GetObjectsByCategory(const String&in)", asFUNCTION(GetObjectsByCategory), asCALL_CDECL);
-    engine->RegisterGlobalFunction("Array<AttributeInfo>@ GetObjectsAttriuteInfos(const String&in)", asFUNCTION(GetObjectsAttriuteInfos), asCALL_CDECL);
+    engine->RegisterGlobalFunction("Array<AttributeInfo>@ GetObjectsAttriuteInfos(const String&in)", asFUNCTION(GetObjectsAttributeInfos), asCALL_CDECL);
 }
 
 void RegisterSceneAPI(asIScriptEngine* engine)

--- a/Source/Urho3D/AngelScript/SceneAPI.cpp
+++ b/Source/Urho3D/AngelScript/SceneAPI.cpp
@@ -302,7 +302,7 @@ static CScriptArray* GetObjectsAttriuteInfos(const String& objectType)
         copy.defaultValue_ = i.ptr_->defaultValue_;
         copy.mode_ = i.ptr_->mode_;
         copy.ptr_ = i.ptr_->ptr_;
-        copiedAttributes.Push (copy);
+        copiedAttributes.Push(copy);
     }
     return VectorToArray<AttributeInfo>(copiedAttributes, "Array<AttributeInfo>");
 }

--- a/Source/Urho3D/AngelScript/SceneAPI.cpp
+++ b/Source/Urho3D/AngelScript/SceneAPI.cpp
@@ -290,20 +290,21 @@ static CScriptArray* GetObjectsAttributeInfos(const String& objectType)
 {
     const Vector<AttributeInfo>* attributes = GetScriptContext()->GetAttributes(Urho3D::StringHash(objectType));
     Vector<AttributeInfo> copiedAttributes;
-    for (Vector<AttributeInfo>::ConstIterator i = attributes->Begin(); i != attributes->End(); ++i)
-    {
-        AttributeInfo copy;
-        copy.type_ = i.ptr_->type_;
-        copy.name_ = i.ptr_->name_;
-        copy.offset_ = i.ptr_->offset_;
-        copy.enumNames_ = i.ptr_->enumNames_;
-        copy.variantStructureElementsNames_ = i.ptr_->variantStructureElementsNames_;
-        copy.accessor_ = i.ptr_->accessor_;
-        copy.defaultValue_ = i.ptr_->defaultValue_;
-        copy.mode_ = i.ptr_->mode_;
-        copy.ptr_ = i.ptr_->ptr_;
-        copiedAttributes.Push(copy);
-    }
+    if (attributes)
+        for (Vector<AttributeInfo>::ConstIterator i = attributes->Begin(); i != attributes->End(); ++i)
+        {
+            AttributeInfo copy;
+            copy.type_ = i.ptr_->type_;
+            copy.name_ = i.ptr_->name_;
+            copy.offset_ = i.ptr_->offset_;
+            copy.enumNames_ = i.ptr_->enumNames_;
+            copy.variantStructureElementsNames_ = i.ptr_->variantStructureElementsNames_;
+            copy.accessor_ = i.ptr_->accessor_;
+            copy.defaultValue_ = i.ptr_->defaultValue_;
+            copy.mode_ = i.ptr_->mode_;
+            copy.ptr_ = i.ptr_->ptr_;
+            copiedAttributes.Push(copy);
+        }
     return VectorToArray<AttributeInfo>(copiedAttributes, "Array<AttributeInfo>");
 }
 

--- a/Source/Urho3D/AngelScript/SceneAPI.cpp
+++ b/Source/Urho3D/AngelScript/SceneAPI.cpp
@@ -286,6 +286,28 @@ static CScriptArray* GetObjectsByCategory(const String& category)
     return VectorToArray<String>(components, "Array<String>");
 }
 
+static CScriptArray* GetObjectsAttriuteInfos(const String& objectType)
+{
+    const Vector<AttributeInfo> *attributes = GetScriptContext ()->GetAttributes (Urho3D::StringHash(objectType));
+    Vector<AttributeInfo> copiedAttributes;
+    for (int index = 0; index < attributes->Size (); index++)
+    {
+        AttributeInfo attribute = attributes->At (index);
+        AttributeInfo copy;
+        copy.type_ = attribute.type_;
+        copy.name_ = attribute.name_;
+        copy.offset_ = attribute.offset_;
+        copy.enumNames_ = attribute.enumNames_;
+        copy.variantStructureElementsNames_ = attribute.variantStructureElementsNames_;
+        copy.accessor_ = attribute.accessor_;
+        copy.defaultValue_ = attribute.defaultValue_;
+        copy.mode_ = attribute.mode_;
+        copy.ptr_ = attribute.ptr_;
+        copiedAttributes.Push (copy);
+    }
+    return VectorToArray<AttributeInfo>(copiedAttributes, "Array<AttributeInfo>");
+}
+
 static void RegisterSmoothedTransform(asIScriptEngine* engine)
 {
     RegisterComponent<SmoothedTransform>(engine, "SmoothedTransform");
@@ -398,6 +420,7 @@ static void RegisterScene(asIScriptEngine* engine)
 
     engine->RegisterGlobalFunction("Array<String>@ GetObjectCategories()", asFUNCTION(GetObjectCategories), asCALL_CDECL);
     engine->RegisterGlobalFunction("Array<String>@ GetObjectsByCategory(const String&in)", asFUNCTION(GetObjectsByCategory), asCALL_CDECL);
+    engine->RegisterGlobalFunction("Array<AttributeInfo>@ GetObjectsAttriuteInfos(const String&in)", asFUNCTION(GetObjectsAttriuteInfos), asCALL_CDECL);
 }
 
 void RegisterSceneAPI(asIScriptEngine* engine)

--- a/Source/Urho3D/AngelScript/SceneAPI.cpp
+++ b/Source/Urho3D/AngelScript/SceneAPI.cpp
@@ -288,21 +288,20 @@ static CScriptArray* GetObjectsByCategory(const String& category)
 
 static CScriptArray* GetObjectsAttriuteInfos(const String& objectType)
 {
-    const Vector<AttributeInfo> *attributes = GetScriptContext ()->GetAttributes (Urho3D::StringHash(objectType));
+    const Vector<AttributeInfo>* attributes = GetScriptContext()->GetAttributes(Urho3D::StringHash(objectType));
     Vector<AttributeInfo> copiedAttributes;
-    for (int index = 0; index < attributes->Size (); index++)
+    for (Vector<AttributeInfo>::ConstIterator i = attributes->Begin(); i != attributes->End(); ++i)
     {
-        AttributeInfo attribute = attributes->At (index);
         AttributeInfo copy;
-        copy.type_ = attribute.type_;
-        copy.name_ = attribute.name_;
-        copy.offset_ = attribute.offset_;
-        copy.enumNames_ = attribute.enumNames_;
-        copy.variantStructureElementsNames_ = attribute.variantStructureElementsNames_;
-        copy.accessor_ = attribute.accessor_;
-        copy.defaultValue_ = attribute.defaultValue_;
-        copy.mode_ = attribute.mode_;
-        copy.ptr_ = attribute.ptr_;
+        copy.type_ = i.ptr_->type_;
+        copy.name_ = i.ptr_->name_;
+        copy.offset_ = i.ptr_->offset_;
+        copy.enumNames_ = i.ptr_->enumNames_;
+        copy.variantStructureElementsNames_ = i.ptr_->variantStructureElementsNames_;
+        copy.accessor_ = i.ptr_->accessor_;
+        copy.defaultValue_ = i.ptr_->defaultValue_;
+        copy.mode_ = i.ptr_->mode_;
+        copy.ptr_ = i.ptr_->ptr_;
         copiedAttributes.Push (copy);
     }
     return VectorToArray<AttributeInfo>(copiedAttributes, "Array<AttributeInfo>");

--- a/Source/Urho3D/AngelScript/SceneAPI.cpp
+++ b/Source/Urho3D/AngelScript/SceneAPI.cpp
@@ -419,7 +419,7 @@ static void RegisterScene(asIScriptEngine* engine)
 
     engine->RegisterGlobalFunction("Array<String>@ GetObjectCategories()", asFUNCTION(GetObjectCategories), asCALL_CDECL);
     engine->RegisterGlobalFunction("Array<String>@ GetObjectsByCategory(const String&in)", asFUNCTION(GetObjectsByCategory), asCALL_CDECL);
-    engine->RegisterGlobalFunction("Array<AttributeInfo>@ GetObjectsAttriuteInfos(const String&in)", asFUNCTION(GetObjectsAttributeInfos), asCALL_CDECL);
+    engine->RegisterGlobalFunction("Array<AttributeInfo>@ GetObjectsAttributeInfos(const String&in)", asFUNCTION(GetObjectsAttributeInfos), asCALL_CDECL);
 }
 
 void RegisterSceneAPI(asIScriptEngine* engine)

--- a/Source/Urho3D/Core/Attribute.h
+++ b/Source/Urho3D/Core/Attribute.h
@@ -69,7 +69,7 @@ struct AttributeInfo
         type_(VAR_NONE),
         offset_(0),
         enumNames_(0),
-        variantStructureElementsNames_ (0),
+        variantStructureElementsNames_(0),
         mode_(AM_DEFAULT),
         ptr_(0)
     {
@@ -81,6 +81,7 @@ struct AttributeInfo
         name_(name),
         offset_((unsigned)offset),
         enumNames_(0),
+        variantStructureElementsNames_(0),
         defaultValue_(defaultValue),
         mode_(mode),
         ptr_(0)
@@ -93,7 +94,7 @@ struct AttributeInfo
         name_(name),
         offset_((unsigned)offset),
         enumNames_(enumNames),
-        variantStructureElementsNames_ (0),
+        variantStructureElementsNames_(0),
         defaultValue_(defaultValue),
         mode_(mode),
         ptr_(0)
@@ -106,7 +107,7 @@ struct AttributeInfo
         name_(name),
         offset_(0),
         enumNames_(0),
-        variantStructureElementsNames_ (0),
+        variantStructureElementsNames_(0),
         accessor_(accessor),
         defaultValue_(defaultValue),
         mode_(mode),
@@ -121,7 +122,7 @@ struct AttributeInfo
         name_(name),
         offset_(0),
         enumNames_(enumNames),
-        variantStructureElementsNames_ (0),
+        variantStructureElementsNames_(0),
         accessor_(accessor),
         defaultValue_(defaultValue),
         mode_(mode),
@@ -135,7 +136,7 @@ struct AttributeInfo
         name_(name),
         offset_(0),
         enumNames_(0),
-        variantStructureElementsNames_ (variantStructureElementsNames),
+        variantStructureElementsNames_(variantStructureElementsNames),
         accessor_(accessor),
         defaultValue_(defaultValue),
         mode_(mode),

--- a/Source/Urho3D/Core/Attribute.h
+++ b/Source/Urho3D/Core/Attribute.h
@@ -69,6 +69,7 @@ struct AttributeInfo
         type_(VAR_NONE),
         offset_(0),
         enumNames_(0),
+        variantStructureElementsNames_ (0),
         mode_(AM_DEFAULT),
         ptr_(0)
     {
@@ -92,6 +93,7 @@ struct AttributeInfo
         name_(name),
         offset_((unsigned)offset),
         enumNames_(enumNames),
+        variantStructureElementsNames_ (0),
         defaultValue_(defaultValue),
         mode_(mode),
         ptr_(0)
@@ -104,6 +106,7 @@ struct AttributeInfo
         name_(name),
         offset_(0),
         enumNames_(0),
+        variantStructureElementsNames_ (0),
         accessor_(accessor),
         defaultValue_(defaultValue),
         mode_(mode),
@@ -118,6 +121,21 @@ struct AttributeInfo
         name_(name),
         offset_(0),
         enumNames_(enumNames),
+        variantStructureElementsNames_ (0),
+        accessor_(accessor),
+        defaultValue_(defaultValue),
+        mode_(mode),
+        ptr_(0)
+    {
+    }
+
+    /// Construct variant structure (structure, which packed to VariantVector) attribute.
+    AttributeInfo(VariantType type, const char* name, AttributeAccessor* accessor, const Variant& defaultValue, const char** variantStructureElementsNames, unsigned mode) :
+        type_(type),
+        name_(name),
+        offset_(0),
+        enumNames_(0),
+        variantStructureElementsNames_ (variantStructureElementsNames),
         accessor_(accessor),
         defaultValue_(defaultValue),
         mode_(mode),
@@ -133,6 +151,8 @@ struct AttributeInfo
     unsigned offset_;
     /// Enum names.
     const char** enumNames_;
+    /// Variant structure elements names.
+    const char** variantStructureElementsNames_;
     /// Helper object for accessor mode.
     SharedPtr<AttributeAccessor> accessor_;
     /// Default value for network replication.

--- a/Source/Urho3D/Graphics/AnimatedModel.cpp
+++ b/Source/Urho3D/Graphics/AnimatedModel.cpp
@@ -49,6 +49,18 @@ namespace Urho3D
 
 extern const char* GEOMETRY_CATEGORY;
 
+const char* animationStatesStructureElementsNames[] =
+{
+    "Anim State Count",
+    "***Animation",
+    "   Start Bone",
+    "   Is Looped",
+    "   Weight",
+    "   Time",
+    "   Layer",
+    0
+};
+
 static bool CompareAnimationOrder(const SharedPtr<AnimationState>& lhs, const SharedPtr<AnimationState>& rhs)
 {
     return lhs->GetLayer() < rhs->GetLayer();
@@ -107,8 +119,9 @@ void AnimatedModel::RegisterObject(Context* context)
     URHO3D_COPY_BASE_ATTRIBUTES(Drawable);
     URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Bone Animation Enabled", GetBonesEnabledAttr, SetBonesEnabledAttr, VariantVector,
         Variant::emptyVariantVector, AM_FILE | AM_NOEDIT);
-    URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Animation States", GetAnimationStatesAttr, SetAnimationStatesAttr, VariantVector,
-        Variant::emptyVariantVector, AM_FILE);
+    URHO3D_MIXED_ACCESSOR_VARIANT_VECTOR_STRUCTURE_ATTRIBUTE("Animation States", GetAnimationStatesAttr, SetAnimationStatesAttr,
+                                                            VariantVector, Variant::emptyVariantVector,
+                                                            animationStatesStructureElementsNames, AM_FILE);
     URHO3D_ACCESSOR_ATTRIBUTE("Morphs", GetMorphsAttr, SetMorphsAttr, PODVector<unsigned char>, Variant::emptyBuffer,
         AM_DEFAULT | AM_NOEDIT);
 }

--- a/Source/Urho3D/Graphics/BillboardSet.cpp
+++ b/Source/Urho3D/Graphics/BillboardSet.cpp
@@ -57,6 +57,19 @@ const char* faceCameraModeNames[] =
     0
 };
 
+const char* billboardsStructureElementsNames[] =
+{
+    "Billboard Count",
+    "***Position",
+    "   Size",
+    "   UV Coordinates",
+    "   Color",
+    "   Rotation",
+    "   Direction",
+    "   Is Enabled",
+    0
+};
+
 inline bool CompareBillboards(Billboard* lhs, Billboard* rhs)
 {
     return lhs->sortDistance_ > rhs->sortDistance_;
@@ -116,8 +129,9 @@ void BillboardSet::RegisterObject(Context* context)
     URHO3D_ACCESSOR_ATTRIBUTE("Shadow Distance", GetShadowDistance, SetShadowDistance, float, 0.0f, AM_DEFAULT);
     URHO3D_ACCESSOR_ATTRIBUTE("Animation LOD Bias", GetAnimationLodBias, SetAnimationLodBias, float, 1.0f, AM_DEFAULT);
     URHO3D_COPY_BASE_ATTRIBUTES(Drawable);
-    URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Billboards", GetBillboardsAttr, SetBillboardsAttr, VariantVector, Variant::emptyVariantVector,
-        AM_FILE);
+    URHO3D_MIXED_ACCESSOR_VARIANT_VECTOR_STRUCTURE_ATTRIBUTE("Billboards", GetBillboardsAttr, SetBillboardsAttr,
+                                                            VariantVector, Variant::emptyVariantVector,
+                                                            billboardsStructureElementsNames, AM_FILE);
     URHO3D_ACCESSOR_ATTRIBUTE("Network Billboards", GetNetBillboardsAttr, SetNetBillboardsAttr, PODVector<unsigned char>,
         Variant::emptyBuffer, AM_NET | AM_NOEDIT);
 }

--- a/Source/Urho3D/Graphics/StaticModelGroup.cpp
+++ b/Source/Urho3D/Graphics/StaticModelGroup.cpp
@@ -40,6 +40,13 @@ namespace Urho3D
 
 extern const char* GEOMETRY_CATEGORY;
 
+const char* instanceNodesStructureElementsNames[] =
+{
+    "Instance Count",
+    "***NodeID",
+    0
+};
+
 StaticModelGroup::StaticModelGroup(Context* context) :
     StaticModel(context),
     nodesDirty_(false),
@@ -58,8 +65,9 @@ void StaticModelGroup::RegisterObject(Context* context)
     context->RegisterFactory<StaticModelGroup>(GEOMETRY_CATEGORY);
 
     URHO3D_COPY_BASE_ATTRIBUTES(StaticModel);
-    URHO3D_ACCESSOR_ATTRIBUTE("Instance Nodes", GetNodeIDsAttr, SetNodeIDsAttr, VariantVector, Variant::emptyVariantVector,
-        AM_DEFAULT | AM_NODEIDVECTOR);
+    URHO3D_ACCESSOR_VARIANT_VECTOR_STRUCTURE_ATTRIBUTE("Instance Nodes", GetNodeIDsAttr, SetNodeIDsAttr,
+                                                       VariantVector, Variant::emptyVariantVector, instanceNodesStructureElementsNames,
+                                                       AM_DEFAULT | AM_NODEIDVECTOR);
 }
 
 void StaticModelGroup::ApplyAttributes()

--- a/Source/Urho3D/Navigation/CrowdManager.cpp
+++ b/Source/Urho3D/Navigation/CrowdManager.cpp
@@ -46,6 +46,31 @@ extern const char* NAVIGATION_CATEGORY;
 static const unsigned DEFAULT_MAX_AGENTS = 512;
 static const float DEFAULT_MAX_AGENT_RADIUS = 0.f;
 
+const char* filterTypesStructureElementsNames[] =
+{
+    "Query Filter Type Count",
+    "***Include Flags",
+    "   Exclude Flags",
+    "   >AreaCost",
+    0
+};
+
+const char* obstacleAvoidanceTypesStructureElementsNames[] =
+{
+    "Obstacle Avoid. Type Count",
+    "***Velocity Bias",
+    "   Desired Velocity Weight",
+    "   Current Velocity Weight",
+    "   Side Bias Weight",
+    "   Time of Impact Weight",
+    "   Time Horizon",
+    "   Grid Size",
+    "   Adaptive Divs",
+    "   Adaptive Rings",
+    "   Adaptive Depth",
+    0
+};
+
 void CrowdAgentUpdateCallback(dtCrowdAgent* ag, float dt)
 {
     static_cast<CrowdAgent*>(ag->params.userData)->OnCrowdUpdate(ag, dt);
@@ -79,10 +104,12 @@ void CrowdManager::RegisterObject(Context* context)
     URHO3D_ATTRIBUTE("Max Agents", unsigned, maxAgents_, DEFAULT_MAX_AGENTS, AM_DEFAULT);
     URHO3D_ATTRIBUTE("Max Agent Radius", float, maxAgentRadius_, DEFAULT_MAX_AGENT_RADIUS, AM_DEFAULT);
     URHO3D_ATTRIBUTE("Navigation Mesh", unsigned, navigationMeshId_, 0, AM_DEFAULT | AM_COMPONENTID);
-    URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Filter Types", GetQueryFilterTypesAttr, SetQueryFilterTypesAttr, VariantVector,
-        Variant::emptyVariantVector, AM_DEFAULT);
-    URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Obstacle Avoidance Types", GetObstacleAvoidanceTypesAttr, SetObstacleAvoidanceTypesAttr,
-        VariantVector, Variant::emptyVariantVector, AM_DEFAULT);
+    URHO3D_MIXED_ACCESSOR_VARIANT_VECTOR_STRUCTURE_ATTRIBUTE("Filter Types", GetQueryFilterTypesAttr, SetQueryFilterTypesAttr,
+                                                             VariantVector, Variant::emptyVariantVector,
+                                                             filterTypesStructureElementsNames, AM_DEFAULT);
+    URHO3D_MIXED_ACCESSOR_VARIANT_VECTOR_STRUCTURE_ATTRIBUTE("Obstacle Avoidance Types", GetObstacleAvoidanceTypesAttr, SetObstacleAvoidanceTypesAttr,
+                                                             VariantVector, Variant::emptyVariantVector,
+                                                             obstacleAvoidanceTypesStructureElementsNames, AM_DEFAULT);
 }
 
 void CrowdManager::ApplyAttributes()

--- a/Source/Urho3D/Scene/Serializable.h
+++ b/Source/Urho3D/Scene/Serializable.h
@@ -365,5 +365,7 @@ public:
 #define URHO3D_MIXED_ACCESSOR_ATTRIBUTE_FREE(name, getFunction, setFunction, typeName, defaultValue, mode) context->RegisterAttribute<ClassName>(Urho3D::AttributeInfo(Urho3D::GetVariantType<typeName >(), name, new Urho3D::AttributeAccessorFreeImpl<ClassName, typeName, Urho3D::MixedAttributeTrait<typeName > >(getFunction, setFunction), defaultValue, mode))
 /// Update the default value of an already registered attribute.
 #define URHO3D_UPDATE_ATTRIBUTE_DEFAULT_VALUE(name, defaultValue) context->UpdateAttributeDefaultValue<ClassName>(name, defaultValue)
+/// Define an variant structure attribute that uses get and set functions, where the get function returns by value, but the set function uses a reference.
+#define URHO3D_VARIANT_STRUCTURE_ATTRIBUTE(name, getFunction, setFunction, typeName, defaultValue, variantStructureElementsNames, mode) context->RegisterAttribute<ClassName>(Urho3D::AttributeInfo(Urho3D::GetVariantType<typeName >(), name, new Urho3D::AttributeAccessorImpl<ClassName, typeName, Urho3D::MixedAttributeTrait<typeName > >(&ClassName::getFunction, &ClassName::setFunction), defaultValue, variantStructureElementsNames, mode))
 
 }

--- a/Source/Urho3D/Scene/Serializable.h
+++ b/Source/Urho3D/Scene/Serializable.h
@@ -365,7 +365,9 @@ public:
 #define URHO3D_MIXED_ACCESSOR_ATTRIBUTE_FREE(name, getFunction, setFunction, typeName, defaultValue, mode) context->RegisterAttribute<ClassName>(Urho3D::AttributeInfo(Urho3D::GetVariantType<typeName >(), name, new Urho3D::AttributeAccessorFreeImpl<ClassName, typeName, Urho3D::MixedAttributeTrait<typeName > >(getFunction, setFunction), defaultValue, mode))
 /// Update the default value of an already registered attribute.
 #define URHO3D_UPDATE_ATTRIBUTE_DEFAULT_VALUE(name, defaultValue) context->UpdateAttributeDefaultValue<ClassName>(name, defaultValue)
+/// Define an attribute that uses get and set functions.
+#define URHO3D_ACCESSOR_VARIANT_VECTOR_STRUCTURE_ATTRIBUTE(name, getFunction, setFunction, typeName, defaultValue, variantStructureElementsNames, mode) context->RegisterAttribute<ClassName>(Urho3D::AttributeInfo(Urho3D::GetVariantType<typeName >(), name, new Urho3D::AttributeAccessorImpl<ClassName, typeName, Urho3D::AttributeTrait<typeName > >(&ClassName::getFunction, &ClassName::setFunction), defaultValue, variantStructureElementsNames, mode))
 /// Define an variant structure attribute that uses get and set functions, where the get function returns by value, but the set function uses a reference.
-#define URHO3D_VARIANT_STRUCTURE_ATTRIBUTE(name, getFunction, setFunction, typeName, defaultValue, variantStructureElementsNames, mode) context->RegisterAttribute<ClassName>(Urho3D::AttributeInfo(Urho3D::GetVariantType<typeName >(), name, new Urho3D::AttributeAccessorImpl<ClassName, typeName, Urho3D::MixedAttributeTrait<typeName > >(&ClassName::getFunction, &ClassName::setFunction), defaultValue, variantStructureElementsNames, mode))
+#define URHO3D_MIXED_ACCESSOR_VARIANT_VECTOR_STRUCTURE_ATTRIBUTE(name, getFunction, setFunction, typeName, defaultValue, variantStructureElementsNames, mode) context->RegisterAttribute<ClassName>(Urho3D::AttributeInfo(Urho3D::GetVariantType<typeName >(), name, new Urho3D::AttributeAccessorImpl<ClassName, typeName, Urho3D::MixedAttributeTrait<typeName > >(&ClassName::getFunction, &ClassName::setFunction), defaultValue, variantStructureElementsNames, mode))
 
 }

--- a/Source/Urho3D/Scene/SplinePath.cpp
+++ b/Source/Urho3D/Scene/SplinePath.cpp
@@ -33,6 +33,13 @@ namespace Urho3D
 extern const char* interpolationModeNames[];
 extern const char* LOGIC_CATEGORY;
 
+const char* controlPointsStructureElementsNames[] =
+{
+    "Control Point Count",
+    "***NodeID",
+    0
+};
+
 SplinePath::SplinePath(Context* context) :
     Component(context),
     spline_(BEZIER_CURVE),
@@ -56,8 +63,9 @@ void SplinePath::RegisterObject(Context* context)
     URHO3D_ATTRIBUTE("Traveled", float, traveled_, 0.f, AM_FILE | AM_NOEDIT);
     URHO3D_ATTRIBUTE("Elapsed Time", float, elapsedTime_, 0.f, AM_FILE | AM_NOEDIT);
     URHO3D_ACCESSOR_ATTRIBUTE("Controlled", GetControlledIdAttr, SetControlledIdAttr, unsigned, 0, AM_FILE | AM_NODEID);
-    URHO3D_ACCESSOR_ATTRIBUTE("Control Points", GetControlPointIdsAttr, SetControlPointIdsAttr, VariantVector, Variant::emptyVariantVector,
-        AM_FILE | AM_NODEIDVECTOR);
+    URHO3D_ACCESSOR_VARIANT_VECTOR_STRUCTURE_ATTRIBUTE("Control Points", GetControlPointIdsAttr, SetControlPointIdsAttr,
+                                                            VariantVector, Variant::emptyVariantVector, controlPointsStructureElementsNames,
+                                                            AM_FILE | AM_NODEIDVECTOR);
 }
 
 void SplinePath::ApplyAttributes()

--- a/bin/Data/Scripts/Editor/AttributeEditor.as
+++ b/bin/Data/Scripts/Editor/AttributeEditor.as
@@ -1491,70 +1491,26 @@ Array<VectorStruct@> vectorStructs;
 
 void InitVectorStructs()
 {
-    // Fill vector structure data
-    Array<String> billboardVariables = {
-        "Billboard Count",
-        "   Position",
-        "   Size",
-        "   UV Coordinates",
-        "   Color",
-        "   Rotation",
-        "   Direction",
-        "   Is Enabled"
-    };
-    vectorStructs.Push(VectorStruct("BillboardSet", "Billboards", billboardVariables, 1));
-
-    Array<String> animationStateVariables = {
-        "Anim State Count",
-        "   Animation",
-        "   Start Bone",
-        "   Is Looped",
-        "   Weight",
-        "   Time",
-        "   Layer"
-    };
-    vectorStructs.Push(VectorStruct("AnimatedModel", "Animation States", animationStateVariables, 1));
-
-    Array<String> staticModelGroupInstanceVariables = {
-        "Instance Count",
-        "   NodeID"
-    };
-    vectorStructs.Push(VectorStruct("StaticModelGroup", "Instance Nodes", staticModelGroupInstanceVariables, 1));
-
-    Array<String> splinePathInstanceVariables = {
-        "Control Point Count",
-        "   NodeID"
-    };
-    vectorStructs.Push(VectorStruct("SplinePath", "Control Points", splinePathInstanceVariables, 1));
-
-    Array<String> crowdManagerFilterTypeVariables = {
-        "Query Filter Type Count",
-        "   Include Flags",
-        "   Exclude Flags",
-        "   >AreaCost"
-    };
-    vectorStructs.Push(VectorStruct("CrowdManager", "Filter Types", crowdManagerFilterTypeVariables, 1));
-
-    Array<String> crowdManagerAreaCostVariables = {
-        "   Area Count",
-        "      Cost"
-    };
-    vectorStructs.Push(VectorStruct("CrowdManager", "   >AreaCost", crowdManagerAreaCostVariables, 1));
-
-    Array<String> crowdManagerObstacleAvoidanceTypeVariables = {
-        "Obstacle Avoid. Type Count",
-        "   Velocity Bias",
-        "   Desired Velocity Weight",
-        "   Current Velocity Weight",
-        "   Side Bias Weight",
-        "   Time of Impact Weight",
-        "   Time Horizon",
-        "   Grid Size",
-        "   Adaptive Divs",
-        "   Adaptive Rings",
-        "   Adaptive Depth"
-    };
-    vectorStructs.Push(VectorStruct("CrowdManager", "Obstacle Avoidance Types", crowdManagerObstacleAvoidanceTypeVariables, 1));
+    Array<String> categories = GetObjectCategories();
+    for (int categoryIndex = 0; categoryIndex < categories.length; categoryIndex++)
+    {
+        Array<String> objectsNames = GetObjectsByCategory(categories[categoryIndex]);
+        for (int objectIndex = 0; objectIndex < objectsNames.length; objectIndex++)
+        {
+            String objectName = objectsNames[objectIndex];
+            Array<AttributeInfo> attributes = GetObjectsAttriuteInfos(objectName);
+            
+            for (int attributeIndex = 0; attributeIndex < attributes.length; attributeIndex++)
+            {
+                AttributeInfo attribute = attributes[attributeIndex];
+                if (attribute.type == VAR_VARIANTVECTOR and attribute.variantStructureElementsNames.length > 0)
+                {
+                    Array<String> elementsNames = attribute.variantStructureElementsNames;
+                    vectorStructs.Push(VectorStruct(objectName, attribute.name, elementsNames, 1));
+                }
+            }
+        }
+    }
 }
 
 VectorStruct@ GetVectorStruct(Array<Serializable@>@ serializables, uint index)

--- a/bin/Data/Scripts/Editor/AttributeEditor.as
+++ b/bin/Data/Scripts/Editor/AttributeEditor.as
@@ -1498,15 +1498,15 @@ void InitVectorStructs()
     vectorStructs.Push(VectorStruct("CrowdManager", "   >AreaCost", crowdManagerAreaCostVariables, 1));
     
     Array<String> categories = GetObjectCategories();
-    for (int categoryIndex = 0; categoryIndex < categories.length; categoryIndex++)
+    for (uint categoryIndex = 0; categoryIndex < categories.length; categoryIndex++)
     {
         Array<String> objectsNames = GetObjectsByCategory(categories[categoryIndex]);
-        for (int objectIndex = 0; objectIndex < objectsNames.length; objectIndex++)
+        for (uint objectIndex = 0; objectIndex < objectsNames.length; objectIndex++)
         {
             String objectName = objectsNames[objectIndex];
-            Array<AttributeInfo> attributes = GetObjectsAttriuteInfos(objectName);
+            Array<AttributeInfo> attributes = GetObjectsAttributeInfos(objectName);
             
-            for (int attributeIndex = 0; attributeIndex < attributes.length; attributeIndex++)
+            for (uint attributeIndex = 0; attributeIndex < attributes.length; attributeIndex++)
             {
                 AttributeInfo attribute = attributes[attributeIndex];
                 if (attribute.type == VAR_VARIANTVECTOR and attribute.variantStructureElementsNames.length > 0)

--- a/bin/Data/Scripts/Editor/AttributeEditor.as
+++ b/bin/Data/Scripts/Editor/AttributeEditor.as
@@ -1491,6 +1491,12 @@ Array<VectorStruct@> vectorStructs;
 
 void InitVectorStructs()
 {
+    Array<String> crowdManagerAreaCostVariables = {
+        "   Area Count",
+        "      Cost"
+    };
+    vectorStructs.Push(VectorStruct("CrowdManager", "   >AreaCost", crowdManagerAreaCostVariables, 1));
+    
     Array<String> categories = GetObjectCategories();
     for (int categoryIndex = 0; categoryIndex < categories.length; categoryIndex++)
     {


### PR DESCRIPTION
See issue #1741 .
Now variant vector structs elements names can be defined from AttributeInfos. Now AnimatedModel, CrowdManager, SplinePath, BilboardSet and StaticModelGroup use this way to do it.