### PR TITLE
Improve Box2D integration

### DIFF
--- a/Source/Urho3D/Urho2D/PhysicsEvents2D.h
+++ b/Source/Urho3D/Urho2D/PhysicsEvents2D.h
@@ -31,6 +31,21 @@
 namespace Urho3D
 {
 
+/// Physics update contact. Global event sent by PhysicsWorld2D.
+URHO3D_EVENT(E_PHYSICSUPDATECONTACT2D, PhysicsUpdateContact2D)
+{
+    URHO3D_PARAM(P_WORLD, World);                  // PhysicsWorld2D pointer
+    URHO3D_PARAM(P_BODYA, BodyA);                  // RigidBody2D pointer
+    URHO3D_PARAM(P_BODYB, BodyB);                  // RigidBody2D pointer
+    URHO3D_PARAM(P_NODEA, NodeA);                  // Node pointer
+    URHO3D_PARAM(P_NODEB, NodeB);                  // Node pointer
+    URHO3D_PARAM(P_CONTACT, Contact);              // b2Contact pointer
+    URHO3D_PARAM(P_CONTACTPOINTS, ContactPoints);  // Buffer containing position (Vector2), normal (Vector2), negative overlap distance (float). Normal is the same for all points.
+    URHO3D_PARAM(P_SHAPEA, ShapeA);                // CollisionShape2D pointer
+    URHO3D_PARAM(P_SHAPEB, ShapeB);                // CollisionShape2D pointer
+    URHO3D_PARAM(P_ENABLED, Enabled);              // bool [in/out]
+}
+
 /// Physics begin contact. Global event sent by PhysicsWorld2D.
 URHO3D_EVENT(E_PHYSICSBEGINCONTACT2D, PhysicsBeginContact2D)
 {
@@ -57,6 +72,19 @@ URHO3D_EVENT(E_PHYSICSENDCONTACT2D, PhysicsEndContact2D)
     URHO3D_PARAM(P_CONTACTPOINTS, ContactPoints);  // Buffer containing position (Vector2), normal (Vector2), negative overlap distance (float). Normal is the same for all points.
     URHO3D_PARAM(P_SHAPEA, ShapeA);                // CollisionShape2D pointer
     URHO3D_PARAM(P_SHAPEB, ShapeB);                // CollisionShape2D pointer
+}
+
+/// Node update contact. Sent by scene nodes participating in a collision.
+URHO3D_EVENT(E_NODEUPDATECONTACT2D, NodeUpdateContact2D)
+{
+    URHO3D_PARAM(P_BODY, Body);                    // RigidBody2D pointer
+    URHO3D_PARAM(P_OTHERNODE, OtherNode);          // Node pointer
+    URHO3D_PARAM(P_OTHERBODY, OtherBody);          // RigidBody2D pointer
+    URHO3D_PARAM(P_CONTACT, Contact);              // b2Contact pointer
+    URHO3D_PARAM(P_CONTACTPOINTS, ContactPoints);  // Buffer containing position (Vector2), normal (Vector2), negative overlap distance (float). Normal is the same for all points.
+    URHO3D_PARAM(P_SHAPE, Shape);                  // CollisionShape2D pointer
+    URHO3D_PARAM(P_OTHERSHAPE, OtherShape);        // CollisionShape2D pointer
+    URHO3D_PARAM(P_ENABLED, Enabled);              // bool [in/out]
 }
 
 /// Node begin contact. Sent by scene nodes participating in a collision.

--- a/Source/Urho3D/Urho2D/PhysicsEvents2D.h
+++ b/Source/Urho3D/Urho2D/PhysicsEvents2D.h
@@ -40,6 +40,7 @@ URHO3D_EVENT(E_PHYSICSBEGINCONTACT2D, PhysicsBeginContact2D)
     URHO3D_PARAM(P_NODEA, NodeA);                  // Node pointer
     URHO3D_PARAM(P_NODEB, NodeB);                  // Node pointer
     URHO3D_PARAM(P_CONTACT, Contact);              // b2Contact pointer
+    URHO3D_PARAM(P_CONTACTPOINTS, ContactPoints);  // Buffer containing position (Vector2), normal (Vector2), negative overlap distance (float). Normal is the same for all points.
     URHO3D_PARAM(P_SHAPEA, ShapeA);                // CollisionShape2D pointer
     URHO3D_PARAM(P_SHAPEB, ShapeB);                // CollisionShape2D pointer
 }
@@ -53,6 +54,7 @@ URHO3D_EVENT(E_PHYSICSENDCONTACT2D, PhysicsEndContact2D)
     URHO3D_PARAM(P_NODEA, NodeA);                  // Node pointer
     URHO3D_PARAM(P_NODEB, NodeB);                  // Node pointer
     URHO3D_PARAM(P_CONTACT, Contact);              // b2Contact pointer
+    URHO3D_PARAM(P_CONTACTPOINTS, ContactPoints);  // Buffer containing position (Vector2), normal (Vector2), negative overlap distance (float). Normal is the same for all points.
     URHO3D_PARAM(P_SHAPEA, ShapeA);                // CollisionShape2D pointer
     URHO3D_PARAM(P_SHAPEB, ShapeB);                // CollisionShape2D pointer
 }
@@ -64,6 +66,7 @@ URHO3D_EVENT(E_NODEBEGINCONTACT2D, NodeBeginContact2D)
     URHO3D_PARAM(P_OTHERNODE, OtherNode);          // Node pointer
     URHO3D_PARAM(P_OTHERBODY, OtherBody);          // RigidBody2D pointer
     URHO3D_PARAM(P_CONTACT, Contact);              // b2Contact pointer
