### PR TITLE
Add info about shapes to PhysicsEvents2D

### DIFF
--- a/Source/Urho3D/Scene/Animatable.cpp
+++ b/Source/Urho3D/Scene/Animatable.cpp
@@ -80,6 +80,7 @@ void Animatable::RegisterObject(Context* context)
 {
     URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Object Animation", GetObjectAnimationAttr, SetObjectAnimationAttr, ResourceRef,
         ResourceRef(ObjectAnimation::GetTypeStatic()), AM_DEFAULT);
+    URHO3D_ACCESSOR_ATTRIBUTE("Name", GetName, SetName, String, String::EMPTY, AM_FILE);
 }
 
 bool Animatable::LoadXML(const XMLElement& source, bool setInstanceDefault)
@@ -184,6 +185,11 @@ bool Animatable::LoadJSON(const JSONValue& source, bool setInstanceDefault)
     }
 
     return true;
+}
+
+void Animatable::SetName(const String& name)
+{
+    name_ = name;
 }
 
 bool Animatable::SaveXML(XMLElement& dest) const

--- a/Source/Urho3D/Scene/Animatable.h
+++ b/Source/Urho3D/Scene/Animatable.h
@@ -121,6 +121,11 @@ public:
     /// Return object animation attribute.
     ResourceRef GetObjectAnimationAttr() const;
 
+    /// Set name.
+    virtual void SetName(const String& name);
+    /// Return name.
+    const String& GetName() const { return name_; }
+
 protected:
     /// Handle attribute animation added.
     virtual void OnAttributeAnimationAdded() = 0;
@@ -153,6 +158,8 @@ protected:
     HashSet<const AttributeInfo*> animatedNetworkAttributes_;
     /// Attribute animation infos.
     HashMap<String, SharedPtr<AttributeAnimationInfo> > attributeAnimationInfos_;
+    /// Name.
+    String name_;
 };
 
 }

--- a/Source/Urho3D/Scene/Node.cpp
+++ b/Source/Urho3D/Scene/Node.cpp
@@ -321,9 +321,9 @@ bool Node::SaveJSON(Serializer& dest, const String& indentation) const
 
 void Node::SetName(const String& name)
 {
-    if (name != impl_->name_)
+    if (name != name_)
     {
-        impl_->name_ = name;
+        name_ = name;
         impl_->nameHash_ = name;
 
         MarkNetworkUpdate();

--- a/Source/Urho3D/Scene/Node.h
+++ b/Source/Urho3D/Scene/Node.h
@@ -59,8 +59,6 @@ struct URHO3D_API NodeImpl
     PODVector<Node*> dependencyNodes_;
     /// Network owner connection.
     Connection* owner_;
-    /// Name.
-    String name_;
     /// Tag strings.
     StringVector tags_;
     /// Name hash.
@@ -336,9 +334,6 @@ public:
 
     /// Return ID.
     unsigned GetID() const { return id_; }
-
-    /// Return name.
-    const String& GetName() const { return impl_->name_; }
 
     /// Return name hash.
     StringHash GetNameHash() const { return impl_->nameHash_; }

--- a/Source/Urho3D/UI/UIElement.h
+++ b/Source/Urho3D/UI/UIElement.h
@@ -391,9 +391,6 @@ public:
     /// Template version of returning child element by variable. If only key is provided, return the first child having the matching variable key. If value is also provided then the actual variable value would also be checked against using dynamic cast. May return 0 when casting failed.
     template <class T> T* GetChildDynamicCast(const StringHash& key, const Variant& value = Variant::EMPTY, bool recursive = false) const;
 
-    /// Return name.
-    const String& GetName() const { return name_; }
-
     /// Return position.
     const IntVector2& GetPosition() const { return position_; }
 
@@ -654,8 +651,6 @@ protected:
     /// Update anchored size & position. Only called when anchoring is enabled.
     void UpdateAnchoring();
 
-    /// Name.
-    String name_;
     /// Child elements.
     Vector<SharedPtr<UIElement> > children_;
     /// Parent element.

--- a/Source/Urho3D/Urho2D/PhysicsEvents2D.h
+++ b/Source/Urho3D/Urho2D/PhysicsEvents2D.h
@@ -40,6 +40,8 @@ URHO3D_EVENT(E_PHYSICSBEGINCONTACT2D, PhysicsBeginContact2D)
     URHO3D_PARAM(P_NODEA, NodeA);                  // Node pointer
     URHO3D_PARAM(P_NODEB, NodeB);                  // Node pointer
     URHO3D_PARAM(P_CONTACT, Contact);              // b2Contact pointer
+    URHO3D_PARAM(P_SHAPEA, ShapeA);                // CollisionShape2D pointer
+    URHO3D_PARAM(P_SHAPEB, ShapeB);                // CollisionShape2D pointer
 }
 
 /// Physics end contact. Global event sent by PhysicsWorld2D.
@@ -51,6 +53,8 @@ URHO3D_EVENT(E_PHYSICSENDCONTACT2D, PhysicsEndContact2D)
     URHO3D_PARAM(P_NODEA, NodeA);                  // Node pointer
     URHO3D_PARAM(P_NODEB, NodeB);                  // Node pointer
     URHO3D_PARAM(P_CONTACT, Contact);              // b2Contact pointer
+    URHO3D_PARAM(P_SHAPEA, ShapeA);                // CollisionShape2D pointer
+    URHO3D_PARAM(P_SHAPEB, ShapeB);                // CollisionShape2D pointer
 }
 
 /// Node begin contact. Sent by scene nodes participating in a collision.
