### PR TITLE
Fixed blend modes for 2D particles

### DIFF
--- a/Source/Urho3D/Urho2D/ParticleEffect2D.cpp
+++ b/Source/Urho3D/Urho2D/ParticleEffect2D.cpp
@@ -43,7 +43,9 @@ static const int srcBlendFuncs[] =
     0x0302, // GL_SRC_ALPHA
     0x0302, // GL_SRC_ALPHA
     1,      // GL_ONE
-    0x0305  // GL_ONE_MINUS_DST_ALPHA
+    0x0305, // GL_ONE_MINUS_DST_ALPHA
+    1,      // GL_ONE
+    0x0302  // GL_SRC_ALPHA
 };
 
 static const int destBlendFuncs[] =
@@ -54,8 +56,17 @@ static const int destBlendFuncs[] =
     0x0303, // GL_ONE_MINUS_SRC_ALPHA
     1,      // GL_ONE
     0x0303, // GL_ONE_MINUS_SRC_ALPHA
-    0x0304  // GL_DST_ALPHA
+    0x0304, // GL_DST_ALPHA
+    1,      // GL_ONE
+    1       // GL_ONE
 };
+
+#if URHO3D_CXX11
+// Make sure that there are are as many blend functions as we have blend modes.
+static_assert(sizeof(srcBlendFuncs) / sizeof(srcBlendFuncs[0]) == MAX_BLENDMODES, "");
+static_assert(sizeof(destBlendFuncs) / sizeof(destBlendFuncs[0]) == MAX_BLENDMODES, "");
+#endif
+
 
 ParticleEffect2D::ParticleEffect2D(Context* context) :
     Resource(context),


### PR DESCRIPTION
The 2D particles had missing blend mode functions for
BlendMode::BLEND_SUBTRACT and BLEND_SUBTRACTALPHA. The values for the
functions have been copied from OGLGraphics.cpp.

If C++11 is enabled, the size of the struct is checked with a static
assertion, now.