### PR TITLE
Fix crash related to TileMap2D when no scene is set

### DIFF
--- a/Source/Urho3D/Urho2D/StaticSprite2D.cpp
+++ b/Source/Urho3D/Urho2D/StaticSprite2D.cpp
@@ -263,6 +263,13 @@ ResourceRef StaticSprite2D::GetCustomMaterialAttr() const
     return GetResourceRef(customMaterial_, Material::GetTypeStatic());
 }
 
+void StaticSprite2D::OnSceneSet(Scene* scene)
+{
+    Drawable2D::OnSceneSet(scene);
+
+    UpdateMaterial();
+}
+
 void StaticSprite2D::OnWorldBoundingBoxUpdate()
 {
     boundingBox_.Clear();
@@ -339,7 +346,7 @@ void StaticSprite2D::UpdateMaterial()
         sourceBatches_[0].material_ = customMaterial_;
     else
     {
-        if (sprite_)
+        if (sprite_ && renderer_)
             sourceBatches_[0].material_ = renderer_->GetMaterial(sprite_->GetTexture(), blendMode_);
         else
             sourceBatches_[0].material_ = 0;

--- a/Source/Urho3D/Urho2D/StaticSprite2D.h
+++ b/Source/Urho3D/Urho2D/StaticSprite2D.h
@@ -119,7 +119,11 @@ public:
     /// Return custom material attribute.
     ResourceRef GetCustomMaterialAttr() const;
 
+
 protected:
+
+    /// Handle scene being assigned.
+    virtual void OnSceneSet(Scene* scene);
     /// Recalculate the world-space bounding box.
     virtual void OnWorldBoundingBoxUpdate();
     /// Handle draw order changed.


### PR DESCRIPTION
Hello, here is a fix for the following case :

 * Create a node without a scene
 * Add TileMap2D component
 * call SetTmxFile(...)

This was crashing because 'renderer_' was null in StaticSprite2D.

Now it won't crash and StaticSprite2D will update its material when added to a scene.