### PR TITLE
PackageTool.cpp: PVS-Studio: fixed conditional expression of the loop.

### DIFF
--- a/Source/Tools/PackageTool/PackageTool.cpp
+++ b/Source/Tools/PackageTool/PackageTool.cpp
@@ -145,7 +145,7 @@ void Run(const Vector<String>& arguments)
         for (unsigned i = fileNames.Size() - 1; i < fileNames.Size(); --i)
         {
             String extension = GetExtension(fileNames[i]);
-            for (unsigned j = 0; ignoreExtensions_[j].Length(); ++j)
+            for (unsigned j = 0; j < ignoreExtensions_[j].Length(); ++j)
             {
                 if (extension == ignoreExtensions_[j])
                 {


### PR DESCRIPTION
We have found and fixed a bug using PVS-Studio tool. PVS-Studio is a static code analyzer for C, C++ and C#: https://www.viva64.com/en/pvs-studio/

We suggests having a look at the emails, sent from @pvs-studio.com.

Analyzer warning: [V693](https://www.viva64.com/en/w/V693/) Consider inspecting conditional expression of the loop. It is possible that 'i < X.size()' should be used instead of 'X.size()'. PackageTool.cpp 148