### PR TITLE
Extract some code to increase reusability.

### DIFF
--- a/Source/Urho3D/AngelScript/APITemplates.h
+++ b/Source/Urho3D/AngelScript/APITemplates.h
@@ -722,6 +722,7 @@ template <class T> void RegisterNode(asIScriptEngine* engine, const char* classN
     engine->RegisterObjectMethod(className, "Array<Component@>@ GetComponents(const String&in, bool recursive = false) const", asFUNCTION(NodeGetComponentsWithType), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod(className, "Component@+ GetComponent(const String&in, bool recursive = false) const", asFUNCTION(NodeGetComponentWithType), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod(className, "Component@+ GetParentComponent(const String&in, bool fullTraversal = false) const", asFUNCTION(NodeGetParentComponentWithType), asCALL_CDECL_OBJLAST);
+    engine->RegisterObjectMethod(className, "bool IsChildOf(Node@+) const", asMETHOD(T, IsChildOf), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "bool HasComponent(const String&in) const", asFUNCTION(NodeHasComponent), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod(className, "bool HasTag(const String&in)", asMETHOD(T, HasTag), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "Array<String>@ get_tags()", asFUNCTION(NodeGetTags), asCALL_CDECL_OBJLAST);

--- a/Source/Urho3D/Container/Vector.h
+++ b/Source/Urho3D/Container/Vector.h
@@ -409,6 +409,12 @@ public:
         return it;
     }
 
+    /// Return index of value in vector, or size if not found.
+    unsigned IndexOf(const T& value) const
+    {
+        return Find(value) - Begin();
+    }
+
     /// Return whether contains a specific value.
     bool Contains(const T& value) const { return Find(value) != End(); }
 
@@ -987,6 +993,12 @@ public:
         while (it != End() && *it != value)
             ++it;
         return it;
+    }
+
+    /// Return index of value in vector, or size if not found.
+    unsigned IndexOf(const T& value) const
+    {
+        return Find(value) - Begin();
     }
 
     /// Return whether contains a specific value.

--- a/Source/Urho3D/Engine/Engine.cpp
+++ b/Source/Urho3D/Engine/Engine.cpp
@@ -211,138 +211,11 @@ bool Engine::Initialize(const VariantMap& parameters)
 #endif
 
     // Add resource paths
+    if (!InitializeResourceCache(parameters, false))
+        return false;
+
     ResourceCache* cache = GetSubsystem<ResourceCache>();
     FileSystem* fileSystem = GetSubsystem<FileSystem>();
-
-    Vector<String> resourcePrefixPaths = GetParameter(parameters, EP_RESOURCE_PREFIX_PATHS, String::EMPTY).GetString().Split(';', true);
-    for (unsigned i = 0; i < resourcePrefixPaths.Size(); ++i)
-        resourcePrefixPaths[i] = AddTrailingSlash(
-            IsAbsolutePath(resourcePrefixPaths[i]) ? resourcePrefixPaths[i] : fileSystem->GetProgramDir() + resourcePrefixPaths[i]);
-    Vector<String> resourcePaths = GetParameter(parameters, EP_RESOURCE_PATHS, "Data;CoreData").GetString().Split(';');
-    Vector<String> resourcePackages = GetParameter(parameters, EP_RESOURCE_PACKAGES).GetString().Split(';');
-    Vector<String> autoLoadPaths = GetParameter(parameters, EP_AUTOLOAD_PATHS, "Autoload").GetString().Split(';');
-
-    for (unsigned i = 0; i < resourcePaths.Size(); ++i)
-    {
-        // If path is not absolute, prefer to add it as a package if possible
-        if (!IsAbsolutePath(resourcePaths[i]))
-        {
-            unsigned j = 0;
-            for (; j < resourcePrefixPaths.Size(); ++j)
-            {
-                String packageName = resourcePrefixPaths[j] + resourcePaths[i] + ".pak";
-                if (fileSystem->FileExists(packageName))
-                {
-                    if (cache->AddPackageFile(packageName))
-                        break;
-                    else
-                        return false;   // The root cause of the error should have already been logged
-                }
-                String pathName = resourcePrefixPaths[j] + resourcePaths[i];
-                if (fileSystem->DirExists(pathName))
-                {
-                    if (cache->AddResourceDir(pathName))
-                        break;
-                    else
-                        return false;
-                }
-            }
-            if (j == resourcePrefixPaths.Size())
-            {
-                URHO3D_LOGERRORF(
-                    "Failed to add resource path '%s', check the documentation on how to set the 'resource prefix path'",
-                    resourcePaths[i].CString());
-                return false;
-            }
-        }
-        else
-        {
-            String pathName = resourcePaths[i];
-            if (fileSystem->DirExists(pathName))
-                if (!cache->AddResourceDir(pathName))
-                    return false;
-        }
-    }
-
-    // Then add specified packages
-    for (unsigned i = 0; i < resourcePackages.Size(); ++i)
-    {
-        unsigned j = 0;
-        for (; j < resourcePrefixPaths.Size(); ++j)
-        {
-            String packageName = resourcePrefixPaths[j] + resourcePackages[i];
-            if (fileSystem->FileExists(packageName))
-            {
-                if (cache->AddPackageFile(packageName))
-                    break;
-                else
-                    return false;
-            }
-        }
-        if (j == resourcePrefixPaths.Size())
-        {
-            URHO3D_LOGERRORF(
-                "Failed to add resource package '%s', check the documentation on how to set the 'resource prefix path'",
-                resourcePackages[i].CString());
-            return false;
-        }
-    }
-
-    // Add auto load folders. Prioritize these (if exist) before the default folders
-    for (unsigned i = 0; i < autoLoadPaths.Size(); ++i)
-    {
-        bool autoLoadPathExist = false;
-
-        for (unsigned j = 0; j < resourcePrefixPaths.Size(); ++j)
-        {
-            String autoLoadPath(autoLoadPaths[i]);
-            if (!IsAbsolutePath(autoLoadPath))
-                autoLoadPath = resourcePrefixPaths[j] + autoLoadPath;
-
-            if (fileSystem->DirExists(autoLoadPath))
-            {
-                autoLoadPathExist = true;
-
-                // Add all the subdirs (non-recursive) as resource directory
-                Vector<String> subdirs;
-                fileSystem->ScanDir(subdirs, autoLoadPath, "*", SCAN_DIRS, false);
-                for (unsigned y = 0; y < subdirs.Size(); ++y)
-                {
-                    String dir = subdirs[y];
-                    if (dir.StartsWith("."))
-                        continue;
-
-                    String autoResourceDir = autoLoadPath + "/" + dir;
-                    if (!cache->AddResourceDir(autoResourceDir, 0))
-                        return false;
-                }
-
-                // Add all the found package files (non-recursive)
-                Vector<String> paks;
-                fileSystem->ScanDir(paks, autoLoadPath, "*.pak", SCAN_FILES, false);
-                for (unsigned y = 0; y < paks.Size(); ++y)
-                {
-                    String pak = paks[y];
-                    if (pak.StartsWith("."))
-                        continue;
-
-                    String autoPackageName = autoLoadPath + "/" + pak;
-                    if (!cache->AddPackageFile(autoPackageName, 0))
-                        return false;
-                }
-            }
-        }
-
-        // The following debug message is confusing when user is not aware of the autoload feature
-        // Especially because the autoload feature is enabled by default without user intervention
-        // The following extra conditional check below is to suppress unnecessary debug log entry under such default situation
-        // The cleaner approach is to not enable the autoload by default, i.e. do not use 'Autoload' as default value for 'AutoloadPaths' engine parameter
-        // However, doing so will break the existing applications that rely on this
-        if (!autoLoadPathExist && (autoLoadPaths.Size() > 1 || autoLoadPaths[0] != "Autoload"))
-            URHO3D_LOGDEBUGF(
-                "Skipped autoload path '%s' as it does not exist, check the documentation on how to set the 'resource prefix path'",
-                autoLoadPaths[i].CString());
-    }
 
     // Initialize graphics & audio output
     if (!headless_)
@@ -437,12 +310,23 @@ bool Engine::Initialize(const VariantMap& parameters)
     return true;
 }
 
-#if 0
+bool Engine::InitializeResourceCache(const VariantMap& parameters, bool removeOld /*= true*/)
 {
-    // Add resource paths
     ResourceCache* cache = GetSubsystem<ResourceCache>();
     FileSystem* fileSystem = GetSubsystem<FileSystem>();
 
+    // Remove all resource paths and packages
+    if (removeOld)
+    {
+        Vector<String> resourceDirs = cache->GetResourceDirs();
+        Vector<SharedPtr<PackageFile> > packageFiles = cache->GetPackageFiles();
+        for (unsigned i = 0; i < resourceDirs.Size(); ++i)
+            cache->RemoveResourceDir(resourceDirs[i]);
+        for (unsigned i = 0; i < packageFiles.Size(); ++i)
+            cache->RemovePackageFile(packageFiles[i]);
+    }
+
+    // Add resource paths
     Vector<String> resourcePrefixPaths = GetParameter(parameters, EP_RESOURCE_PREFIX_PATHS, String::EMPTY).GetString().Split(';', true);
     for (unsigned i = 0; i < resourcePrefixPaths.Size(); ++i)
         resourcePrefixPaths[i] = AddTrailingSlash(
@@ -572,8 +456,9 @@ bool Engine::Initialize(const VariantMap& parameters)
                 "Skipped autoload path '%s' as it does not exist, check the documentation on how to set the 'resource prefix path'",
                 autoLoadPaths[i].CString());
     }
+
+    return true;
 }
