### PR TITLE
WebGL Module.arguments not work on Urho3DPlayer.

### DIFF
--- a/Source/Tools/Urho3DPlayer/Urho3DPlayer.cpp
+++ b/Source/Tools/Urho3DPlayer/Urho3DPlayer.cpp
@@ -144,11 +144,7 @@ void Urho3DPlayer::Start()
 {
     // Reattempt reading the command line from the resource system now if not read before
     // Note that the engine can not be reconfigured at this point; only the script name can be specified
-    if (GetArguments().Empty()
-#ifndef __EMSCRIPTEN__
-        && !commandLineRead_
-#endif
-        )
+    if (GetArguments().Empty() && !commandLineRead_)
     {
         SharedPtr<File> commandFile = GetSubsystem<ResourceCache>()->GetFile("CommandLine.txt", false);
         if (commandFile)

--- a/Source/Tools/Urho3DPlayer/Urho3DPlayer.cpp
+++ b/Source/Tools/Urho3DPlayer/Urho3DPlayer.cpp
@@ -144,7 +144,11 @@ void Urho3DPlayer::Start()
 {
     // Reattempt reading the command line from the resource system now if not read before
     // Note that the engine can not be reconfigured at this point; only the script name can be specified
-    if (GetArguments().Empty() && !commandLineRead_)
+    if (GetArguments().Empty()
+#ifndef __EMSCRIPTEN__
+        && !commandLineRead_
+#endif
+        )
     {
         SharedPtr<File> commandFile = GetSubsystem<ResourceCache>()->GetFile("CommandLine.txt", false);
         if (commandFile)
@@ -162,6 +166,18 @@ void Urho3DPlayer::Start()
             return;
         }
     }
+#ifdef __EMSCRIPTEN__
+    else
+    {
+        GetScriptFileName();
+
+        if (scriptFileName_.Empty())
+        {
+            ErrorExit("Script file name not specified; cannot proceed");
+            return;
+        }
+    }
+#endif
 
     String extension = GetExtension(scriptFileName_);
     if (extension != ".lua" && extension != ".luc")


### PR DESCRIPTION
Hi,

When I attempt to pass arguments to Urho3DPlayer web sample, It fires unexpected application failure. So I changed and tested the related source file. Now it works.