+    URHO3D_PARAM(P_CONTACTPOINTS, ContactPoints);  // Buffer containing position (Vector2), normal (Vector2), negative overlap distance (float). Normal is the same for all points.
     URHO3D_PARAM(P_SHAPE, Shape);                  // CollisionShape2D pointer
     URHO3D_PARAM(P_OTHERSHAPE, OtherShape);        // CollisionShape2D pointer
 }
@@ -75,6 +78,7 @@ URHO3D_EVENT(E_NODEENDCONTACT2D, NodeEndContact2D)
     URHO3D_PARAM(P_OTHERNODE, OtherNode);          // Node pointer
     URHO3D_PARAM(P_OTHERBODY, OtherBody);          // RigidBody2D pointer
     URHO3D_PARAM(P_CONTACT, Contact);              // b2Contact pointer
+    URHO3D_PARAM(P_CONTACTPOINTS, ContactPoints);  // Buffer containing position (Vector2), normal (Vector2), negative overlap distance (float). Normal is the same for all points.
     URHO3D_PARAM(P_SHAPE, Shape);                  // CollisionShape2D pointer
     URHO3D_PARAM(P_OTHERSHAPE, OtherShape);        // CollisionShape2D pointer
 }

--- a/Source/Urho3D/Urho2D/PhysicsWorld2D.cpp
+++ b/Source/Urho3D/Urho2D/PhysicsWorld2D.cpp
@@ -148,7 +148,6 @@ void PhysicsWorld2D::EndContact(b2Contact* contact)
         return;
 
     endContactInfos_.Push(ContactInfo(contact));
-    disabledContacts_.Erase(contact);
 }
 
 void PhysicsWorld2D::PreSolve(b2Contact* contact, const b2Manifold* oldManifold)
@@ -158,8 +157,6 @@ void PhysicsWorld2D::PreSolve(b2Contact* contact, const b2Manifold* oldManifold)
     if (!fixtureA || !fixtureB)
         return;
 
-    if (disabledContacts_.Contains(contact))
-        contact->SetEnabled(false);
     ContactInfo contactInfo(contact);
 
     // Send global event
@@ -208,10 +205,6 @@ void PhysicsWorld2D::PreSolve(b2Contact* contact, const b2Manifold* oldManifold)
     }
 
     contact->SetEnabled(eventData[NodeUpdateContact2D::P_ENABLED].GetBool());
-    if (contact->IsEnabled())
-        disabledContacts_.Erase(contact);
-    else
-        disabledContacts_.Insert(contact);
 }
 
 void PhysicsWorld2D::DrawPolygon(const b2Vec2* vertices, int32 vertexCount, const b2Color& color)

--- a/Source/Urho3D/Urho2D/PhysicsWorld2D.h
+++ b/Source/Urho3D/Urho2D/PhysicsWorld2D.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "../Scene/Component.h"
+#include "../IO/VectorBuffer.h"
 
 #include <Box2D/Box2D.h>
 
@@ -275,6 +276,8 @@ protected:
     Vector<ContactInfo> beginContactInfos_;
     /// End contact infos.
     Vector<ContactInfo> endContactInfos_;
+    /// Temporary buffer with contact data.
+    VectorBuffer contacts_;
 };
 
 }

--- a/Source/Urho3D/Urho2D/PhysicsWorld2D.h
+++ b/Source/Urho3D/Urho2D/PhysicsWorld2D.h
@@ -93,6 +93,8 @@ public:
     virtual void BeginContact(b2Contact* contact);
     /// Called when two fixtures cease to touch.
     virtual void EndContact(b2Contact* contact);
+    /// Called when contact is updated.
+    virtual void PreSolve(b2Contact* contact, const b2Manifold* oldManifold);
 
     // Implement b2Draw
     /// Draw a closed polygon provided in CCW order.
@@ -278,6 +280,8 @@ protected:
     Vector<ContactInfo> endContactInfos_;
     /// Temporary buffer with contact data.
     VectorBuffer contacts_;
+    /// Disabled contacts.
+    HashSet<b2Contact*> disabledContacts_;
 };
 
 }

--- a/Source/Urho3D/Urho2D/PhysicsWorld2D.h
+++ b/Source/Urho3D/Urho2D/PhysicsWorld2D.h
@@ -280,8 +280,6 @@ protected:
     Vector<ContactInfo> endContactInfos_;
     /// Temporary buffer with contact data.
     VectorBuffer contacts_;
-    /// Disabled contacts.
-    HashSet<b2Contact*> disabledContacts_;
 };
 
 }


### PR DESCRIPTION
- Added serialized contact info for each physical2D event;
  + Temporary pre-allocated buffer inside PhysicsWorld2D is used, so it shan't be heavy;
  + New parameter is called `ContactPoints` and similar to `Contacts` parameter of physical events;
  + I wanted to call new parameter `Contacts` too, but it can be easily mixed up with already existing `Contact` parameter. May be discussed.

- Added event for contact update.
  + Similar to `NodeCollision` event, called from Box2D internals while contact is on between pre-step and post-step;
  + Can be used for simple check of ongoing contact in script logic;
  + Contact may be disabled in event handler;
  + Can be used for creating simple one-way obstacles and so on.

- By default Box2D re-enable contact before each check. I disabled this behavior because I find it disturbing. One can easily re-enable any contact on his own.