@@ -60,6 +64,8 @@ URHO3D_EVENT(E_NODEBEGINCONTACT2D, NodeBeginContact2D)
     URHO3D_PARAM(P_OTHERNODE, OtherNode);          // Node pointer
     URHO3D_PARAM(P_OTHERBODY, OtherBody);          // RigidBody2D pointer
     URHO3D_PARAM(P_CONTACT, Contact);              // b2Contact pointer
+    URHO3D_PARAM(P_SHAPE, Shape);                  // CollisionShape2D pointer
+    URHO3D_PARAM(P_OTHERSHAPE, OtherShape);        // CollisionShape2D pointer
 }
 
 /// Node end contact. Sent by scene nodes participating in a collision.
@@ -69,6 +75,8 @@ URHO3D_EVENT(E_NODEENDCONTACT2D, NodeEndContact2D)
     URHO3D_PARAM(P_OTHERNODE, OtherNode);          // Node pointer
     URHO3D_PARAM(P_OTHERBODY, OtherBody);          // RigidBody2D pointer
     URHO3D_PARAM(P_CONTACT, Contact);              // b2Contact pointer
+    URHO3D_PARAM(P_SHAPE, Shape);                  // CollisionShape2D pointer
+    URHO3D_PARAM(P_OTHERSHAPE, OtherShape);        // CollisionShape2D pointer
 }
 
 }

--- a/Source/Urho3D/Urho2D/PhysicsWorld2D.cpp
+++ b/Source/Urho3D/Urho2D/PhysicsWorld2D.cpp
@@ -30,6 +30,7 @@
 #include "../IO/Log.h"
 #include "../Scene/Scene.h"
 #include "../Scene/SceneEvents.h"
+#include "../Urho2D/CollisionShape2D.h"
 #include "../Urho2D/PhysicsEvents2D.h"
 #include "../Urho2D/PhysicsUtils2D.h"
 #include "../Urho2D/PhysicsWorld2D.h"
@@ -686,6 +687,8 @@ void PhysicsWorld2D::SendBeginContactEvents()
         eventData[P_NODEA] = contactInfo.nodeA_.Get();
         eventData[P_NODEB] = contactInfo.nodeB_.Get();
         eventData[P_CONTACT] = (void*)contactInfo.contact_;
+        eventData[P_SHAPEA] = contactInfo.shapeA_.Get();
+        eventData[P_SHAPEB] = contactInfo.shapeB_.Get();
 
         SendEvent(E_PHYSICSBEGINCONTACT2D, eventData);
 
@@ -696,6 +699,8 @@ void PhysicsWorld2D::SendBeginContactEvents()
             nodeEventData[NodeBeginContact2D::P_BODY] = contactInfo.bodyA_.Get();
             nodeEventData[NodeBeginContact2D::P_OTHERNODE] = contactInfo.nodeB_.Get();
             nodeEventData[NodeBeginContact2D::P_OTHERBODY] = contactInfo.bodyB_.Get();
+            nodeEventData[NodeBeginContact2D::P_SHAPE] = contactInfo.shapeA_.Get();
+            nodeEventData[NodeBeginContact2D::P_OTHERSHAPE] = contactInfo.shapeB_.Get();
 
             contactInfo.nodeA_->SendEvent(E_NODEBEGINCONTACT2D, nodeEventData);
         }
@@ -705,6 +710,8 @@ void PhysicsWorld2D::SendBeginContactEvents()
             nodeEventData[NodeBeginContact2D::P_BODY] = contactInfo.bodyB_.Get();
             nodeEventData[NodeBeginContact2D::P_OTHERNODE] = contactInfo.nodeA_.Get();
             nodeEventData[NodeBeginContact2D::P_OTHERBODY] = contactInfo.bodyA_.Get();
