### PR TITLE
fixes #1907 - Compiler error when URHO3D_IK=OFF

### DIFF
--- a/Source/Urho3D/AngelScript/IKAPI.cpp
+++ b/Source/Urho3D/AngelScript/IKAPI.cpp
@@ -20,7 +20,7 @@
 // THE SOFTWARE.
 //
 
-#ifdef URHO3D_PHYSICS
+#ifdef URHO3D_IK
 
 #include "../Precompiled.h"
 

--- a/Source/Urho3D/Core/Context.cpp
+++ b/Source/Urho3D/Core/Context.cpp
@@ -279,6 +279,7 @@ void Context::ReleaseSDL()
         URHO3D_LOGERROR("Too many calls to Context::ReleaseSDL()!");
 }
 
+#ifdef URHO3D_IK
 void Context::RequireIK()
 {
     // Always increment, the caller must match with ReleaseSDL(), regardless of
@@ -309,7 +310,8 @@ void Context::ReleaseIK()
     if (ikInitCounter < 0)
         URHO3D_LOGERROR("Too many calls to Context::ReleaseIK()");
 }
-#endif
+#endif // ifdef URHO3D_IK
+#endif // ifndef MINI_URHO
 
 void Context::CopyBaseAttributes(StringHash baseType, StringHash derivedType)
 {


### PR DESCRIPTION
Is the sample 45_InverseKinematics supposed to fail compilation if you set URHO3D_IK=OFF? I don't see any header guards around the physics samples (though I haven't tried compiling the physics samples with URHO3D_PHYSICS=OFF).