### PR TITLE
Populate a newly created rapidjson-value before adding it to the parent.

### DIFF
--- a/Source/Urho3D/Resource/JSONFile.cpp
+++ b/Source/Urho3D/Resource/JSONFile.cpp
@@ -186,8 +186,8 @@ static void ToRapidjsonValue(rapidjson::Value& rapidjsonValue, const JSONValue& 
             for (unsigned i = 0; i < jsonArray.Size(); ++i)
             {
                 rapidjson::Value value;
+                ToRapidjsonValue(value, jsonArray[i], allocator);
                 rapidjsonValue.PushBack(value, allocator);
-                ToRapidjsonValue(rapidjsonValue[i], jsonArray[i], allocator);
             }
         }
         break;
@@ -201,8 +201,8 @@ static void ToRapidjsonValue(rapidjson::Value& rapidjsonValue, const JSONValue& 
             {
                 const char* name = i->first_.CString();
                 rapidjson::Value value;
+                ToRapidjsonValue(value, i->second_, allocator);
                 rapidjsonValue.AddMember(name, value, allocator);
-                ToRapidjsonValue(rapidjsonValue[name], i->second_, allocator);
             }
         }
         break;


### PR DESCRIPTION
When converting JSONValue to rapidsjon::Value, create the array elements and
object properties fully before adding them to rapidjson. This makes the
whole operation more efficient because it avoids a useless lookup on the
newly created/added elements.