+            nodeEventData[NodeBeginContact2D::P_SHAPE] = contactInfo.shapeB_.Get();
+            nodeEventData[NodeBeginContact2D::P_OTHERSHAPE] = contactInfo.shapeA_.Get();
 
             contactInfo.nodeB_->SendEvent(E_NODEBEGINCONTACT2D, nodeEventData);
         }
@@ -731,6 +738,8 @@ void PhysicsWorld2D::SendEndContactEvents()
         eventData[P_NODEA] = contactInfo.nodeA_.Get();
         eventData[P_NODEB] = contactInfo.nodeB_.Get();
         eventData[P_CONTACT] = (void*)contactInfo.contact_;
+        eventData[P_SHAPEA] = contactInfo.shapeA_.Get();
+        eventData[P_SHAPEB] = contactInfo.shapeB_.Get();
 
         SendEvent(E_PHYSICSENDCONTACT2D, eventData);
 
@@ -741,6 +750,8 @@ void PhysicsWorld2D::SendEndContactEvents()
             nodeEventData[NodeEndContact2D::P_BODY] = contactInfo.bodyA_.Get();
             nodeEventData[NodeEndContact2D::P_OTHERNODE] = contactInfo.nodeB_.Get();
             nodeEventData[NodeEndContact2D::P_OTHERBODY] = contactInfo.bodyB_.Get();
+            nodeEventData[NodeBeginContact2D::P_SHAPE] = contactInfo.shapeA_.Get();
+            nodeEventData[NodeBeginContact2D::P_OTHERSHAPE] = contactInfo.shapeB_.Get();
 
             contactInfo.nodeA_->SendEvent(E_NODEENDCONTACT2D, nodeEventData);
         }
@@ -750,6 +761,8 @@ void PhysicsWorld2D::SendEndContactEvents()
             nodeEventData[NodeEndContact2D::P_BODY] = contactInfo.bodyB_.Get();
             nodeEventData[NodeEndContact2D::P_OTHERNODE] = contactInfo.nodeA_.Get();
             nodeEventData[NodeEndContact2D::P_OTHERBODY] = contactInfo.bodyA_.Get();
+            nodeEventData[NodeBeginContact2D::P_SHAPE] = contactInfo.shapeB_.Get();
+            nodeEventData[NodeBeginContact2D::P_OTHERSHAPE] = contactInfo.shapeA_.Get();
 
             contactInfo.nodeB_->SendEvent(E_NODEENDCONTACT2D, nodeEventData);
         }
@@ -771,6 +784,8 @@ PhysicsWorld2D::ContactInfo::ContactInfo(b2Contact* contact)
     nodeA_ = bodyA_->GetNode();
     nodeB_ = bodyB_->GetNode();
     contact_ = contact;
+    shapeA_ = (CollisionShape2D*)fixtureA->GetUserData();
+    shapeB_ = (CollisionShape2D*)fixtureB->GetUserData();
 }
 
 PhysicsWorld2D::ContactInfo::ContactInfo(const ContactInfo& other) :
@@ -778,7 +793,9 @@ PhysicsWorld2D::ContactInfo::ContactInfo(const ContactInfo& other) :
     bodyB_(other.bodyB_),
     nodeA_(other.nodeA_),
     nodeB_(other.nodeB_),
-    contact_(other.contact_)
+    contact_(other.contact_),
+    shapeA_(other.shapeA_),
+    shapeB_(other.shapeB_)
 {
 }
 

--- a/Source/Urho3D/Urho2D/PhysicsWorld2D.h
+++ b/Source/Urho3D/Urho2D/PhysicsWorld2D.h
@@ -30,6 +30,7 @@ namespace Urho3D
 {
 
 class Camera;
+class CollisionShape2D;
 class RigidBody2D;
 
 /// 2D Physics raycast hit.
@@ -265,6 +266,10 @@ protected:
         SharedPtr<Node> nodeB_;
         /// Box2D contact.
         b2Contact* contact_;
+        /// Shape A.
+        SharedPtr<CollisionShape2D> shapeA_;
+        /// Shape B.
+        SharedPtr<CollisionShape2D> shapeB_;
     };
     /// Begin contact infos.
     Vector<ContactInfo> beginContactInfos_;


### PR DESCRIPTION
Sometimes it is necessary to identify collided shapes: http://www.iforce2d.net/b2dtut/jumpability

Can we also add to components name_, tags or vars? (currently I compare pointers to identify shape)

EDIT: May be move "name", "vars" and "tags" to Animatable (or Serializable) class?
