### PR TITLE
AbstractFile class

### DIFF
--- a/Source/Urho3D/IO/AbstractFile.h
+++ b/Source/Urho3D/IO/AbstractFile.h
@@ -1,0 +1,43 @@
+//
+// Copyright (c) 2008-2017 the Urho3D project.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+#include "../IO/Serializer.h"
+#include "../IO/Deserializer.h"
+
+namespace Urho3D
+{
+
+/// A common root class for objects that implement both Serializer and Deserializer.
+class URHO3D_API AbstractFile : public Deserializer, public Serializer
+{
+public:
+    /// Construct.
+    AbstractFile() : Deserializer() { }
+    /// Construct.
+    AbstractFile(unsigned int size) : Deserializer(size) { }
+    /// Destruct.
+    virtual ~AbstractFile() { }
+};
+
+};

--- a/Source/Urho3D/IO/File.h
+++ b/Source/Urho3D/IO/File.h
@@ -24,8 +24,7 @@
 
 #include "../Container/ArrayPtr.h"
 #include "../Core/Object.h"
-#include "../IO/Deserializer.h"
-#include "../IO/Serializer.h"
+#include "../IO/AbstractFile.h"
 
 #ifdef __ANDROID__
 struct SDL_RWops;
@@ -58,7 +57,7 @@ enum FileMode
 class PackageFile;
 
 /// %File opened either through the filesystem or from within a package file.
-class URHO3D_API File : public Object, public Deserializer, public Serializer
+class URHO3D_API File : public Object, public AbstractFile
 {
     URHO3D_OBJECT(File, Object);
 

--- a/Source/Urho3D/IO/MemoryBuffer.cpp
+++ b/Source/Urho3D/IO/MemoryBuffer.cpp
@@ -28,7 +28,7 @@ namespace Urho3D
 {
 
 MemoryBuffer::MemoryBuffer(void* data, unsigned size) :
-    Deserializer(size),
+    AbstractFile(size),
     buffer_((unsigned char*)data),
     readOnly_(false)
 {
@@ -37,7 +37,7 @@ MemoryBuffer::MemoryBuffer(void* data, unsigned size) :
 }
 
 MemoryBuffer::MemoryBuffer(const void* data, unsigned size) :
-    Deserializer(size),
+    AbstractFile(size),
     buffer_((unsigned char*)data),
     readOnly_(true)
 {
@@ -46,14 +46,14 @@ MemoryBuffer::MemoryBuffer(const void* data, unsigned size) :
 }
 
 MemoryBuffer::MemoryBuffer(PODVector<unsigned char>& data) :
-    Deserializer(data.Size()),
+    AbstractFile(data.Size()),
     buffer_(data.Begin().ptr_),
     readOnly_(false)
 {
 }
 
 MemoryBuffer::MemoryBuffer(const PODVector<unsigned char>& data) :
-    Deserializer(data.Size()),
+    AbstractFile(data.Size()),
     buffer_(data.Begin().ptr_),
     readOnly_(true)
 {

--- a/Source/Urho3D/IO/MemoryBuffer.h
+++ b/Source/Urho3D/IO/MemoryBuffer.h
@@ -22,14 +22,13 @@
 
 #pragma once
 
-#include "../IO/Deserializer.h"
-#include "../IO/Serializer.h"
+#include "../IO/AbstractFile.h"
 
 namespace Urho3D
 {
 
 /// Memory area that can be read and written to as a stream.
-class URHO3D_API MemoryBuffer : public Deserializer, public Serializer
+class URHO3D_API MemoryBuffer : public AbstractFile
 {
 public:
     /// Construct with a pointer and size.

--- a/Source/Urho3D/IO/NamedPipe.h
+++ b/Source/Urho3D/IO/NamedPipe.h
@@ -24,8 +24,7 @@
 
 #include "../Container/ArrayPtr.h"
 #include "../Core/Object.h"
-#include "../IO/Deserializer.h"
-#include "../IO/Serializer.h"
+#include "../IO/AbstractFile.h"
 
 #ifdef __ANDROID__
 #include <SDL/SDL_rwops.h>
@@ -35,7 +34,7 @@ namespace Urho3D
 {
 
 /// Named pipe for interprocess communication.
-class URHO3D_API NamedPipe : public Object, public Deserializer, public Serializer
+class URHO3D_API NamedPipe : public Object, public AbstractFile
 {
     URHO3D_OBJECT(NamedPipe, Object);
 

--- a/Source/Urho3D/IO/VectorBuffer.h
+++ b/Source/Urho3D/IO/VectorBuffer.h
@@ -22,14 +22,13 @@
 
 #pragma once
 
-#include "../IO/Deserializer.h"
-#include "../IO/Serializer.h"
+#include "../IO/AbstractFile.h"
 
 namespace Urho3D
 {
 
 /// Dynamically sized buffer that can be read and written to as a stream.
-class URHO3D_API VectorBuffer : public Deserializer, public Serializer
+class URHO3D_API VectorBuffer : public AbstractFile
 {
 public:
     /// Construct an empty buffer.


### PR DESCRIPTION
Added AbstractFile class. It is used as parent class for classes that implement both Serializer and Deserialized.

While doing profiler work i found a need to interact with objects that implement both `Serializer` and `Deserializer`. Urho3D has several such objects but all of them inherit both classes separately. That means there is no way to have type system require an object implementing both. For this reason `AbstractFile` class was created and objects that inherited both `Serializer` and `Deserializer` now inherit `AbstractFile` instead.