### PR TITLE
Update Assimp

### DIFF
--- a/Source/ThirdParty/Assimp/CMakeLists.txt
+++ b/Source/ThirdParty/Assimp/CMakeLists.txt
@@ -675,6 +675,8 @@ SET( zlib_SRCS
 SOURCE_GROUP( zlib FILES ${zlib_SRCS})
 
 SET ( openddl_parser_SRCS
+  contrib/openddlparser/code/OpenDDLExport.cpp 
+  contrib/openddlparser/code/OpenDDLCommon.cpp
   contrib/openddlparser/code/OpenDDLParser.cpp
   contrib/openddlparser/code/DDLNode.cpp
   contrib/openddlparser/code/Value.cpp
@@ -683,6 +685,7 @@ SET ( openddl_parser_SRCS
   contrib/openddlparser/include/openddlparser/OpenDDLCommon.h
   contrib/openddlparser/include/openddlparser/DDLNode.h
   contrib/openddlparser/include/openddlparser/Value.h
+  contrib/openddlparser/include/openddlparser/OpenDDLExport.h
 )
 SOURCE_GROUP( openddl_parser FILES ${openddl_parser_SRCS})
 

--- a/Source/ThirdParty/Assimp/INSTALL
+++ b/Source/ThirdParty/Assimp/INSTALL
@@ -33,13 +33,12 @@ CMake is the preferred build system for Assimp. The minimum required version
 is 2.6. If you don't have it yet, downloads for CMake can be found on
 http://www.cmake.org/. 
 
-Building Assimp with CMake is 'business as usual' if you've used CMake
-before. All steps can be done either on the command line / shell or
-by using the CMake GUI tool, the choice is up to you. 
+For Unix:
 
-First, invoke CMake to generate build files for a particular
-toolchain (for standard GNU makefiles: cmake -G 'Unix Makefiles').
-Afterwards, use the generated build files to perform the actual
-build. 
+1. cmake CMakeLists.txt -G 'Unix Makefiles'
+2. make
 
-
+For Windows:
+1. Open a command prompt
+2. cmake CMakeLists.txt
+2. Open your default IDE and build it

--- a/Source/ThirdParty/Assimp/Readme.md
+++ b/Source/ThirdParty/Assimp/Readme.md
@@ -113,7 +113,9 @@ If the docs don't solve your problem, ask on [StackOverflow](http://stackoverflo
 For development discussions, there is also a (very low-volume) mailing list, _assimp-discussions_
   [(subscribe here)]( https://lists.sourceforge.net/lists/listinfo/assimp-discussions) 
 
-And we also have an IRC-channel at freenode: #assetimporterlib .
+And we also have an IRC-channel at freenode: #assetimporterlib . You can easily join us via: [KiwiIRC/freenote](https://kiwiirc.com/client/irc.freenode.net), choose your nickname and type
+> /join #assetimporterlib
+
 ### Contributing ###
 
 Contributions to assimp are highly appreciated. The easiest way to get involved is to submit 
@@ -127,3 +129,6 @@ An _informal_ summary is: do whatever you want, but include Assimp's license tex
 and don't sue us if our code doesn't work. Note that, unlike LGPLed code, you may link statically to Assimp.
 For the legal details, see the `LICENSE` file. 
 
+### Why this name ###
+
+Sorry, we're germans :-), no english native speakers ...

--- a/Source/ThirdParty/Assimp/code/ASEParser.h
+++ b/Source/ThirdParty/Assimp/code/ASEParser.h
@@ -138,7 +138,7 @@ struct Bone
     }
 
     //! Construction from an existing name
-    Bone( const std::string& name)
+    explicit Bone( const std::string& name)
         :   mName   (name)
     {}
 
@@ -216,7 +216,7 @@ struct BaseNode
     enum Type {Light, Camera, Mesh, Dummy} mType;
 
     //! Constructor. Creates a default name for the node
-    BaseNode(Type _mType)
+    explicit BaseNode(Type _mType)
         : mType         (_mType)
         , mProcessed    (false)
     {

--- a/Source/ThirdParty/Assimp/code/Assimp.cpp
+++ b/Source/ThirdParty/Assimp/code/Assimp.cpp
@@ -110,7 +110,7 @@ static boost::mutex gLogStreamMutex;
 class LogToCallbackRedirector : public LogStream
 {
 public:
-    LogToCallbackRedirector(const aiLogStream& s)
+    explicit LogToCallbackRedirector(const aiLogStream& s)
         : stream (s)    {
             ai_assert(NULL != s.callback);
     }

--- a/Source/ThirdParty/Assimp/code/BVHLoader.h
+++ b/Source/ThirdParty/Assimp/code/BVHLoader.h
@@ -83,7 +83,7 @@ class BVHLoader : public BaseImporter
         std::vector<float> mChannelValues; // motion data values for that node. Of size NumChannels * NumFrames
 
         Node() { }
-        Node( const aiNode* pNode) : mNode( pNode) { }
+        explicit Node( const aiNode* pNode) : mNode( pNode) { }
     };
 
 public:

--- a/Source/ThirdParty/Assimp/code/BaseImporter.cpp
+++ b/Source/ThirdParty/Assimp/code/BaseImporter.cpp
@@ -63,7 +63,7 @@ using namespace Assimp;
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
 BaseImporter::BaseImporter()
-: progress()
+: m_progress()
 {
     // nothing to do here
 }
@@ -79,8 +79,8 @@ BaseImporter::~BaseImporter()
 // Imports the given file and returns the imported data.
 aiScene* BaseImporter::ReadFile(const Importer* pImp, const std::string& pFile, IOSystem* pIOHandler)
 {
-    progress = pImp->GetProgressHandler();
-    ai_assert(progress);
+    m_progress = pImp->GetProgressHandler();
+    ai_assert(m_progress);
 
     // Gather configuration properties for this run
     SetupProperties( pImp );
@@ -98,8 +98,8 @@ aiScene* BaseImporter::ReadFile(const Importer* pImp, const std::string& pFile, 
 
     } catch( const std::exception& err )    {
         // extract error description
-        mErrorText = err.what();
-        DefaultLogger::get()->error(mErrorText);
+        m_ErrorText = err.what();
+        DefaultLogger::get()->error(m_ErrorText);
         return NULL;
     }
 
@@ -274,7 +274,7 @@ void BaseImporter::GetExtensionList(std::set<std::string>& extensions)
 
         for (unsigned int i = 0; i < num; ++i) {
             // also check against big endian versions of tokens with size 2,4
-            // that's just for convinience, the chance that we cause conflicts
+            // that's just for convenience, the chance that we cause conflicts
             // is quite low and it can save some lines and prevent nasty bugs
             if (2 == size) {
                 uint16_t rev = *magic_u16;

--- a/Source/ThirdParty/Assimp/code/BaseImporter.h
+++ b/Source/ThirdParty/Assimp/code/BaseImporter.h
@@ -70,7 +70,7 @@ class IOStream;
 template <typename T>
 struct ScopeGuard
 {
-    ScopeGuard(T* obj) : obj(obj), mdismiss() {}
+    explicit ScopeGuard(T* obj) : obj(obj), mdismiss() {}
     ~ScopeGuard () throw() {
         if (!mdismiss) {
             delete obj;
@@ -181,7 +181,7 @@ public:
      * string if there was no error.
      */
     const std::string& GetErrorText() const {
-        return mErrorText;
+        return m_ErrorText;
     }
 
     // -------------------------------------------------------------------
@@ -362,10 +362,10 @@ public: // static utilities
 protected:
 
     /** Error description in case there was one. */
-    std::string mErrorText;
+    std::string m_ErrorText;
 
     /** Currently set progress handler */
-    ProgressHandler* progress;
+    ProgressHandler* m_progress;
 };
 
 

--- a/Source/ThirdParty/Assimp/code/BaseProcess.h
+++ b/Source/ThirdParty/Assimp/code/BaseProcess.h
@@ -74,7 +74,7 @@ public:
     template <typename T>
     struct THeapData : public Base
     {
-        THeapData(T* in)
+        explicit THeapData(T* in)
             : data (in)
         {}
 
@@ -89,7 +89,7 @@ public:
     template <typename T>
     struct TStaticData : public Base
     {
-        TStaticData(T in)
+        explicit TStaticData(T in)
             : data (in)
         {}
 

--- a/Source/ThirdParty/Assimp/code/CInterfaceIOWrapper.h
+++ b/Source/ThirdParty/Assimp/code/CInterfaceIOWrapper.h
@@ -57,7 +57,7 @@ class CIOStreamWrapper : public IOStream
     friend class CIOSystemWrapper;
 public:
 
-    CIOStreamWrapper(aiFile* pFile)
+    explicit CIOStreamWrapper(aiFile* pFile)
         : mFile(pFile)
     {}
 
@@ -110,7 +110,7 @@ private:
 class CIOSystemWrapper : public IOSystem
 {
 public:
-    CIOSystemWrapper(aiFileIO* pFile)
+    explicit CIOSystemWrapper(aiFileIO* pFile)
         : mFileSystem(pFile)
     {}
 

--- a/Source/ThirdParty/Assimp/code/CMakeLists.txt
+++ b/Source/ThirdParty/Assimp/code/CMakeLists.txt
@@ -632,10 +632,13 @@ SOURCE_GROUP( unzip FILES ${unzip_SRCS})
 SET ( openddl_parser_SRCS
   ../contrib/openddlparser/code/OpenDDLParser.cpp
   ../contrib/openddlparser/code/DDLNode.cpp
+  ../contrib/openddlparser/code/OpenDDLCommon.cpp
+  ../contrib/openddlparser/code/OpenDDLExport.cpp
   ../contrib/openddlparser/code/Value.cpp
   ../contrib/openddlparser/include/openddlparser/OpenDDLParser.h
   ../contrib/openddlparser/include/openddlparser/OpenDDLParserUtils.h
   ../contrib/openddlparser/include/openddlparser/OpenDDLCommon.h
+  ../contrib/openddlparser/include/openddlparser/OpenDDLExport.h
   ../contrib/openddlparser/include/openddlparser/DDLNode.h
   ../contrib/openddlparser/include/openddlparser/Value.h
 )

--- a/Source/ThirdParty/Assimp/code/ComputeUVMappingProcess.h
+++ b/Source/ThirdParty/Assimp/code/ComputeUVMappingProcess.h
@@ -125,7 +125,7 @@ private:
     // temporary structure to describe a mapping
     struct MappingInfo
     {
-        MappingInfo(aiTextureMapping _type)
+        explicit MappingInfo(aiTextureMapping _type)
             : type  (_type)
             , axis  (0.f,1.f,0.f)
             , uv    (0u)

--- a/Source/ThirdParty/Assimp/code/DefaultIOSystem.cpp
+++ b/Source/ThirdParty/Assimp/code/DefaultIOSystem.cpp
@@ -135,11 +135,11 @@ inline void MakeAbsolutePath (const char* in, char* _out)
 {
     ai_assert(in && _out);
     char* ret;
-#ifdef _WIN32
-    ret = ::_fullpath(_out, in,PATHLIMIT);
+#if defined( _MSC_VER ) || defined( __MINGW32__ )
+    ret = ::_fullpath( _out, in, PATHLIMIT );
 #else
-        // use realpath
-        ret = realpath(in, _out);
+    // use realpath
+    ret = realpath(in, _out);
 #endif
     if(!ret) {
         // preserve the input path, maybe someone else is able to fix
@@ -167,8 +167,8 @@ bool DefaultIOSystem::ComparePaths (const char* one, const char* second) const
     return !ASSIMP_stricmp(temp1,temp2);
 }
 
-
-std::string DefaultIOSystem::fileName(std::string path)
+// ------------------------------------------------------------------------------------------------
+std::string DefaultIOSystem::fileName( const std::string &path )
 {
     std::string ret = path;
     std::size_t last = ret.find_last_of("\\/");
@@ -177,7 +177,8 @@ std::string DefaultIOSystem::fileName(std::string path)
 }
 
 
-std::string DefaultIOSystem::completeBaseName(std::string path)
+// ------------------------------------------------------------------------------------------------
+std::string DefaultIOSystem::completeBaseName( const std::string &path )
 {
     std::string ret = fileName(path);
     std::size_t pos = ret.find_last_of('.');
@@ -185,13 +186,15 @@ std::string DefaultIOSystem::completeBaseName(std::string path)
     return ret;
 }
 
-
-std::string DefaultIOSystem::absolutePath(std::string path)
+// ------------------------------------------------------------------------------------------------
+std::string DefaultIOSystem::absolutePath( const std::string &path )
 {
     std::string ret = path;
     std::size_t last = ret.find_last_of("\\/");
     if (last != std::string::npos) ret = ret.substr(0, last);
     return ret;
 }
+
+// ------------------------------------------------------------------------------------------------
 
 #undef PATHLIMIT

--- a/Source/ThirdParty/Assimp/code/DefaultIOSystem.h
+++ b/Source/ThirdParty/Assimp/code/DefaultIOSystem.h
@@ -80,17 +80,17 @@ public:
     /** @brief get the file name of a full filepath
      * example: /tmp/archive.tar.gz -> archive.tar.gz
      */
-    static std::string fileName(std::string path);
+    static std::string fileName( const std::string &path );
 
     /** @brief get the complete base name of a full filepath
      * example: /tmp/archive.tar.gz -> archive.tar
      */
-    static std::string completeBaseName(std::string path);
+    static std::string completeBaseName( const std::string &path);
 
     /** @brief get the path of a full filepath
      * example: /tmp/archive.tar.gz -> /tmp/
      */
-    static std::string absolutePath(std::string path);
+    static std::string absolutePath( const std::string &path);
 };
 
 } //!ns Assimp

--- a/Source/ThirdParty/Assimp/code/FBXParser.h
+++ b/Source/ThirdParty/Assimp/code/FBXParser.h
@@ -38,8 +38,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------
 */
 
-// Modified by Lasse Oorni for Urho3D
-
 /** @file  FBXParser.h
  *  @brief FBX parsing code
  */

--- a/Source/ThirdParty/Assimp/code/FBXProperties.h
+++ b/Source/ThirdParty/Assimp/code/FBXProperties.h
@@ -87,7 +87,7 @@ class TypedProperty : public Property
 {
 public:
 
-    TypedProperty(const T& value)
+    explicit TypedProperty(const T& value)
         : value(value)
     {
     }

--- a/Source/ThirdParty/Assimp/code/HMPFileData.h
+++ b/Source/ThirdParty/Assimp/code/HMPFileData.h
@@ -37,9 +37,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ----------------------------------------------------------------------
 */
-
-// Modified by Lasse Oorni for Urho3D
-
 //!
 //! @file Data structures for the 3D Game Studio Heightmap format (HMP)
 //!

--- a/Source/ThirdParty/Assimp/code/Hash.h
+++ b/Source/ThirdParty/Assimp/code/Hash.h
@@ -38,8 +38,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------
 */
 
-// Modified by Lasse Oorni for Urho3D
-
 #ifndef AI_HASH_H_INCLUDED
 #define AI_HASH_H_INCLUDED
 

--- a/Source/ThirdParty/Assimp/code/IFCBoolean.cpp
+++ b/Source/ThirdParty/Assimp/code/IFCBoolean.cpp
@@ -261,7 +261,7 @@ bool IntersectsBoundaryProfile(const IfcVector3& e0, const IfcVector3& e1, const
     for( size_t i = 0, bcount = boundary.size(); i < bcount; ++i ) {
         IfcVector3 b01 = boundary[(i + 1) % bcount] - boundary[i];
         IfcVector3 b12 = boundary[(i + 2) % bcount] - boundary[(i + 1) % bcount];
-        IfcVector3 b1_side = IfcVector3(b01.y, -b01.x, 0.0); // rotated 90° clockwise in Z plane
+        IfcVector3 b1_side = IfcVector3(b01.y, -b01.x, 0.0); // rotated 90ï¿½ clockwise in Z plane
         // Warning: rough estimate only. A concave poly with lots of small segments each featuring a small counter rotation
         // could fool the accumulation. Correct implementation would be sum( acos( b01 * b2) * sign( b12 * b1_side))
         windingOrder += (b1_side.x*b12.x + b1_side.y*b12.y);

--- a/Source/ThirdParty/Assimp/code/IFCOpenings.cpp
+++ b/Source/ThirdParty/Assimp/code/IFCOpenings.cpp
@@ -903,8 +903,8 @@ size_t CloseWindows(ContourVector& contours,
             curmesh.verts.reserve(curmesh.verts.size() + (*it).contour.size() * 4);
             curmesh.vertcnt.reserve(curmesh.vertcnt.size() + (*it).contour.size());
 
-            // compare base poly normal and contour normal to detect if we need to reverse the face winding
-            // Urho3D: modified to not use C++11
+            // compare base poly normal and contour normal to detect if we need to reverse the face winding 
+            // Urho3D: modified to not use C++11 
             IfcVector3 basePolyNormal = TempMesh::ComputePolygonNormal( &curmesh.verts[0], curmesh.vertcnt.front());
             std::vector<IfcVector3> worldSpaceContourVtx( it->contour.size());
             for( size_t a = 0; a < it->contour.size(); ++a )

--- a/Source/ThirdParty/Assimp/code/IRRLoader.h
+++ b/Source/ThirdParty/Assimp/code/IRRLoader.h
@@ -113,7 +113,7 @@ private:
 
         } type;
 
-        Animator(AT t = UNKNOWN)
+        explicit Animator(AT t = UNKNOWN)
             : type              (t)
             , speed             (0.001f)
             , direction         (0.f,1.f,0.f)
@@ -163,7 +163,7 @@ private:
             ANIMMESH
         } type;
 
-        Node(ET t)
+        explicit Node(ET t)
             :   type                (t)
             ,   scaling             (1.f,1.f,1.f) // assume uniform scaling by default
             ,   parent()

--- a/Source/ThirdParty/Assimp/code/IRRShared.h
+++ b/Source/ThirdParty/Assimp/code/IRRShared.h
@@ -1,5 +1,4 @@
 
-// Modified by Lasse Oorni for Urho3D
 
 /** @file  IRRShared.h
   * @brief Shared utilities for the IRR and IRRMESH loaders

--- a/Source/ThirdParty/Assimp/code/Importer.h
+++ b/Source/ThirdParty/Assimp/code/Importer.h
@@ -167,7 +167,7 @@ public:
     // -------------------------------------------------------------------
     /** Construct a batch loader from a given IO system to be used
      *  to acess external files */
-    BatchLoader(IOSystem* pIO);
+    explicit BatchLoader(IOSystem* pIO);
     ~BatchLoader();
 
 

--- a/Source/ThirdParty/Assimp/code/LWOFileData.h
+++ b/Source/ThirdParty/Assimp/code/LWOFileData.h
@@ -269,7 +269,7 @@ struct Face : public aiFace
     {}
 
     //! Construction from given type
-    Face(uint32_t _type)
+    explicit Face(uint32_t _type)
         : surfaceIndex  (0)
         , smoothGroup   (0)
         , type          (_type)
@@ -305,7 +305,7 @@ struct Face : public aiFace
  */
 struct VMapEntry
 {
-    VMapEntry(unsigned int _dims)
+    explicit VMapEntry(unsigned int _dims)
         :  dims(_dims)
     {}
 

--- a/Source/ThirdParty/Assimp/code/MD2FileData.h
+++ b/Source/ThirdParty/Assimp/code/MD2FileData.h
@@ -38,8 +38,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------
 */
 
-// Modified by Lasse Oorni for Urho3D
-
 /** @file  MD2FileData.h
  *  @brief Defines helper data structures for importing MD2 files
  *  http://linux.ucla.edu/~phaethon/q3/formats/md2-schoenblum.html

--- a/Source/ThirdParty/Assimp/code/MD3FileData.h
+++ b/Source/ThirdParty/Assimp/code/MD3FileData.h
@@ -38,8 +38,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------
 */
 
-// Modified by Lasse Oorni for Urho3D
-
 /** @file Md3FileData.h
  *
  *  @brief Defines helper data structures for importing MD3 files.

--- a/Source/ThirdParty/Assimp/code/MD5Loader.cpp
+++ b/Source/ThirdParty/Assimp/code/MD5Loader.cpp
@@ -285,9 +285,6 @@ void MD5Importer::AttachChilds_Mesh(int iParentID,aiNode* piParent, BoneList& bo
                 aiQuaternion quat;
                 MD5::ConvertQuaternion ( bones[i].mRotationQuat, quat );
 
-                // FIX to get to Assimp's quaternion conventions
-                quat.w *= -1.f;
-
                 bones[i].mTransform = aiMatrix4x4 ( quat.GetMatrix());
                 bones[i].mTransform.a4 = bones[i].mPositionXYZ.x;
                 bones[i].mTransform.b4 = bones[i].mPositionXYZ.y;
@@ -656,9 +653,6 @@ void MD5Importer::LoadMD5AnimFile ()
 
                     MD5::ConvertQuaternion(vTemp, qKey->mValue);
                     qKey->mTime = vKey->mTime = dTime;
-
-                    // we need this to get to Assimp quaternion conventions
-                    qKey->mValue.w *= -1.f;
                 }
             }
 

--- a/Source/ThirdParty/Assimp/code/MD5Parser.h
+++ b/Source/ThirdParty/Assimp/code/MD5Parser.h
@@ -38,7 +38,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------
 */
 
-// Modified by Lasse Oorni for Urho3D
 
 /** @file  MD5Parser.h
  *  @brief Definition of the .MD5 parser class.
@@ -268,6 +267,9 @@ inline void ConvertQuaternion (const aiVector3D& in, aiQuaternion& out) {
     if (t < 0.0f)
         out.w = 0.0f;
     else out.w = std::sqrt (t);
+
+    // Assimp convention.
+    out.w *= -1.f;
 }
 
 // ---------------------------------------------------------------------------
@@ -283,7 +285,7 @@ public:
      *
      *  @param mSections List of file sections (output of MD5Parser)
      */
-    MD5MeshParser(SectionList& mSections);
+    explicit MD5MeshParser(SectionList& mSections);
 
     //! List of all meshes
     MeshList mMeshes;
@@ -308,7 +310,7 @@ public:
      *
      *  @param mSections List of file sections (output of MD5Parser)
      */
-    MD5AnimParser(SectionList& mSections);
+    explicit MD5AnimParser(SectionList& mSections);
 
 
     //! Output frame rate
@@ -340,7 +342,7 @@ public:
      *
      *  @param mSections List of file sections (output of MD5Parser)
      */
-    MD5CameraParser(SectionList& mSections);
+    explicit MD5CameraParser(SectionList& mSections);
 
 
     //! Output frame rate

--- a/Source/ThirdParty/Assimp/code/MDCFileData.h
+++ b/Source/ThirdParty/Assimp/code/MDCFileData.h
@@ -38,8 +38,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------
 */
 
-// Modified by Lasse Oorni for Urho3D
-
 /** @file Defines the helper data structures for importing MDC files
 
 **********************************************************************

--- a/Source/ThirdParty/Assimp/code/MDLFileData.h
+++ b/Source/ThirdParty/Assimp/code/MDLFileData.h
@@ -38,7 +38,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------
 */
 
-// Modified by Lasse Oorni for Urho3D
 
 /**
  * @file  MDLFileData.h

--- a/Source/ThirdParty/Assimp/code/MaterialSystem.h
+++ b/Source/ThirdParty/Assimp/code/MaterialSystem.h
@@ -38,8 +38,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------
 */
 
-// Modified by Lasse Oorni for Urho3D
-
 /** @file MaterialSystem.h
  *  Now that #MaterialHelper is gone, this file only contains some
  *  internal material utility functions.

--- a/Source/ThirdParty/Assimp/code/MemoryIOWrapper.h
+++ b/Source/ThirdParty/Assimp/code/MemoryIOWrapper.h
@@ -38,8 +38,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------
 */
 
-// Modified by Lasse Oorni for Urho3D
-
 /** @file MemoryIOWrapper.h
  *  Handy IOStream/IOSystem implemetation to read directly from a memory buffer */
 #ifndef AI_MEMORYIOSTREAM_H_INC

--- a/Source/ThirdParty/Assimp/code/NDOLoader.h
+++ b/Source/ThirdParty/Assimp/code/NDOLoader.h
@@ -38,8 +38,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------
 */
 
-// Modified by Lasse Oorni for Urho3D
-
 /** @file NDOLoader.h
  *  Declaration of the Nendo importer class.
  */

--- a/Source/ThirdParty/Assimp/code/ObjFileData.h
+++ b/Source/ThirdParty/Assimp/code/ObjFileData.h
@@ -156,6 +156,7 @@ struct Material
     aiString textureEmissive;
     aiString textureBump;
     aiString textureNormal;
+    aiString textureReflection[6];
     aiString textureSpecularity;
     aiString textureOpacity;
     aiString textureDisp;
@@ -167,6 +168,13 @@ struct Material
         TextureEmissiveType,
         TextureBumpType,
         TextureNormalType,
+        TextureReflectionSphereType,
+        TextureReflectionCubeTopType,
+        TextureReflectionCubeBottomType,
+        TextureReflectionCubeFrontType,
+        TextureReflectionCubeBackType,
+        TextureReflectionCubeLeftType,
+        TextureReflectionCubeRightType,
         TextureSpecularityType,
         TextureOpacityType,
         TextureDispType,
@@ -234,7 +242,7 @@ struct Mesh {
     bool m_hasNormals;
 
     /// Constructor
-    Mesh( const std::string &name ) 
+    explicit Mesh( const std::string &name ) 
     : m_name( name )
     , m_pMaterial(NULL)
     , m_uiNumIndices(0)

--- a/Source/ThirdParty/Assimp/code/ObjFileImporter.cpp
+++ b/Source/ThirdParty/Assimp/code/ObjFileImporter.cpp
@@ -138,7 +138,7 @@ void ObjFileImporter::InternReadFile( const std::string& pFile, aiScene* pScene,
     if ( pos != std::string::npos ) {
         modelName = pFile.substr(pos+1, pFile.size() - pos - 1);
         folderName = pFile.substr( 0, pos );
-        if ( folderName.empty() ) {
+        if ( !folderName.empty() ) {
             pIOHandler->PushDirectory( folderName );
         }
     } else {
@@ -634,6 +634,22 @@ void ObjFileImporter::createMaterials(const ObjFile::Model* pModel, aiScene* pSc
             {
                 addTextureMappingModeProperty(mat, aiTextureType_NORMALS);
             }
+        }
+
+        if( 0 != pCurrentMaterial->textureReflection[0].length )
+        {
+            ObjFile::Material::TextureType type = 0 != pCurrentMaterial->textureReflection[1].length ?
+                ObjFile::Material::TextureReflectionCubeTopType :
+                ObjFile::Material::TextureReflectionSphereType;
+
+            unsigned count = type == ObjFile::Material::TextureReflectionSphereType ? 1 : 6;
+            for( unsigned i = 0; i < count; i++ )
+                mat->AddProperty(&pCurrentMaterial->textureReflection[i], AI_MATKEY_TEXTURE_REFLECTION(i));
+
+            if(pCurrentMaterial->clamp[type])
+                //TODO addTextureMappingModeProperty should accept an index to handle clamp option for each
+                //texture of a cubemap
+                addTextureMappingModeProperty(mat, aiTextureType_REFLECTION);
         }
 
         if ( 0 != pCurrentMaterial->textureDisp.length )

--- a/Source/ThirdParty/Assimp/code/ObjFileMtlImporter.cpp
+++ b/Source/ThirdParty/Assimp/code/ObjFileMtlImporter.cpp
@@ -64,6 +64,7 @@ static const std::string BumpTexture1        = "map_bump";
 static const std::string BumpTexture2        = "map_Bump";
 static const std::string BumpTexture3        = "bump";
 static const std::string NormalTexture       = "map_Kn";
+static const std::string ReflectionTexture   = "refl";
 static const std::string DisplacementTexture = "disp";
 static const std::string SpecularityTexture  = "map_ns";
 
@@ -200,6 +201,7 @@ void ObjFileMtlImporter::load()
 
         case 'm':   // Texture
         case 'b':   // quick'n'dirty - for 'bump' sections
+        case 'r':   // quick'n'dirty - for 'refl' sections
             {
                 getTexture();
                 m_DataIt = skipLine<DataArrayIt>( m_DataIt, m_DataItEnd, m_uiLine );
@@ -332,6 +334,9 @@ void ObjFileMtlImporter::getTexture() {
         // Normal map
         out = & m_pModel->m_pCurrentMaterial->textureNormal;
         clampIndex = ObjFile::Material::TextureNormalType;
+    } else if(!ASSIMP_strincmp( pPtr, ReflectionTexture.c_str(), ReflectionTexture.size() ) ) {
+        // Reflection texture(s)
+        //Do nothing here
     } else if (!ASSIMP_strincmp( pPtr, DisplacementTexture.c_str(), DisplacementTexture.size() ) ) {
         // Displacement texture
         out = &m_pModel->m_pCurrentMaterial->textureDisp;
@@ -346,7 +351,7 @@ void ObjFileMtlImporter::getTexture() {
     }
 
     bool clamp = false;
-    getTextureOption(clamp);
+    getTextureOption(clamp, clampIndex, out);
     m_pModel->m_pCurrentMaterial->clamp[clampIndex] = clamp;
 
     std::string texture;
@@ -369,7 +374,7 @@ void ObjFileMtlImporter::getTexture() {
  * Because aiMaterial supports clamp option, so we also want to return it
  * /////////////////////////////////////////////////////////////////////////////
  */
-void ObjFileMtlImporter::getTextureOption(bool &clamp)
+void ObjFileMtlImporter::getTextureOption(bool &clamp, int &clampIndex, aiString *&out)
 {
     m_DataIt = getNextToken<DataArrayIt>(m_DataIt, m_DataItEnd);
 
@@ -392,13 +397,55 @@ void ObjFileMtlImporter::getTextureOption(bool &clamp)
 
             skipToken = 2;
         }
-        else if (  !ASSIMP_strincmp(pPtr, BlendUOption.c_str(), BlendUOption.size())
+        else if( !ASSIMP_strincmp( pPtr, TypeOption.c_str(), TypeOption.size() ) )
+        {
+            DataArrayIt it = getNextToken<DataArrayIt>( m_DataIt, m_DataItEnd );
+            char value[ 12 ];
+            CopyNextWord( it, m_DataItEnd, value, sizeof( value ) / sizeof( *value ) );
+            if( !ASSIMP_strincmp( value, "cube_top", 8 ) )
+            {
+                clampIndex = ObjFile::Material::TextureReflectionCubeTopType;
+                out = &m_pModel->m_pCurrentMaterial->textureReflection[0];
+            }
+            else if( !ASSIMP_strincmp( value, "cube_bottom", 11 ) )
+            {
+                clampIndex = ObjFile::Material::TextureReflectionCubeBottomType;
+                out = &m_pModel->m_pCurrentMaterial->textureReflection[1];
+            }
+            else if( !ASSIMP_strincmp( value, "cube_front", 10 ) )
+            {
+                clampIndex = ObjFile::Material::TextureReflectionCubeFrontType;
+                out = &m_pModel->m_pCurrentMaterial->textureReflection[2];
+            }
+            else if( !ASSIMP_strincmp( value, "cube_back", 9 ) )
+            {
+                clampIndex = ObjFile::Material::TextureReflectionCubeBackType;
+                out = &m_pModel->m_pCurrentMaterial->textureReflection[3];
+            }
+            else if( !ASSIMP_strincmp( value, "cube_left", 9 ) )
+            {
+                clampIndex = ObjFile::Material::TextureReflectionCubeLeftType;
+                out = &m_pModel->m_pCurrentMaterial->textureReflection[4];
+            }
+            else if( !ASSIMP_strincmp( value, "cube_right", 10 ) )
+            {
+                clampIndex = ObjFile::Material::TextureReflectionCubeRightType;
+                out = &m_pModel->m_pCurrentMaterial->textureReflection[5];
+            }
+            else if( !ASSIMP_strincmp( value, "sphere", 6 ) )
+            {
+                clampIndex = ObjFile::Material::TextureReflectionSphereType;
+                out = &m_pModel->m_pCurrentMaterial->textureReflection[0];
+            }
+
+            skipToken = 2;
+        }
+        else if (!ASSIMP_strincmp(pPtr, BlendUOption.c_str(), BlendUOption.size())
                 || !ASSIMP_strincmp(pPtr, BlendVOption.c_str(), BlendVOption.size())
                 || !ASSIMP_strincmp(pPtr, BoostOption.c_str(), BoostOption.size())
                 || !ASSIMP_strincmp(pPtr, ResolutionOption.c_str(), ResolutionOption.size())
                 || !ASSIMP_strincmp(pPtr, BumpOption.c_str(), BumpOption.size())
-                || !ASSIMP_strincmp(pPtr, ChannelOption.c_str(), ChannelOption.size())
-                || !ASSIMP_strincmp(pPtr, TypeOption.c_str(), TypeOption.size()) )
+                || !ASSIMP_strincmp(pPtr, ChannelOption.c_str(), ChannelOption.size()))
         {
             skipToken = 2;
         }

--- a/Source/ThirdParty/Assimp/code/ObjFileMtlImporter.h
+++ b/Source/ThirdParty/Assimp/code/ObjFileMtlImporter.h
@@ -43,6 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 
 struct aiColor3D;
+struct aiString;
 
 namespace Assimp {
 
@@ -89,7 +90,7 @@ private:
     void createMaterial();
     /// Get texture name from loaded data.
     void getTexture();
-    void getTextureOption(bool &clamp);
+    void getTextureOption(bool &clamp, int &clampIndex, aiString *&out);
 
 private:
     //! Absolute pathname

--- a/Source/ThirdParty/Assimp/code/ObjFileParser.cpp
+++ b/Source/ThirdParty/Assimp/code/ObjFileParser.cpp
@@ -414,7 +414,7 @@ void ObjFileParser::getFace(aiPrimitiveType type)
 
     if ( pIndices->empty() ) {
         DefaultLogger::get()->error("Obj: Ignoring empty face");
-        // skip line and clean up 
+        // skip line and clean up
         m_DataIt = skipLine<DataArrayIt>( m_DataIt, m_DataItEnd, m_uiLine );
         delete pNormalID;
         delete pTexID;
@@ -539,7 +539,10 @@ void ObjFileParser::getMaterialLib()
     const std::string strMatName(pStart, &(*m_DataIt));
     std::string absName;
     if ( m_pIO->StackSize() > 0 ) {
-        const std::string &path = m_pIO->CurrentDirectory();
+        std::string path = m_pIO->CurrentDirectory();
+        if ( '/' != *path.rbegin() ) {
+          path += '/';
+        }
         absName = path + strMatName;
     } else {
         absName = strMatName;

--- a/Source/ThirdParty/Assimp/code/OgreParsingUtils.h
+++ b/Source/ThirdParty/Assimp/code/OgreParsingUtils.h
@@ -38,8 +38,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------
 */
 
-// Modified by Lasse Oorni for Urho3D
-
 #ifndef AI_OGREPARSINGUTILS_H_INC
 #define AI_OGREPARSINGUTILS_H_INC
 

--- a/Source/ThirdParty/Assimp/code/OgreStructs.h
+++ b/Source/ThirdParty/Assimp/code/OgreStructs.h
@@ -381,8 +381,8 @@ typedef std::vector<VertexAnimationTrack> VertexAnimationTrackList;
 class Animation
 {
 public:
-    Animation(Skeleton *parent);
-    Animation(Mesh *parent);
+    explicit Animation(Skeleton *parent);
+    explicit Animation(Mesh *parent);
 
     /// Returns the associated vertex data for a track in this animation.
     /** @note Only valid to call when parent Mesh is set. */

--- a/Source/ThirdParty/Assimp/code/OgreXmlSerializer.h
+++ b/Source/ThirdParty/Assimp/code/OgreXmlSerializer.h
@@ -69,7 +69,7 @@ public:
     static bool ImportSkeleton(Assimp::IOSystem *pIOHandler, Mesh *mesh);
 
 private:
-    OgreXmlSerializer(XmlReader *reader) :
+    explicit OgreXmlSerializer(XmlReader *reader) :
         m_reader(reader)
     {
     }

--- a/Source/ThirdParty/Assimp/code/PlyParser.cpp
+++ b/Source/ThirdParty/Assimp/code/PlyParser.cpp
@@ -857,7 +857,7 @@ bool PLY::PropertyInstance::ParseValueBinary(
 
     case EDT_UShort:
         {
-        int16_t i = *((uint16_t*)pCur);
+        uint16_t i = *((uint16_t*)pCur);
 
         // Swap endianess
         if (p_bBE)ByteSwap::Swap(&i);

--- a/Source/ThirdParty/Assimp/code/Q3BSPFileImporter.cpp
+++ b/Source/ThirdParty/Assimp/code/Q3BSPFileImporter.cpp
@@ -325,7 +325,7 @@ void Q3BSPFileImporter::CreateNodes( const Q3BSP::Q3BSPModel *pModel, aiScene* p
         matIdx++;
     }
 
-    pScene->mNumMeshes = MeshArray.size();
+    pScene->mNumMeshes = static_cast<unsigned int>( MeshArray.size() );
     if ( pScene->mNumMeshes > 0 )
     {
         pScene->mMeshes = new aiMesh*[ pScene->mNumMeshes ];

--- a/Source/ThirdParty/Assimp/code/Q3BSPZipArchive.h
+++ b/Source/ThirdParty/Assimp/code/Q3BSPZipArchive.h
@@ -90,7 +90,7 @@ class ZipFile : public IOStream {
 
     public:
 
-        ZipFile(size_t size);
+        explicit ZipFile(size_t size);
 
         ~ZipFile();
 

--- a/Source/ThirdParty/Assimp/code/Q3DLoader.h
+++ b/Source/ThirdParty/Assimp/code/Q3DLoader.h
@@ -38,8 +38,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------
 */
 
-// Modified by Lasse Oorni for Urho3D
-
 /** @file  Q3DLoader.h
  *  @brief Declaration of the Q3D importer class.
  */
@@ -110,7 +108,7 @@ private:
 
     struct Face
     {
-        Face(unsigned int s)
+        explicit Face(unsigned int s)
             :   indices   (s)
             ,   uvindices (s)
             ,   mat       (0)

--- a/Source/ThirdParty/Assimp/code/RawLoader.h
+++ b/Source/ThirdParty/Assimp/code/RawLoader.h
@@ -88,7 +88,7 @@ private:
 
     struct MeshInformation
     {
-        MeshInformation(const std::string& _name)
+        explicit MeshInformation(const std::string& _name)
             : name(_name)
         {
             vertices.reserve(100);
@@ -103,7 +103,7 @@ private:
 
     struct GroupInformation
     {
-        GroupInformation(const std::string& _name)
+        explicit GroupInformation(const std::string& _name)
             : name(_name)
         {
             meshes.reserve(10);

--- a/Source/ThirdParty/Assimp/code/SGSpatialSort.h
+++ b/Source/ThirdParty/Assimp/code/SGSpatialSort.h
@@ -38,8 +38,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------
 */
 
-// Modified by Lasse Oorni for Urho3D
-
 /** Small helper classes to optimise finding vertizes close to a given location
  */
 #ifndef AI_D3DSSPATIALSORT_H_INC
@@ -73,7 +71,7 @@ public:
     /** Construction from a given face array, handling smoothing groups
      *  properly
      */
-    SGSpatialSort(const std::vector<aiVector3D>& vPositions);
+    explicit SGSpatialSort(const std::vector<aiVector3D>& vPositions);
 
     // -------------------------------------------------------------------
     /** Add a vertex to the spatial sort

--- a/Source/ThirdParty/Assimp/code/STLLoader.cpp
+++ b/Source/ThirdParty/Assimp/code/STLLoader.cpp
@@ -74,7 +74,7 @@ static const aiImporterDesc desc = {
 // 1) 80 byte header
 // 2) 4 byte face count
 // 3) 50 bytes per face
-bool IsBinarySTL(const char* buffer, unsigned int fileSize) {
+static bool IsBinarySTL(const char* buffer, unsigned int fileSize) {
     if( fileSize < 84 ) {
         return false;
     }
@@ -88,7 +88,7 @@ bool IsBinarySTL(const char* buffer, unsigned int fileSize) {
 // An ascii STL buffer will begin with "solid NAME", where NAME is optional.
 // Note: The "solid NAME" check is necessary, but not sufficient, to determine
 // if the buffer is ASCII; a binary header could also begin with "solid NAME".
-bool IsAsciiSTL(const char* buffer, unsigned int fileSize) {
+static bool IsAsciiSTL(const char* buffer, unsigned int fileSize) {
     if (IsBinarySTL(buffer, fileSize))
         return false;
 

--- a/Source/ThirdParty/Assimp/code/SceneCombiner.h
+++ b/Source/ThirdParty/Assimp/code/SceneCombiner.h
@@ -38,8 +38,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------
 */
 
-// Modified by Lasse Oorni for Urho3D
-
 /** @file Declares a helper class, "SceneCombiner" providing various
  *  utilities to merge scenes.
  */
@@ -58,6 +56,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #else
 #include "../include/assimp/Compiler/pstdint.h"
 #endif
+//#include "../include/assimp/Compiler/pstdint.h"
 
 #include <vector>
 
@@ -172,7 +171,7 @@ struct SceneHelper
         id[0] = 0;
     }
 
-    SceneHelper (aiScene* _scene)
+    explicit SceneHelper (aiScene* _scene)
         : scene     (_scene)
         , idlen     (0)
     {

--- a/Source/ThirdParty/Assimp/code/SmoothingGroups.h
+++ b/Source/ThirdParty/Assimp/code/SmoothingGroups.h
@@ -38,8 +38,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------
 */
 
-// Modified by Lasse Oorni for Urho3D
-
 /** @file Defines the helper data structures for importing 3DS files.
 http://www.jalix.org/ressources/graphics/3DS/_unofficials/3ds-unofficial.txt */
 

--- a/Source/ThirdParty/Assimp/code/StdOStreamLogStream.h
+++ b/Source/ThirdParty/Assimp/code/StdOStreamLogStream.h
@@ -16,7 +16,7 @@ public:
     /** @brief  Construction from an existing std::ostream
      *  @param _ostream Output stream to be used
     */
-    StdOStreamLogStream(std::ostream& _ostream);
+    explicit StdOStreamLogStream(std::ostream& _ostream);
 
     /** @brief  Destructor  */
     ~StdOStreamLogStream();

--- a/Source/ThirdParty/Assimp/code/StringComparison.h
+++ b/Source/ThirdParty/Assimp/code/StringComparison.h
@@ -38,8 +38,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------
 */
 
-// Modified by Lasse Oorni for Urho3D
-
 /** @file Definition of platform independent string workers:
 
    ASSIMP_itoa10

--- a/Source/ThirdParty/Assimp/code/TinyFormatter.h
+++ b/Source/ThirdParty/Assimp/code/TinyFormatter.h
@@ -97,7 +97,7 @@ public:
     // being bound to const ref& function parameters. Copying streams is not permitted, though.
     // This workaround avoids this by manually specifying a copy ctor.
 #if !defined(__GNUC__) || !defined(__APPLE__) || __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
-    basic_formatter(const basic_formatter& other) {
+    explicit basic_formatter(const basic_formatter& other) {
         underlying << (string)other;
     }
 #endif

--- a/Source/ThirdParty/Assimp/code/UnrealLoader.h
+++ b/Source/ThirdParty/Assimp/code/UnrealLoader.h
@@ -38,8 +38,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------
 */
 
-// Modified by Lasse Oorni for Urho3D
-
 /** @file  UnrealLoader.h
  *  @brief Declaration of the .3d (UNREAL) importer class.
  */
@@ -94,7 +92,7 @@ struct TempMat  {
         ,   numFaces    (0)
     {}
 
-    TempMat(const Triangle& in)
+    explicit TempMat(const Triangle& in)
         :   type        ((Unreal::MeshFlags)in.mType)
         ,   tex         (in.mTextureNum)
         ,   numFaces    (0)

--- a/Source/ThirdParty/Assimp/code/Version.cpp
+++ b/Source/ThirdParty/Assimp/code/Version.cpp
@@ -6,7 +6,7 @@
 #include "ScenePrivate.h"
 
 static const unsigned int MajorVersion = 3;
-static const unsigned int MinorVersion = 1;
+static const unsigned int MinorVersion = 2;
 
 // --------------------------------------------------------------------------------
 // Legal information string - dont't remove this.

--- a/Source/ThirdParty/Assimp/code/XFileHelper.h
+++ b/Source/ThirdParty/Assimp/code/XFileHelper.h
@@ -38,7 +38,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------
 */
 
-// Modified by Lasse Oorni for Urho3D
 
 /** @file Defines the helper data structures for importing XFiles */
 #ifndef AI_XFILEHELPER_H_INC
@@ -135,7 +134,7 @@ struct Mesh
 
     std::vector<Bone> mBones;
 
-    Mesh(const std::string &pName = "") { mName = pName; mNumTextures = 0; mNumColorSets = 0; }
+    explicit Mesh(const std::string &pName = "") { mName = pName; mNumTextures = 0; mNumColorSets = 0; }
 };
 
 /** Helper structure to represent a XFile frame */
@@ -148,7 +147,7 @@ struct Node
     std::vector<Mesh*> mMeshes;
 
     Node() { mParent = NULL; }
-    Node( Node* pParent) { mParent = pParent; }
+    explicit Node( Node* pParent) { mParent = pParent; }
     ~Node()
     {
         for( unsigned int a = 0; a < mChildren.size(); a++)

--- a/Source/ThirdParty/Assimp/code/XFileParser.h
+++ b/Source/ThirdParty/Assimp/code/XFileParser.h
@@ -68,7 +68,7 @@ public:
     /** Constructor. Creates a data structure out of the XFile given in the memory block.
      * @param pBuffer Null-terminated memory buffer containing the XFile
      */
-    XFileParser( const std::vector<char>& pBuffer);
+    explicit XFileParser( const std::vector<char>& pBuffer);
 
     /** Destructor. Destroys all imported data along with it */
     ~XFileParser();

--- a/Source/ThirdParty/Assimp/code/fast_atof.h
+++ b/Source/ThirdParty/Assimp/code/fast_atof.h
@@ -26,7 +26,6 @@
 #else
 #include "../include/assimp/Compiler/pstdint.h"
 #endif
-
 #include <stdexcept>
 
 #include "StringComparison.h"

--- a/Source/ThirdParty/Assimp/code/irrXMLWrapper.h
+++ b/Source/ThirdParty/Assimp/code/irrXMLWrapper.h
@@ -76,7 +76,7 @@ public:
 
     // ----------------------------------------------------------------------------------
     //! Construction from an existing IOStream
-    CIrrXML_IOStreamReader(IOStream* _stream)
+    explicit CIrrXML_IOStreamReader(IOStream* _stream)
         : stream (_stream)
         , t (0)
     {

--- a/Source/ThirdParty/Assimp/code/qnan.h
+++ b/Source/ThirdParty/Assimp/code/qnan.h
@@ -39,8 +39,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---------------------------------------------------------------------------
 */
 
-// Modified by Lasse Oorni for Urho3D
-
 /**  @file  qnan.h
  *   @brief Some utilities for our dealings with qnans.
  *

--- a/Source/ThirdParty/Assimp/contrib/openddlparser/code/DDLNode.cpp
+++ b/Source/ThirdParty/Assimp/contrib/openddlparser/code/DDLNode.cpp
@@ -49,11 +49,7 @@ static void releaseReferencedNames( Reference *ref ) {
         return;
     }
 
-    if( ref->m_referencedName ) {
-        for( size_t i = 0; i < ref->m_numRefs; i++ ) {
-            delete ref->m_referencedName;
-        }
-    }
+    delete ref;
 }
 
 DDLNode::DDLNode( const std::string &type, const std::string &name, size_t idx, DDLNode *parent )
@@ -121,7 +117,6 @@ const std::string &DDLNode::getType() const {
     return m_type;
 }
 
-
 void DDLNode::setName( const std::string &name ) {
     m_name = name;
 }
@@ -143,6 +138,10 @@ bool DDLNode::hasProperty( const std::string &name ) {
     return ( ddl_nullptr != prop );
 }
 
+bool DDLNode::hasProperties() const {
+    return( ddl_nullptr != m_properties );
+}
+
 Property *DDLNode::findPropertyByName( const std::string &name ) {
     if( name.empty() ) {
         return ddl_nullptr;
@@ -151,6 +150,7 @@ Property *DDLNode::findPropertyByName( const std::string &name ) {
     if( ddl_nullptr == m_properties ) {
         return ddl_nullptr;
     }
+
     Property *current( m_properties );
     while( ddl_nullptr != current ) {
         int res = strncmp( current->m_key->m_text.m_buffer, name.c_str(), name.size() );

--- a/Source/ThirdParty/Assimp/contrib/openddlparser/code/OpenDDLCommon.cpp
+++ b/Source/ThirdParty/Assimp/contrib/openddlparser/code/OpenDDLCommon.cpp
@@ -1,0 +1,168 @@
+/*-----------------------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2014-2015 Kim Kulling
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+-----------------------------------------------------------------------------------------------*/
+#include <openddlparser/OpenDDLCommon.h>
+#include <openddlparser/DDLNode.h>
+
+BEGIN_ODDLPARSER_NS
+
+Text::Text( const char *buffer, size_t numChars )
+: m_capacity( 0 )
+, m_len( 0 )
+, m_buffer( ddl_nullptr ) {
+    set( buffer, numChars );
+}
+
+Text::~Text() {
+    clear();
+}
+
+void Text::clear() {
+    delete[] m_buffer;
+    m_buffer = ddl_nullptr;
+    m_capacity = 0;
+    m_len = 0;
+}
+
+void Text::set( const char *buffer, size_t numChars ) {
+    clear();
+    if( numChars > 0 ) {
+        m_len = numChars;
+        m_capacity = m_len + 1;
+        m_buffer = new char[ m_capacity ];
+        strncpy( m_buffer, buffer, numChars );
+        m_buffer[ numChars ] = '\0';
+    }
+}
+
+bool Text::operator == ( const std::string &name ) const {
+    if( m_len != name.size() ) {
+        return false;
+    }
+    const int res( strncmp( m_buffer, name.c_str(), name.size() ) );
+
+    return ( 0 == res );
+}
+
+bool Text::operator == ( const Text &rhs ) const {
+    if( m_len != rhs.m_len ) {
+        return false;
+    }
+
+    const int res( strncmp( m_buffer, rhs.m_buffer, m_len ) );
+
+    return ( 0 == res );
+}
+
+Identifier::Identifier( const char buffer[], size_t len )
+: m_text( buffer, len ) {
+    // empty
+}
+
+Identifier::Identifier( const char buffer[] )
+: m_text( buffer, strlen( buffer ) ) {
+    // empty
+}
+
+Identifier::~Identifier() {
+    // empty
+}
+
+bool Identifier::operator == ( const Identifier &rhs ) const {
+    return m_text == rhs.m_text;
+}
+
+Name::Name( NameType type, Identifier *id )
+: m_type( type )
+, m_id( id ) {
+    // empty
+}
+
+Name::~Name() {
+    m_id = ddl_nullptr;
+}
+
+Reference::Reference()
+: m_numRefs( 0 )
+, m_referencedName( ddl_nullptr ) {
+    // empty
+}
+
+Reference::Reference( size_t numrefs, Name **names )
+: m_numRefs( numrefs )
+, m_referencedName( ddl_nullptr ) {
+    m_referencedName = new Name *[ numrefs ];
+    for( size_t i = 0; i < numrefs; i++ ) {
+        Name *name = new Name( names[ i ]->m_type, names[ i ]->m_id );
+        m_referencedName[ i ] = name;
+    }
+}
+
+Reference::~Reference() {
+    for( size_t i = 0; i < m_numRefs; i++ ) {
+        delete m_referencedName[ i ];
+    }
+    m_numRefs = 0;
+    m_referencedName = ddl_nullptr;
+}
+
+Property::Property( Identifier *id )
+: m_key( id )
+, m_value( ddl_nullptr )
+, m_ref( ddl_nullptr )
+, m_next( ddl_nullptr ) {
+    // empty
+}
+
+Property::~Property() {
+    m_key = ddl_nullptr;
+    m_value = ddl_nullptr;
+    m_ref = ddl_nullptr;;
+    m_next = ddl_nullptr;;
+}
+
+DataArrayList::DataArrayList()
+: m_numItems( 0 )
+, m_dataList( ddl_nullptr )
+, m_next( ddl_nullptr ) {
+    // empty
+}
+
+DataArrayList::~DataArrayList() {
+    // empty
+}
+
+Context::Context()
+: m_root( ddl_nullptr ) {
+    // empty
+}
+
+Context::~Context() {
+    m_root = ddl_nullptr;
+}
+
+void Context::clear() {
+    delete m_root;
+    m_root = ddl_nullptr;
+}
+
+END_ODDLPARSER_NS

--- a/Source/ThirdParty/Assimp/contrib/openddlparser/code/OpenDDLExport.cpp
+++ b/Source/ThirdParty/Assimp/contrib/openddlparser/code/OpenDDLExport.cpp
@@ -1,0 +1,412 @@
+/*-----------------------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2014-2015 Kim Kulling
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+-----------------------------------------------------------------------------------------------*/
+#include <openddlparser/OpenDDLExport.h>
+#include <openddlparser/DDLNode.h>
+#include <openddlparser/Value.h>
+#include <openddlparser/OpenDDLParser.h>
+
+#include <sstream>
+
+BEGIN_ODDLPARSER_NS
+
+IOStreamBase::IOStreamBase()
+: m_file( ddl_nullptr ) {
+    // empty
+}
+IOStreamBase::~IOStreamBase() {
+    // empty
+}
+
+bool IOStreamBase::open( const std::string &name ) {
+    m_file = ::fopen( name.c_str(), "a" );
+    if (m_file == ddl_nullptr) {
+        return false;
+    }
+    
+    return true;
+}
+
+bool IOStreamBase::close() {
+    if (ddl_nullptr == m_file) {
+        return false;
+    }
+
+    ::fclose( m_file );
+    m_file = ddl_nullptr;
+
+    return true;
+}
+
+void IOStreamBase::write( const std::string &statement ) {
+    if (ddl_nullptr == m_file) {
+        return;
+    }
+
+    ::fwrite( statement.c_str(), sizeof( char ), statement.size(), m_file );
+}
+
+struct DDLNodeIterator {
+    const DDLNode::DllNodeList &m_childs;
+    size_t m_idx;
+
+    DDLNodeIterator( const DDLNode::DllNodeList &childs ) 
+    : m_childs( childs )
+    , m_idx( 0 ) {
+        // empty
+    }
+
+    ~DDLNodeIterator() {
+        // empty
+    }
+
+    bool getNext( DDLNode **node ) {
+        if( m_childs.size() > (m_idx+1) ) {
+            m_idx++;
+            *node = m_childs[ m_idx ];
+            return true;
+        }
+
+        return false;
+    }
+};
+
+static void writeLineEnd( std::string &statement ) {
+    statement += "\n";
+}
+
+OpenDDLExport::OpenDDLExport( IOStreamBase *stream )
+: m_stream( stream ) {
+    if (ddl_nullptr == m_stream) {
+        m_stream = new IOStreamBase();
+    }
+}
+
+OpenDDLExport::~OpenDDLExport() {
+    if (ddl_nullptr != m_stream) {
+        m_stream->close();
+    }
+    delete m_stream;
+}
+
+bool OpenDDLExport::exportContext( Context *ctx, const std::string &filename ) {
+    if( ddl_nullptr == ctx ) {
+        return false;
+    }
+
+    DDLNode *root( ctx->m_root );
+    if ( ddl_nullptr == root ) {
+        return true;
+    }
+
+    if (!filename.empty()) {
+        if (!m_stream->open( filename )) {
+            return false;
+        }
+    }
+
+    const bool retValue( handleNode( root ) );
+    
+    return retValue;
+}
+
+bool OpenDDLExport::handleNode( DDLNode *node ) {
+    if( ddl_nullptr == node ) {
+        return true;
+    }
+
+    const DDLNode::DllNodeList &childs = node->getChildNodeList();
+    if( childs.empty() ) {
+        return true;
+    }
+    DDLNode *current( ddl_nullptr );
+    DDLNodeIterator it( childs );
+    std::string statement;
+    bool success( true );
+    while( it.getNext( &current ) ) {
+        if( ddl_nullptr != current ) {
+            success |= writeNode( current, statement );
+            if( !handleNode( current ) ) {
+                success = false;
+            }
+        }
+    }
+
+    return success;
+}
+
+bool OpenDDLExport::writeToStream( const std::string &statement ) {
+    if (ddl_nullptr == m_stream ) {
+        return false;
+    }
+
+    if ( !statement.empty()) {
+        m_stream->write( statement );
+    }
+
+    return true;
+}
+
+bool OpenDDLExport::writeNode( DDLNode *node, std::string &statement ) {
+    bool success( true );
+    writeNodeHeader( node, statement );
+    if (node->hasProperties()) {
+        success |= writeProperties( node, statement );
+    }
+    writeLineEnd( statement );
+
+    statement = "}";
+    DataArrayList *al( node->getDataArrayList() );
+    if ( ddl_nullptr != al ) {
+        writeValueType( al->m_dataList->m_type, al->m_numItems, statement );
+        writeValueArray( al, statement );
+    }
+    Value *v( node->getValue() );
+    if (ddl_nullptr != v ) {
+        writeValueType( v->m_type, 1, statement );
+        statement = "{";
+        writeLineEnd( statement );
+        writeValue( v, statement );
+        statement = "}";
+        writeLineEnd( statement );
+    }
+    statement = "}";
+    writeLineEnd( statement );
+
+    writeToStream( statement );
+
+    return true;
+}
+
+bool OpenDDLExport::writeNodeHeader( DDLNode *node, std::string &statement ) {
+    if (ddl_nullptr == node) {
+        return false;
+    }
+
+    statement += node->getType();
+    const std::string &name( node->getName() );
+    if ( !name.empty() ) {
+        statement += " ";
+        statement += "$";
+        statement += name;
+    }
+
+    return true;
+}
+
+bool OpenDDLExport::writeProperties( DDLNode *node, std::string &statement ) {
+    if ( ddl_nullptr == node ) {
+        return false;
+    }
+
+    Property *prop( node->getProperties() );
+    // if no properties are there, return
+    if ( ddl_nullptr == prop ) {
+        return true;
+    }
+
+    if ( ddl_nullptr != prop ) {
+        // for instance (attrib = "position", bla=2)
+        statement += "(";
+        bool first( true );
+        while ( ddl_nullptr != prop ) {
+            if (!first) {
+                statement += ", ";
+            } else {
+                first = false;
+            }
+            statement += std::string( prop->m_key->m_text.m_buffer );
+            statement += " = ";
+            writeValue( prop->m_value, statement );
+            prop = prop->m_next;
+        }
+
+        statement += ")";
+    }
+
+    return true;
+}
+
+bool OpenDDLExport::writeValueType( Value::ValueType type, size_t numItems, std::string &statement ) {
+    if ( Value::ddl_types_max == type) {
+        return false;
+    }
+
+    const std::string typeStr( getTypeToken( type ) );
+    statement += typeStr;
+    // if we have an array to write
+    if ( numItems > 1 ) {
+        statement += "[";
+        char buffer[ 256 ];
+        ::memset( buffer, '\0', 256 * sizeof( char ) );
+        sprintf( buffer, "%d", numItems );
+        statement += buffer;
+        statement += "]";
+    }
+
+    return true;
+}
+
+bool OpenDDLExport::writeValue( Value *val, std::string &statement ) {
+    if (ddl_nullptr == val) {
+        return false;
+    }
+
+    switch ( val->m_type ) {
+        case Value::ddl_bool:
+            if ( true == val->getBool() ) {
+                statement += "true";
+            } else {
+                statement += "false";
+            }
+            break;
+        case Value::ddl_int8: 
+            {
+                std::stringstream stream;
+                const int i = static_cast<int>( val->getInt8() );
+                stream << i;
+                statement += stream.str();
+            }
+            break;
+        case Value::ddl_int16:
+            {
+                std::stringstream stream;
+                char buffer[ 256 ];
+                ::memset( buffer, '\0', 256 * sizeof( char ) );
+                sprintf( buffer, "%d", val->getInt16() );
+                statement += buffer;
+        }
+            break;
+        case Value::ddl_int32:
+            {
+                std::stringstream stream;
+                char buffer[ 256 ];
+                ::memset( buffer, '\0', 256 * sizeof( char ) );
+                const int i = static_cast< int >( val->getInt32() );
+                sprintf( buffer, "%d", i );
+                statement += buffer;
+            }
+            break;
+        case Value::ddl_int64:
+            {
+                std::stringstream stream;
+                const int i = static_cast< int >( val->getInt64() );
+                stream << i;
+                statement += stream.str();
+        }
+            break;
+        case Value::ddl_unsigned_int8:
+            {
+                std::stringstream stream;
+                const int i = static_cast< unsigned int >( val->getUnsignedInt8() );
+                stream << i;
+                statement += stream.str();
+            }
+            break;
+        case Value::ddl_unsigned_int16:
+            {
+                std::stringstream stream;
+                const int i = static_cast< unsigned int >( val->getUnsignedInt16() );
+                stream << i;
+                statement += stream.str();
+            }
+            break;
+        case Value::ddl_unsigned_int32:
+            {
+                std::stringstream stream;
+                const int i = static_cast< unsigned int >( val->getUnsignedInt32() );
+                stream << i;
+                statement += stream.str();
+            }
+            break;
+        case Value::ddl_unsigned_int64:
+            {
+                std::stringstream stream;
+                const int i = static_cast< unsigned int >( val->getUnsignedInt64() );
+                stream << i;
+                statement += stream.str();
+            }
+            break;
+        case Value::ddl_half:
+            break;
+        case Value::ddl_float:
+            {
+                std::stringstream stream;
+                stream << val->getFloat();
+                statement += stream.str();
+            }
+            break;
+        case Value::ddl_double:
+            break;
+        case Value::ddl_string:
+            {
+                std::stringstream stream;
+                stream << val->getString();
+                statement += "\"";
+                statement += stream.str();
+                statement += "\"";
+             }
+            break;
+        case Value::ddl_ref:
+            break;
+        case Value::ddl_none:
+        case Value::ddl_types_max:
+        default:
+            break;
+    }
+
+    return true;
+}
+
+bool OpenDDLExport::writeValueArray( DataArrayList *al, std::string &statement ) {
+    if (ddl_nullptr == al) {
+        return false;
+    }
+
+    if (0 == al->m_numItems) {
+        return true;
+    }
+
+    DataArrayList *nextDataArrayList = al ;
+    Value *nextValue( nextDataArrayList->m_dataList );
+    while (ddl_nullptr != nextDataArrayList) {
+        if (ddl_nullptr != nextDataArrayList) {
+            statement += "{ ";
+            nextValue = nextDataArrayList->m_dataList;
+            size_t idx( 0 );
+            while (ddl_nullptr != nextValue) {
+                if (idx > 0) {
+                    statement += ", ";
+                }
+                writeValue( nextValue, statement );
+                nextValue = nextValue->m_next;
+                idx++;
+            }
+            statement += " }";
+        }
+        nextDataArrayList = nextDataArrayList->m_next;
+    }
+
+    return true;
+}
+
+END_ODDLPARSER_NS

--- a/Source/ThirdParty/Assimp/contrib/openddlparser/include/openddlparser/DDLNode.h
+++ b/Source/ThirdParty/Assimp/contrib/openddlparser/include/openddlparser/DDLNode.h
@@ -101,6 +101,10 @@ public:
     /// @return true, if a corresponding property is assigned to the node, false if not.
     bool hasProperty( const std::string &name );
 
+    ///	@brief  Will return true, if any properties are assigned to the node instance.
+    ///	@return True, if properties are assigned.
+    bool hasProperties() const;
+
     ///	@brief  Search for a given property and returns it. Will return ddl_nullptr if no property was found.
     /// @param  name    [in] The name for the property to look for.
     /// @return The property or ddl_nullptr if no property was found.

--- a/Source/ThirdParty/Assimp/contrib/openddlparser/include/openddlparser/OpenDDLCommon.h
+++ b/Source/ThirdParty/Assimp/contrib/openddlparser/include/openddlparser/OpenDDLCommon.h
@@ -20,15 +20,13 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -----------------------------------------------------------------------------------------------*/
-
-// Modified by Lasse Oorni for Urho3D
-
 #pragma once
 
 #include <cstddef>
 #include <vector>
 #include <string>
 
+#include <stdio.h>
 #include <string.h>
 #ifndef _WIN32
 #  include <inttypes.h>
@@ -62,10 +60,11 @@ BEGIN_ODDLPARSER_NS
     // All C++11 constructs
 #   define ddl_nullptr nullptr
 #else
-    // Fallback for older compilers
+    // Fall-back for older compilers
 #   define ddl_nullptr NULL
 #endif // OPENDDL_NO_USE_CPP11
 
+// Forward declarations
 class DDLNode;
 class Value;
 
@@ -75,6 +74,7 @@ struct Reference;
 struct Property;
 struct DataArrayList;
 
+// Platform-specific typedefs
 #ifdef _WIN32
 typedef signed __int64    int64_impl;
 typedef unsigned __int64  uint64_impl;
@@ -93,65 +93,36 @@ typedef unsigned short    uint16;  ///< Unsigned integer, 2 byte
 typedef unsigned int      uint32;  ///< Unsigned integer, 4 byte
 typedef uint64_impl       uint64;  ///< Unsigned integer, 8 byte
 
-///	@brief  Description of the type of a name.
-enum NameType {
-    GlobalName, ///< Name is global.
-    LocalName   ///< Name is local.
-};
+///	@brief  Stores a text.
+///
+/// A text is stored in a simple character buffer. Texts buffer can be 
+/// greater than the number of stored characters in them.
+struct DLL_ODDLPARSER_EXPORT Text {
+    size_t m_capacity;  ///< The capacity of the text.
+    size_t m_len;       ///< The length of the text.
+    char *m_buffer;     ///< The buffer with the text.
 
-///	@brief  Stores a text
-struct Text {
-    size_t m_capacity;
-    size_t m_len;
-    char *m_buffer;
+    ///	@brief  The constructor with a given text buffer.
+    /// @param  buffer      [in] The buffer.
+    /// @param  numChars    [in] The number of characters in the buffer.
+    Text( const char *buffer, size_t numChars );
 
-    Text( const char *buffer, size_t numChars )
-    : m_capacity( 0 )
-    , m_len( 0 )
-    , m_buffer( ddl_nullptr ) {
-        set( buffer, numChars );
-    }
+    ///	@brief  The destructor.
+    ~Text();
 
-    ~Text() {
-        clear();
-    }
+    ///	@brief  Clears the text.
+    void clear();
 
-    void clear() {
-        delete[] m_buffer;
-        m_buffer = ddl_nullptr;
-        m_capacity = 0;
-        m_len = 0;
-    }
+    ///	@brief  Set a new text.
+    /// @param  buffer      [in] The buffer.
+    /// @param  numChars    [in] The number of characters in the buffer.
+    void set( const char *buffer, size_t numChars );
 
-    void set( const char *buffer, size_t numChars ) {
-        clear();
-        if( numChars > 0 ) {
-            m_len = numChars;
-            m_capacity = m_len + 1;
-            m_buffer = new char[ m_capacity ];
-            strncpy( m_buffer, buffer, numChars );
-            m_buffer[ numChars ] = '\0';
-        }
-    }
+    ///	@brief  The compare operator for std::strings.
+    bool operator == ( const std::string &name ) const;
 
-    bool operator == ( const std::string &name ) const {
-        if( m_len != name.size() ) {
-            return false;
-        }
-        const int res( strncmp( m_buffer, name.c_str(), name.size() ) );
-        
-        return ( 0 == res );
-    }
-
-    bool operator == ( const Text &rhs ) const {
-        if( m_len != rhs.m_len ) {
-            return false;
-        }
-
-        const int res( strncmp( m_buffer, rhs.m_buffer, m_len ) );
-        
-        return ( 0 == res );
-    }
+    ///	@brief  The compare operator for Texts.
+    bool operator == ( const Text &rhs ) const;
 
 private:
     Text( const Text & );
@@ -159,38 +130,48 @@ private:
 };
 
 ///	@brief  Stores an OpenDDL-specific identifier type.
-struct Identifier {
-    Text m_text;
+struct DLL_ODDLPARSER_EXPORT Identifier {
+    Text m_text;    ///< The text element.
 
-    Identifier( char buffer[], size_t len )
-        : m_text( buffer, len ) {
-        // empty
-    }
+    ///	@brief  The constructor with a sized buffer full of characters.
+    ///	@param  buffer  [in] The identifier buffer.
+    ///	@param  len     [in] The length of the buffer
+    Identifier( const char buffer[], size_t len );
 
-    Identifier( char buffer[] )
-    : m_text( buffer, strlen( buffer ) ) {
-        // empty
-    }
+    ///	@brief  The constructor with a buffer full of characters.
+    ///	@param  buffer  [in] The identifier buffer.
+    /// @remark Buffer must be null-terminated.
+    Identifier( const char buffer[] );
 
-    bool operator == ( const Identifier &rhs ) const {
-        return m_text == rhs.m_text;
-    }
+    ///	@brief  The destructor.
+    ~Identifier();
+    
+    ///	@brief  The compare operator.
+    bool operator == ( const Identifier &rhs ) const;
 
 private:
     Identifier( const Identifier & );
     Identifier &operator = ( const Identifier & );
 };
 
-///	@brief  Stores an OpenDDL-specific name
-struct Name {
-    NameType    m_type;
-    Identifier *m_id;
+///	@brief  Description of the type of a name.
+enum NameType {
+    GlobalName, ///< Name is global.
+    LocalName   ///< Name is local.
+};
 
-    Name( NameType type, Identifier *id )
-        : m_type( type )
-        , m_id( id ) {
-        // empty
-    }
+///	@brief  Stores an OpenDDL-specific name
+struct DLL_ODDLPARSER_EXPORT Name {
+    NameType    m_type; ///< The type of the name ( @see NameType ).
+    Identifier *m_id;   ///< The id.
+
+    ///	@brief  The constructor with the type and the id.
+    ///	@param  type    [in] The name type.
+    ///	@param  id      [in] The id.
+    Name( NameType type, Identifier *id );
+
+    ///	@brief  The destructor.
+    ~Name();
 
 private:
     Name( const Name & );
@@ -198,33 +179,20 @@ private:
 };
 
 ///	@brief  Stores a bundle of references.
-struct Reference {
-    size_t   m_numRefs;
-    Name   **m_referencedName;
+struct DLL_ODDLPARSER_EXPORT Reference {
+    size_t   m_numRefs;         ///< The number of stored references.
+    Name   **m_referencedName;  ///< The reference names.
 
-    Reference()
-    : m_numRefs( 0 )
-    , m_referencedName( ddl_nullptr ) {
-        // empty
-    }
+    ///	@brief  The default constructor.
+    Reference();
      
-    Reference( size_t numrefs, Name **names )
-    : m_numRefs( numrefs )
-    , m_referencedName( ddl_nullptr ) {
-        m_referencedName = new Name *[ numrefs ];
-        for( size_t i = 0; i < numrefs; i++ ) {
-            Name *name = new Name( names[ i ]->m_type, names[ i ]->m_id );
-            m_referencedName[ i ] = name;
-        }
-    }
+    ///	@brief  The constructor with an array of ref names.
+    /// @param  numrefs     [in] The number of ref names.
+    /// @param  names       [in] The ref names.
+    Reference( size_t numrefs, Name **names );
 
-    ~Reference() {
-        for( size_t i = 0; i < m_numRefs; i++ ) {
-            delete m_referencedName[ i ];
-        }
-        m_numRefs = 0;
-        m_referencedName = ddl_nullptr;
-    }
+    ///	@brief  The destructor.
+    ~Reference();
 
 private:
     Reference( const Reference & );
@@ -232,26 +200,21 @@ private:
 };
 
 ///	@brief  Stores a property list.
-struct Property {
-    Identifier *m_key;
-    Value *m_value;
-    Reference *m_ref;
-    Property *m_next;
+struct DLL_ODDLPARSER_EXPORT Property {
+    Identifier *m_key;      ///< The identifier / key of the property.
+    Value      *m_value;    ///< The value assigned to its key / id ( ddl_nullptr if none ).
+    Reference  *m_ref;      ///< References assigned to its key / id ( ddl_nullptr if none ).
+    Property   *m_next;     ///< The next property ( ddl_nullptr if none ).
 
-    Property( Identifier *id )
-    : m_key( id )
-    , m_value( ddl_nullptr )
-    , m_ref( ddl_nullptr )
-    , m_next( ddl_nullptr ) {
-        // empty
-    }
+    ///	@brief  The default constructor.
+    Property();
 
-    ~Property() {
-        m_key = ddl_nullptr;
-        m_value = ddl_nullptr;
-        m_ref = ddl_nullptr;;
-        m_next = ddl_nullptr;;
-    }
+    ///	@brief  The constructor for initialization.
+    /// @param  id      [in] The identifier
+    Property( Identifier *id );
+
+    ///	@brief  The destructor.
+    ~Property();
 
 private:
     Property( const Property & );
@@ -259,17 +222,16 @@ private:
 };
 
 ///	@brief  Stores a data array list.
-struct DataArrayList {
-    size_t m_numItems;
-    Value *m_dataList;
-    DataArrayList *m_next;
+struct DLL_ODDLPARSER_EXPORT DataArrayList {
+    size_t         m_numItems;  ///< The number of items in the list.
+    Value         *m_dataList;  ///< The data list ( ee Value ).
+    DataArrayList *m_next;      ///< The next data array list ( ddl_nullptr if last ).
 
-    DataArrayList()
-        : m_numItems( 0 )
-        , m_dataList( ddl_nullptr )
-        , m_next( ddl_nullptr ) {
-        // empty
-    }
+    ///	@brief  The default constructor for initialization.
+    DataArrayList();
+
+    ///	@brief  The destructor.
+    ~DataArrayList();
 
 private:
     DataArrayList( const DataArrayList & ); 
@@ -277,17 +239,17 @@ private:
 };
 
 ///	@brief  Stores the context of a parsed OpenDDL declaration.
-struct Context {
-    DDLNode *m_root;
+struct DLL_ODDLPARSER_EXPORT Context {
+    DDLNode *m_root;    ///< The root node of the OpenDDL node tree.
 
-    Context()
-        : m_root( ddl_nullptr ) {
-        // empty
-    }
+    ///	@brief  Constructor for initialization.
+    Context();
 
-    ~Context() {
-        m_root = ddl_nullptr;
-    }
+    ///	@brief  Destructor.
+    ~Context();
+
+    ///	@brief  Clears the whole node tree.
+    void clear();
 
 private:
     Context( const Context & );

--- a/Source/ThirdParty/Assimp/contrib/openddlparser/include/openddlparser/OpenDDLExport.h
+++ b/Source/ThirdParty/Assimp/contrib/openddlparser/include/openddlparser/OpenDDLExport.h
@@ -1,0 +1,88 @@
+/*-----------------------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2014-2015 Kim Kulling
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+-----------------------------------------------------------------------------------------------*/
+#pragma once
+
+#include <openddlparser/OpenDDLCommon.h>
+#include <openddlparser/Value.h>
+
+BEGIN_ODDLPARSER_NS
+
+//-------------------------------------------------------------------------------------------------
+/// @ingroup    IOStreamBase
+///	@brief      This class represents the stream to write out.
+//-------------------------------------------------------------------------------------------------
+class DLL_ODDLPARSER_EXPORT IOStreamBase {
+public:
+    IOStreamBase();
+    virtual ~IOStreamBase();
+    virtual bool open( const std::string &anme );
+    virtual bool close();
+    virtual void write( const std::string &statement );
+
+private:
+    FILE *m_file;
+};
+
+//-------------------------------------------------------------------------------------------------
+///
+/// @ingroup    OpenDDLParser
+///	@brief      This class represents the OpenDDLExporter.
+///
+//-------------------------------------------------------------------------------------------------
+class DLL_ODDLPARSER_EXPORT OpenDDLExport {
+public:
+    ///	@brief  The class constructor
+    OpenDDLExport( IOStreamBase *stream = ddl_nullptr );
+
+    ///	@brief  The class destructor.
+    ~OpenDDLExport();
+
+    ///	@brief  Export the data of a parser context.
+    /// @param  ctx         [in] Pointer to the context.
+    /// @param  filename    [in] The filename for the export.
+    /// @return True in case of success, false in case of an error.
+    bool exportContext( Context *ctx, const std::string &filename );
+
+    ///	@brief  Handles a node export.
+    /// @param  node        [in] The node to handle with.
+    /// @return True in case of success, false in case of an error.
+    bool handleNode( DDLNode *node );
+
+    ///	@brief  Writes the statement to the stream.
+    /// @param  statement   [in]  The content to write.
+    /// @return True in case of success, false in case of an error.
+    bool writeToStream( const std::string &statement );
+
+protected:
+    bool writeNode( DDLNode *node, std::string &statement );
+    bool writeNodeHeader( DDLNode *node, std::string &statement );
+    bool writeProperties( DDLNode *node, std::string &statement );
+    bool writeValueType( Value::ValueType type, size_t numItems, std::string &statement );
+    bool writeValue( Value *val, std::string &statement );
+    bool writeValueArray( DataArrayList *al, std::string &statement );
+
+private:
+    IOStreamBase *m_stream;
+};
+
+END_ODDLPARSER_NS

--- a/Source/ThirdParty/Assimp/contrib/openddlparser/include/openddlparser/Value.h
+++ b/Source/ThirdParty/Assimp/contrib/openddlparser/include/openddlparser/Value.h
@@ -61,6 +61,8 @@ public:
         /// @param  start   [in] The first value for iteration,
         Iterator( Value *start );
 
+        Iterator( const Iterator &rhs );
+
         ///	@brief  The class destructor.
         ~Iterator();
 
@@ -71,13 +73,27 @@ public:
         ///	@brief  Returns the next item and moves the iterator to it.
         ///	@return The next value, is ddl_nullptr in case of being the last item.
         Value *getNext();
+        
+        ///	@brief  The post-increment operator.
+        const Iterator operator++( int );
+        
+        ///	@brief  The pre-increment operator.
+        Iterator &operator++( );
+
+        ///	@brief  The compare operator.
+        /// @param  rhs [in] The instance to compare.
+        /// @return true if equal.
+        bool operator == ( const Iterator &rhs ) const;
+
+        /// @brief  The * operator.
+        /// @return The instance or ddl_nullptr if end of list is reached.
+        Value *operator->( ) const;
 
     private:
         Value *m_start;
         Value *m_current;
 
     private:
-        Iterator( const Iterator & );
         Iterator &operator = ( const Iterator & );
     };
 
@@ -135,11 +151,23 @@ public:
     size_t m_size;
     unsigned char *m_data;
     Value *m_next;
+
+private:
+    Value &operator =( const Value & );
+    Value( const Value  & );
 };
 
+///------------------------------------------------------------------------------------------------
+///	@brief  This class implements the value allocator.
+///------------------------------------------------------------------------------------------------
 struct DLL_ODDLPARSER_EXPORT ValueAllocator {
     static Value *allocPrimData( Value::ValueType type, size_t len = 1 );
     static void releasePrimData( Value **data );
+
+private:
+    ValueAllocator();
+    ValueAllocator( const ValueAllocator  & );
+    ValueAllocator &operator = ( const ValueAllocator & );
 };
 
 END_ODDLPARSER_NS

--- a/Source/ThirdParty/Assimp/include/assimp/DefaultLogger.hpp
+++ b/Source/ThirdParty/Assimp/include/assimp/DefaultLogger.hpp
@@ -135,7 +135,7 @@ private:
     // ----------------------------------------------------------------------
     /** @briefPrivate construction for internal use by create().
      *  @param severity Logging granularity  */
-    DefaultLogger(LogSeverity severity);
+    explicit DefaultLogger(LogSeverity severity);
 
     // ----------------------------------------------------------------------
     /** @briefDestructor    */

--- a/Source/ThirdParty/Assimp/include/assimp/Logger.hpp
+++ b/Source/ThirdParty/Assimp/include/assimp/Logger.hpp
@@ -160,7 +160,7 @@ protected:
     Logger();
 
     /** Construction with a given log severity */
-    Logger(LogSeverity severity);
+    explicit Logger(LogSeverity severity);
 
     // ----------------------------------------------------------------------
     /** @brief Called as a request to write a specific debug message

--- a/Source/ThirdParty/Assimp/include/assimp/color4.h
+++ b/Source/ThirdParty/Assimp/include/assimp/color4.h
@@ -59,7 +59,7 @@ public:
     aiColor4t () : r(), g(), b(), a() {}
     aiColor4t (TReal _r, TReal _g, TReal _b, TReal _a)
         : r(_r), g(_g), b(_b), a(_a) {}
-    aiColor4t (TReal _r) : r(_r), g(_r), b(_r), a(_r) {}
+    explicit aiColor4t (TReal _r) : r(_r), g(_r), b(_r), a(_r) {}
     aiColor4t (const aiColor4t& o)
         : r(o.r), g(o.g), b(o.b), a(o.a) {}
 

--- a/Source/ThirdParty/Assimp/include/assimp/material.h
+++ b/Source/ThirdParty/Assimp/include/assimp/material.h
@@ -735,7 +735,7 @@ public:
         C_STRUCT aiString* path,
         aiTextureMapping* mapping   = NULL,
         unsigned int* uvindex       = NULL,
-        float* blend                   = NULL,
+        float* blend                = NULL,
         aiTextureOp* op             = NULL,
         aiTextureMapMode* mapmode   = NULL) const;
 
@@ -1344,9 +1344,9 @@ ASSIMP_API C_ENUM aiReturn aiGetMaterialProperty(
  *   arrays remains unmodified and pMax is set to 0.*/
 // ---------------------------------------------------------------------------
 ASSIMP_API C_ENUM aiReturn aiGetMaterialFloatArray(
-     const C_STRUCT aiMaterial* pMat,
+    const C_STRUCT aiMaterial* pMat,
     const char* pKey,
-     unsigned int type,
+    unsigned int type,
     unsigned int index,
     float* pOut,
     unsigned int* pMax);
@@ -1376,7 +1376,7 @@ ASSIMP_API C_ENUM aiReturn aiGetMaterialFloatArray(
 inline aiReturn aiGetMaterialFloat(const aiMaterial* pMat,
     const char* pKey,
     unsigned int type,
-   unsigned int index,
+    unsigned int index,
     float* pOut)
 {
     return aiGetMaterialFloatArray(pMat,pKey,type,index,pOut,(unsigned int*)0x0);
@@ -1397,11 +1397,11 @@ inline aiReturn aiGetMaterialFloat(const aiMaterial* pMat,
  *
  * See the sample for aiGetMaterialFloatArray for more information.*/
 ASSIMP_API C_ENUM aiReturn aiGetMaterialIntegerArray(const C_STRUCT aiMaterial* pMat,
-    const char* pKey,
+     const char* pKey,
      unsigned int  type,
      unsigned int  index,
-    int* pOut,
-    unsigned int* pMax);
+     int* pOut,
+     unsigned int* pMax);
 
 
 #ifdef __cplusplus
@@ -1437,9 +1437,9 @@ inline aiReturn aiGetMaterialInteger(const C_STRUCT aiMaterial* pMat,
 // ---------------------------------------------------------------------------
 ASSIMP_API C_ENUM aiReturn aiGetMaterialColor(const C_STRUCT aiMaterial* pMat,
     const char* pKey,
-     unsigned int type,
+    unsigned int type,
     unsigned int index,
-     C_STRUCT aiColor4D* pOut);
+    C_STRUCT aiColor4D* pOut);
 
 
 // ---------------------------------------------------------------------------
@@ -1449,9 +1449,9 @@ ASSIMP_API C_ENUM aiReturn aiGetMaterialColor(const C_STRUCT aiMaterial* pMat,
 // ---------------------------------------------------------------------------
 ASSIMP_API C_ENUM aiReturn aiGetMaterialUVTransform(const C_STRUCT aiMaterial* pMat,
     const char* pKey,
-     unsigned int type,
+    unsigned int type,
     unsigned int index,
-     C_STRUCT aiUVTransform* pOut);
+    C_STRUCT aiUVTransform* pOut);
 
 
 // ---------------------------------------------------------------------------
@@ -1461,7 +1461,7 @@ ASSIMP_API C_ENUM aiReturn aiGetMaterialUVTransform(const C_STRUCT aiMaterial* p
 // ---------------------------------------------------------------------------
 ASSIMP_API C_ENUM aiReturn aiGetMaterialString(const C_STRUCT aiMaterial* pMat,
     const char* pKey,
-     unsigned int type,
+    unsigned int type,
     unsigned int index,
     C_STRUCT aiString* pOut);
 

--- a/Source/ThirdParty/Assimp/include/assimp/metadata.h
+++ b/Source/ThirdParty/Assimp/include/assimp/metadata.h
@@ -39,8 +39,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---------------------------------------------------------------------------
 */
 
-// Modified by Lasse Oorni for Urho3D
-
 /** @file metadata.h
  *  @brief Defines the data structures for holding node meta information.
  */

--- a/Source/ThirdParty/Assimp/include/assimp/quaternion.h
+++ b/Source/ThirdParty/Assimp/include/assimp/quaternion.h
@@ -60,7 +60,7 @@ public:
         : w(pw), x(px), y(py), z(pz) {}
 
     /** Construct from rotation matrix. Result is undefined if the matrix is not orthonormal. */
-    aiQuaterniont( const aiMatrix3x3t<TReal>& pRotMatrix);
+    explicit aiQuaterniont( const aiMatrix3x3t<TReal>& pRotMatrix);
 
     /** Construct from euler angles */
     aiQuaterniont( TReal rotx, TReal roty, TReal rotz);
@@ -69,7 +69,7 @@ public:
     aiQuaterniont( aiVector3t<TReal> axis, TReal angle);
 
     /** Construct from a normalized quaternion stored in a vec3 */
-    aiQuaterniont( aiVector3t<TReal> normalized);
+    explicit aiQuaterniont( aiVector3t<TReal> normalized);
 
     /** Returns a matrix representation of the quaternion */
     aiMatrix3x3t<TReal> GetMatrix() const;

--- a/Source/ThirdParty/Assimp/include/assimp/scene.h
+++ b/Source/ThirdParty/Assimp/include/assimp/scene.h
@@ -135,7 +135,7 @@ struct aiNode
 
 
     /** Construction from a specific name */
-    aiNode(const std::string& name)
+    explicit aiNode(const std::string& name)
         // set all members to zero by default
         : mName(name)
         , mParent(NULL)

--- a/Source/ThirdParty/Assimp/include/assimp/types.h
+++ b/Source/ThirdParty/Assimp/include/assimp/types.h
@@ -47,7 +47,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // Some runtime headers
 #include <sys/types.h>
-#include <memory.h>
 #include <math.h>
 #include <stddef.h>
 #include <string.h>
@@ -161,7 +160,7 @@ struct aiColor3D
 #ifdef __cplusplus
     aiColor3D () : r(0.0f), g(0.0f), b(0.0f) {}
     aiColor3D (float _r, float _g, float _b) : r(_r), g(_g), b(_b) {}
-    aiColor3D (float _r) : r(_r), g(_r), b(_r) {}
+    explicit aiColor3D (float _r) : r(_r), g(_r), b(_r) {}
     aiColor3D (const aiColor3D& o) : r(o.r), g(o.g), b(o.b) {}
 
     /** Component-wise comparison */


### PR DESCRIPTION
Unfortunately, as of Assimp 3.3 the developers have switched to C++11 and does not provide any pre-C++11 fallback paths. Reversing that would take some time and effort, so I've only updated to the latest release which still sticks with C++03 and here's a PR for that. 