### PR TITLE
IKSolver.spp: PVS-Studio: Non-void function should return a value

### DIFF
--- a/Source/Urho3D/IK/IKSolver.cpp
+++ b/Source/Urho3D/IK/IKSolver.cpp
@@ -54,6 +54,8 @@ static bool ChildrenHaveEffector(const Node* node)
         if (ChildrenHaveEffector(it->Get()))
             return true;
     }
+
+    return false;
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
We have found and fixed a bug using PVS-Studio tool. PVS-Studio is a static code analyzer for C, C++ and C#: https://www.viva64.com/en/pvs-studio/

We suggests having a look at the emails, sent from @pvs-studio.com.

Analyzer warning: [V591](https://www.viva64.com/en/w/V591/) Non-void function should return a value. IKSolver.cpp 57
