### PR TITLE
Added missing includes.

### DIFF
--- a/Source/Urho3D/Scene/ValueAnimationInfo.h
+++ b/Source/Urho3D/Scene/ValueAnimationInfo.h
@@ -22,7 +22,9 @@
 
 #pragma once
 
+#include "../Container/Ptr.h"
 #include "../Container/RefCounted.h"
+#include "../Core/Variant.h"
 #include "../Scene/AnimationDefs.h"
 
 namespace Urho3D


### PR DESCRIPTION
The header ValueInformationInfo.h did not include the Variant.h and so its usage was sensitive to
the include oder.