### PR TITLE
Fix jumping slider knob when it's size is fixed.

### DIFF
--- a/Source/Urho3D/UI/Slider.cpp
+++ b/Source/Urho3D/UI/Slider.cpp
@@ -236,7 +236,7 @@ void Slider::UpdateSlider()
         {
             int sliderLength = (int)Max((float)GetWidth() / (range_ + 1.0f), (float)(border.left_ + border.right_));
 
-            if (knob_->IsFixedSize())
+            if (knob_->IsFixedWidth())
                 sliderLength = knob_->GetWidth();
 
             float sliderPos = (float)(GetWidth() - sliderLength) * value_ / range_;
@@ -253,7 +253,7 @@ void Slider::UpdateSlider()
         {
             int sliderLength = (int)Max((float)GetHeight() / (range_ + 1.0f), (float)(border.top_ + border.bottom_));
 
-            if (knob_->IsFixedSize())
+            if (knob_->IsFixedHeight())
                 sliderLength = knob_->GetHeight();
 
             float sliderPos = (float)(GetHeight() - sliderLength) * value_ / range_;


### PR DESCRIPTION
Slider has a feature where setting min and max size of knob allows us to control it's size. However when knob size is enlarged moving know causes it to jump forward and back. This change fixes the issue.