### PR TITLE
Editor: F3 also toggle Physics2D debug geometry

### DIFF
--- a/bin/Data/Scripts/Editor/EditorView.as
+++ b/bin/Data/Scripts/Editor/EditorView.as
@@ -1747,8 +1747,26 @@ void HandlePostRenderUpdate()
 
     if (renderingDebug)
         renderer.DrawDebugGeometry(false);
+
     if (physicsDebug && editorScene.physicsWorld !is null)
         editorScene.physicsWorld.DrawDebugGeometry(true);
+
+    if (physicsDebug && editorScene.physicsWorld2D !is null)
+    {
+        bool needDraw = true;
+        for (uint i = 0; i < selectedComponents.length; ++i)
+        {
+            if (cast<PhysicsWorld2D>(selectedComponents[i]) !is null)
+            {
+                needDraw = false; // Already drawed
+                break;
+            }
+        }
+
+        if (needDraw)
+            physicsWorld2D.DrawDebugGeometry();
+    }
+
     if (octreeDebug && editorScene.octree !is null)
         editorScene.octree.DrawDebugGeometry(true);
 


### PR DESCRIPTION
Currently Physics2D debug is visible only when PhysicsWorld2D component is selected, so is hard to tuning Shape2D size