### PR TITLE
Help the compiler eliminate calls to strlen at compile time, wherever possible.

### DIFF
--- a/Source/Urho3D/Container/Str.h
+++ b/Source/Urho3D/Container/Str.h
@@ -64,17 +64,17 @@ template <typename T> struct IsNotCharPtr<char*, T>
 {
 };
 
-/// Exclude (at compile-time, if possible) the null character from the actual size of string literals and/or array of caharacters.
+/// Exclude (at compile-time, if possible) the null character from the actual size of string literals and/or array of characters.
 template < unsigned N > inline unsigned LiteralStrLen(const char(&a)[N])
 {
-    return a[N-1] == '\0' ? N-1 : N;
+    return a[N-1] == '\0' ? N-1 : strlen(a);
 }
-/// Exclude (at compile-time, if possible) the null character from the actual size of string literals and/or array of caharacters.
+/// Exclude (at compile-time, if possible) the null character from the actual size of string literals and/or array of characters.
 inline unsigned LiteralStrLen(const char(&a)[1])
 {
     return a[0] == '\0' ? 0 : 1;
 }
-/// Exclude (at compile-time, if possible) the null character from the actual size of string literals and/or array of caharacters.
+/// Exclude (at compile-time, if possible) the null character from the actual size of string literals and/or array of characters.
 inline unsigned LiteralStrLen(const char(&)[0])
 {
     return 0;
@@ -632,7 +632,7 @@ private:
 #endif
     }
 
-    /// Append with a C string of known length.
+    /// Append a C string of known length.
     void Add(const char* str, unsigned length)
     {
         unsigned oldLength = length_;
@@ -640,7 +640,7 @@ private:
         CopyChars(&buffer_[oldLength], str, length);
     }
 
-    /// Assign with a C string of known length.
+    /// Assign a C string of known length.
     void Set(const char* str, unsigned length)
     {
         Resize(length);


### PR DESCRIPTION
Also Fix add-assign operator of arbitrary types to return a reference and not a copy.

Normally you would see this using something like `constexpr` but since there's heap memory involved, might have undesired results. However, any decent compiler is able to fold `LiteralStrLen` at compile-time.

I know these kinds of additions are likely to be discarded but I thought I should make a pull request anyway.

Performance wise, I opened the Character demo and left it on idle after I pressed F2 to bring the debug text (so there's some actual text being used). Without this, the CPU was averaging around 19-21% and with it, around 8-10%. Might have to run some further tests to see how much (if any) performance is gained.

I've tried this with MinGW 7.1 x64. Although, theoretically, the code should be C++98 compatible.