### PR TITLE
Input scaling between backbuffer / window

### DIFF
--- a/Source/Urho3D/AngelScript/InputAPI.cpp
+++ b/Source/Urho3D/AngelScript/InputAPI.cpp
@@ -591,7 +591,7 @@ static void RegisterInput(asIScriptEngine* engine)
     engine->RegisterObjectMethod("Input", "int get_qualifiers() const", asMETHOD(Input, GetQualifiers), asCALL_THISCALL);
     engine->RegisterObjectMethod("Input", "void set_mousePosition(const IntVector2&in)", asMETHOD(Input, SetMousePosition), asCALL_THISCALL);
     engine->RegisterObjectMethod("Input", "IntVector2 get_mousePosition() const", asMETHOD(Input, GetMousePosition), asCALL_THISCALL);
-    engine->RegisterObjectMethod("Input", "const IntVector2& get_mouseMove() const", asMETHOD(Input, GetMouseMove), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Input", "IntVector2 get_mouseMove() const", asMETHOD(Input, GetMouseMove), asCALL_THISCALL);
     engine->RegisterObjectMethod("Input", "int get_mouseMoveX() const", asMETHOD(Input, GetMouseMoveX), asCALL_THISCALL);
     engine->RegisterObjectMethod("Input", "int get_mouseMoveY() const", asMETHOD(Input, GetMouseMoveY), asCALL_THISCALL);
     engine->RegisterObjectMethod("Input", "int get_mouseMoveWheel() const", asMETHOD(Input, GetMouseMoveWheel), asCALL_THISCALL);

--- a/Source/Urho3D/Input/Input.h
+++ b/Source/Urho3D/Input/Input.h
@@ -212,7 +212,7 @@ public:
     bool RemoveGesture(unsigned gestureID);
     /// Remove all in-memory gestures.
     void RemoveAllGestures();
-    /// Set the mouse cursor position.
+    /// Set the mouse cursor position. Uses the backbuffer (Graphics width/height) coordinates.
     void SetMousePosition(const IntVector2& position);
     /// Center the mouse position.
     void CenterMousePosition();
@@ -247,10 +247,10 @@ public:
     bool GetQualifierPress(int qualifier) const;
     /// Return the currently held down qualifiers.
     int GetQualifiers() const;
-    /// Return mouse position within window. Should only be used with a visible mouse cursor.
+    /// Return mouse position within window. Should only be used with a visible mouse cursor. Uses the backbuffer (Graphics width/height) coordinates.
     IntVector2 GetMousePosition() const;
     /// Return mouse movement since last frame.
-    const IntVector2& GetMouseMove() const;
+    IntVector2 GetMouseMove() const;
     /// Return horizontal mouse movement since last frame.
     int GetMouseMoveX() const;
     /// Return vertical mouse movement since last frame.
@@ -393,6 +393,8 @@ private:
     IntVector2 mouseMove_;
     /// Mouse wheel movement since last frame.
     int mouseMoveWheel_;
+    /// Input coordinate scaling. Non-unity when window and backbuffer have different sizes (e.g. Retina display.)
+    Vector2 inputScale_;
     /// SDL window ID.
     unsigned windowID_;
     /// Fullscreen toggle flag.
@@ -423,6 +425,8 @@ private:
     bool focusedThisFrame_;
     /// Next mouse move suppress flag.
     bool suppressNextMouseMove_;
+    /// Whether mouse move is accumulated in backbuffer scale or not (when using events directly).
+    bool mouseMoveScaled_;
     /// Initialized flag.
     bool initialized_;
 

--- a/Source/Urho3D/LuaScript/pkgs/Input/Input.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Input/Input.pkg
@@ -83,7 +83,7 @@ class Input : public Object
     bool GetQualifierPress(int qualifier) const;
     int GetQualifiers() const;
     IntVector2 GetMousePosition() const;
-    const IntVector2& GetMouseMove() const;
+    IntVector2 GetMouseMove() const;
     int GetMouseMoveX() const;
     int GetMouseMoveY() const;
     int GetMouseMoveWheel() const;
@@ -106,7 +106,7 @@ class Input : public Object
 
     tolua_readonly tolua_property__get_set int qualifiers;
     tolua_property__get_set IntVector2 mousePosition;
-    tolua_readonly tolua_property__get_set IntVector2& mouseMove;
+    tolua_readonly tolua_property__get_set IntVector2 mouseMove;
     tolua_readonly tolua_property__get_set int mouseMoveX;
     tolua_readonly tolua_property__get_set int mouseMoveY;
     tolua_readonly tolua_property__get_set int mouseMoveWheel;


### PR DESCRIPTION
Scales mouse position and deltas if backbuffer (Graphics) has different size than SDL window. Inspired by work of Elissa Ross in PR #1725. Related to issue #1252, might resolve it, but not tested on actual Retina hardware.

For code simplicity, this now applies scale always, even if it's (1,1). Involves somewhat horrible int-float-int conversions. If anyone has time, please review so that I didn't commit too bad sins. I tested in D3D9 by intentionally creating half sized or double sized backbuffer, and it seemed to work right.