### PR TITLE
fixes #1781 - Moved SDL_Init() into Context class

### DIFF
--- a/Source/Urho3D/Audio/Audio.cpp
+++ b/Source/Urho3D/Audio/Audio.cpp
@@ -58,6 +58,8 @@ Audio::Audio(Context* context) :
     sampleSize_(0),
     playing_(false)
 {
+    context_->RequireSDL(SDL_INIT_AUDIO);
+
     // Set the master to the default value
     masterGain_[SOUND_MASTER_HASH] = 1.0f;
 
@@ -70,6 +72,7 @@ Audio::Audio(Context* context) :
 Audio::~Audio()
 {
     Release();
+    context_->ReleaseSDL();
 }
 
 bool Audio::SetMode(int bufferLengthMSec, int mixRate, bool stereo, bool interpolation)

--- a/Source/Urho3D/Core/Context.cpp
+++ b/Source/Urho3D/Core/Context.cpp
@@ -34,7 +34,7 @@ namespace Urho3D
 {
 
 // Keeps track of how many times SDL was initialised so we know when to call SDL_Quit().
-static int g_sdlInitCounter = 0;
+static int sdlInitCounter = 0;
 
 void EventReceiverGroup::BeginSendEvent()
 {
@@ -219,13 +219,13 @@ bool Context::RequireSDL(unsigned int sdlFlags)
 {
     // Always increment, the caller must match with ReleaseSDL(), regardless of
     // what happens.
-    g_sdlInitCounter++;
+    sdlInitCounter++;
 
     // Need to call SDL_Init() at least once before SDL_InitSubsystem()
-    if(g_sdlInitCounter == 0)
+    if (sdlInitCounter == 0)
     {
         URHO3D_LOGDEBUG("Initialising SDL");
-        if(SDL_Init(0) != 0)
+        if (SDL_Init(0) != 0)
         {
             URHO3D_LOGERRORF("Failed to initialise SDL: %s", SDL_GetError());
             return false;
@@ -233,9 +233,9 @@ bool Context::RequireSDL(unsigned int sdlFlags)
     }
 
     Uint32 remainingFlags = sdlFlags & ~SDL_WasInit(0);
-    if(remainingFlags != 0)
+    if (remainingFlags != 0)
     {
-        if(SDL_InitSubSystem(remainingFlags) != 0)
+        if (SDL_InitSubSystem(remainingFlags) != 0)
         {
             URHO3D_LOGERRORF("Failed to initialise SDL subsystem: %s", SDL_GetError());
             return false;
@@ -247,14 +247,16 @@ bool Context::RequireSDL(unsigned int sdlFlags)
 
 void Context::ReleaseSDL()
 {
-    g_sdlInitCounter--;
-    if(g_sdlInitCounter == 0)
+    sdlInitCounter--;
+
+    if (sdlInitCounter == 0)
     {
         URHO3D_LOGDEBUG("Quitting SDL");
         SDL_QuitSubSystem(SDL_INIT_EVERYTHING);
         SDL_Quit();
     }
-    if(g_sdlInitCounter < 0)
+
+    if (sdlInitCounter < 0)
     {
         URHO3D_LOGERRORF("Too many calls to Context::ReleaseSDL()!");
     }

--- a/Source/Urho3D/Core/Context.h
+++ b/Source/Urho3D/Core/Context.h
@@ -96,6 +96,10 @@ public:
     void UpdateAttributeDefaultValue(StringHash objectType, const char* name, const Variant& defaultValue);
     /// Return a preallocated map for event data. Used for optimization to avoid constant re-allocation of event data maps.
     VariantMap& GetEventDataMap();
+    /// Initialises the specified SDL systems, if not already. Returns true if successful. This call must be matched with ReleaseSDL() when SDL functions are no longer required, even if this call fails.
+    bool RequireSDL(unsigned int sdlFlags);
+    /// Indicate that you are done with using SDL. Must be called after using RequireSDL().
+    void ReleaseSDL();
 
     /// Copy base class attributes to derived class.
     void CopyBaseAttributes(StringHash baseType, StringHash derivedType);

--- a/Source/Urho3D/Graphics/Direct3D11/D3D11Graphics.cpp
+++ b/Source/Urho3D/Graphics/Direct3D11/D3D11Graphics.cpp
@@ -237,7 +237,7 @@ Graphics::Graphics(Context* context) :
     SetTextureUnitMappings();
     ResetCachedState();
 
-    context_->RequireSDL(SDL_INIT_VIDEO | SDL_INIT_NOPARACHUTE);
+    context_->RequireSDL(SDL_INIT_VIDEO);
 
     // Register Graphics library object factories
     RegisterGraphicsLibrary(context_);

--- a/Source/Urho3D/Graphics/Direct3D11/D3D11Graphics.cpp
+++ b/Source/Urho3D/Graphics/Direct3D11/D3D11Graphics.cpp
@@ -237,8 +237,7 @@ Graphics::Graphics(Context* context) :
     SetTextureUnitMappings();
     ResetCachedState();
 
-    // Initialize SDL now. Graphics should be the first SDL-using subsystem to be created
-    SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER | SDL_INIT_NOPARACHUTE);
+    context_->RequireSDL(SDL_INIT_VIDEO | SDL_INIT_NOPARACHUTE);
 
     // Register Graphics library object factories
     RegisterGraphicsLibrary(context_);
@@ -295,8 +294,7 @@ Graphics::~Graphics()
     delete impl_;
     impl_ = 0;
 
-    // Shut down SDL now. Graphics should be the last SDL-using subsystem to be destroyed
-    SDL_Quit();
+    context_->ReleaseSDL();
 }
 
 bool Graphics::SetMode(int width, int height, bool fullscreen, bool borderless, bool resizable, bool highDPI, bool vsync, bool tripleBuffer,
@@ -1406,7 +1404,7 @@ void Graphics::SetRenderTarget(unsigned index, RenderSurface* renderTarget)
                 if (textures_[i] == parentTexture)
                     SetTexture(i, textures_[i]->GetBackupTexture());
             }
-            
+
             // If multisampled, mark the texture & surface needing resolve
             if (parentTexture->GetMultiSample() > 1 && parentTexture->GetAutoResolve())
             {
@@ -2560,7 +2558,7 @@ void Graphics::PrepareDraw()
         int scaledDepthBias = (int)(constantDepthBias_ * (1 << depthBits));
 
         unsigned newRasterizerStateHash =
-            (scissorTest_ ? 1 : 0) | (lineAntiAlias_ ? 2 : 0) | (fillMode_ << 2) | (cullMode_ << 4) | 
+            (scissorTest_ ? 1 : 0) | (lineAntiAlias_ ? 2 : 0) | (fillMode_ << 2) | (cullMode_ << 4) |
             ((scaledDepthBias & 0x1fff) << 6) | (((int)(slopeScaledDepthBias_ * 100.0f) & 0x1fff) << 19);
         if (newRasterizerStateHash != impl_->rasterizerStateHash_)
         {

--- a/Source/Urho3D/Graphics/Direct3D9/D3D9Graphics.cpp
+++ b/Source/Urho3D/Graphics/Direct3D9/D3D9Graphics.cpp
@@ -289,8 +289,7 @@ Graphics::Graphics(Context* context) :
 {
     SetTextureUnitMappings();
 
-    // Initialize SDL now. Graphics should be the first SDL-using subsystem to be created
-    SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER | SDL_INIT_NOPARACHUTE);
+    context_->RequireSDL(SDL_INIT_VIDEO | SDL_INIT_NOPARACHUTE);
 
     // Register Graphics library object factories
     RegisterGraphicsLibrary(context_);
@@ -325,8 +324,7 @@ Graphics::~Graphics()
     delete impl_;
     impl_ = 0;
 
-    // Shut down SDL now. Graphics should be the last SDL-using subsystem to be destroyed
-    SDL_Quit();
+    context_->ReleaseSDL();
 }
 
 bool Graphics::SetMode(int width, int height, bool fullscreen, bool borderless, bool resizable, bool highDPI, bool vsync,
@@ -886,7 +884,7 @@ bool Graphics::ResolveToTexture(TextureCube* texture)
         return false;
 
     URHO3D_PROFILE(ResolveToTexture);
-    
+
     texture->SetResolveDirty(false);
 
     RECT rect;
@@ -2432,7 +2430,7 @@ void Graphics::CheckFeatureSupport()
 {
     anisotropySupport_ = true;
     dxtTextureSupport_ = true;
-    
+
     // Reset features first
     lightPrepassSupport_ = false;
     deferredSupport_ = false;

--- a/Source/Urho3D/Graphics/Direct3D9/D3D9Graphics.cpp
+++ b/Source/Urho3D/Graphics/Direct3D9/D3D9Graphics.cpp
@@ -289,7 +289,7 @@ Graphics::Graphics(Context* context) :
 {
     SetTextureUnitMappings();
 
-    context_->RequireSDL(SDL_INIT_VIDEO | SDL_INIT_NOPARACHUTE);
+    context_->RequireSDL(SDL_INIT_VIDEO);
 
     // Register Graphics library object factories
     RegisterGraphicsLibrary(context_);

--- a/Source/Urho3D/Graphics/OpenGL/OGLGraphics.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLGraphics.cpp
@@ -267,7 +267,7 @@ Graphics::Graphics(Context* context_) :
     SetTextureUnitMappings();
     ResetCachedState();
 
-    context_->RequireSDL(SDL_INIT_VIDEO | SDL_INIT_NOPARACHUTE);
+    context_->RequireSDL(SDL_INIT_VIDEO);
 
     // Register Graphics library object factories
     RegisterGraphicsLibrary(context_);

--- a/Source/Urho3D/Graphics/OpenGL/OGLGraphics.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLGraphics.cpp
@@ -267,8 +267,7 @@ Graphics::Graphics(Context* context_) :
     SetTextureUnitMappings();
     ResetCachedState();
 
-    // Initialize SDL now. Graphics should be the first SDL-using subsystem to be created
-    SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER | SDL_INIT_NOPARACHUTE);
+    context_->RequireSDL(SDL_INIT_VIDEO | SDL_INIT_NOPARACHUTE);
 
     // Register Graphics library object factories
     RegisterGraphicsLibrary(context_);
@@ -281,8 +280,7 @@ Graphics::~Graphics()
     delete impl_;
     impl_ = 0;
 
-    // Shut down SDL now. Graphics should be the last SDL-using subsystem to be destroyed
-    SDL_Quit();
+    context_->ReleaseSDL();
 }
 
 bool Graphics::SetMode(int width, int height, bool fullscreen, bool borderless, bool resizable, bool highDPI, bool vsync,
@@ -788,7 +786,7 @@ bool Graphics::ResolveToTexture(Texture2D* texture)
         glFramebufferRenderbuffer(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, surface->GetRenderBuffer());
         glBindFramebuffer(GL_DRAW_FRAMEBUFFER, impl_->resolveDestFBO_);
         glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture->GetGPUObjectName(), 0);
-        glBlitFramebuffer(0, 0, texture->GetWidth(), texture->GetHeight(), 0, 0, texture->GetWidth(), texture->GetHeight(), 
+        glBlitFramebuffer(0, 0, texture->GetWidth(), texture->GetHeight(), 0, 0, texture->GetWidth(), texture->GetHeight(),
             GL_COLOR_BUFFER_BIT, GL_NEAREST);
         glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
         glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
@@ -849,7 +847,7 @@ bool Graphics::ResolveToTexture(TextureCube* texture)
             RenderSurface* surface = texture->GetRenderSurface((CubeMapFace)i);
             if (!surface->IsResolveDirty())
                 continue;
-            
+
             surface->SetResolveDirty(false);
             glBindFramebuffer(GL_READ_FRAMEBUFFER, impl_->resolveSrcFBO_);
             glFramebufferRenderbuffer(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, surface->GetRenderBuffer());
@@ -1622,7 +1620,7 @@ void Graphics::SetDefaultTextureFilterMode(TextureFilterMode mode)
 void Graphics::SetDefaultTextureAnisotropy(unsigned level)
 {
     level = Max(level, 1U);
-    
+
     if (level != defaultTextureAnisotropy_)
     {
         defaultTextureAnisotropy_ = level;

--- a/Source/Urho3D/Input/Input.cpp
+++ b/Source/Urho3D/Input/Input.cpp
@@ -348,6 +348,8 @@ Input::Input(Context* context) :
     mouseMoveScaled_(false),
     initialized_(false)
 {
+    context_->RequireSDL(SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER);
+
     for (int i = 0; i < TOUCHID_MAX; i++)
         availableTouchIDs_.Push(i);
 
@@ -365,6 +367,11 @@ Input::Input(Context* context) :
 
 Input::~Input()
 {
+#ifdef __EMSCRIPTEN__
+    delete emscriptenInput_;
+    emscriptenInput_ = 0;
+#endif
+    context_->ReleaseSDL();
 }
 
 void Input::Update()


### PR DESCRIPTION
```SDL_Init()``` and ```SDL_Quit()``` are now located in the ```Context``` class. Urho3D subsystems can use ```context_->RequireSDL(SDL_INIT_SUBSYSTEM);``` and ```context_->ReleaseSDL()``` in their constructor/destructors if they require the use of SDL functions. The ```Context``` class globally keeps track of the number of calls to ```RequireSDL()``` so it knows when to call ```SDL_Quit()```