-#endif
 
 void Engine::RunFrame()
 {

--- a/Source/Urho3D/Engine/Engine.h
+++ b/Source/Urho3D/Engine/Engine.h
@@ -44,6 +44,8 @@ public:
 
     /// Initialize engine using parameters given and show the application window. Return true if successful.
     bool Initialize(const VariantMap& parameters);
+    /// Reinitialize resource cache subsystem using parameters given. Implicitly called by Initialize. Return true if successful.
+    bool InitializeResourceCache(const VariantMap& parameters, bool removeOld = true);
     /// Run one frame.
     void RunFrame();
     /// Create the console and return it. May return null if engine configuration does not allow creation (headless mode.)

--- a/Source/Urho3D/LuaScript/pkgs/Scene/Node.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Scene/Node.pkg
@@ -132,6 +132,7 @@ class Node : public Animatable
     StringHash GetNameHash() const;
     Node* GetParent() const;
     Scene* GetScene() const;
+    bool IsChildOf(Node* node) const;
     bool IsEnabled() const;
     bool IsEnabledSelf() const;
     Connection* GetOwner() const;

--- a/Source/Urho3D/Scene/Node.cpp
+++ b/Source/Urho3D/Scene/Node.cpp
@@ -800,13 +800,8 @@ void Node::AddChild(Node* node, unsigned index)
     if (!node || node == this || node->parent_ == this)
         return;
     // Check for possible cyclic parent assignment
-    Node* parent = parent_;
-    while (parent)
-    {
-        if (parent == node)
-            return;
-        parent = parent->parent_;
-    }
+    if (IsChildOf(node))
+        return;
 
     // Keep a shared ptr to the node while transferring
     SharedPtr<Node> nodeShared(node);
@@ -1362,6 +1357,18 @@ bool Node::HasComponent(StringHash type) const
 bool Node::HasTag(const String& tag) const
 {
     return impl_->tags_.Contains(tag);
+}
+
+bool Node::IsChildOf(Node* node) const
+{
+    Node* parent = parent_;
+    while (parent)
+    {
+        if (parent == node)
+            return true;
+        parent = parent->parent_;
+    }
+    return false;
 }
 
 const Variant& Node::GetVar(StringHash key) const

--- a/Source/Urho3D/Scene/Node.h
+++ b/Source/Urho3D/Scene/Node.h
@@ -355,10 +355,13 @@ public:
     /// Return scene.
     Scene* GetScene() const { return scene_; }
 
+    /// Return whether is a direct or indirect child of specified node.
+    bool IsChildOf(Node* node) const;
+
     /// Return whether is enabled. Disables nodes effectively disable all their components.
     bool IsEnabled() const { return enabled_; }
 
-    /// Returns the node's last own enabled state. May be different than the value returned by IsEnabled when SetDeepEnabled has been used.
+    /// Return the node's last own enabled state. May be different than the value returned by IsEnabled when SetDeepEnabled has been used.
     bool IsEnabledSelf() const { return enabledPrev_; }
 
     /// Return owner connection in networking.


### PR DESCRIPTION
Main change here is in 4th commit of this PR.
I wanted to allow change paths on-the-fly with the same semantic as they are initialized.
I intentionally didn't add force ResourceCache force cleanup because it can be easlily done outside.

@cadaver, please check for important things that I may have missed.

**Note for reviewers**: it's easier to review changes in Engine.cpp via https://github.com/urho3d/Urho3D/pull/1832/commits/f386678667396b342bc40a9ba9a52154914452e3