### PR TITLE
Hash code calculation for Vector3

### DIFF
--- a/Source/Urho3D/Math/MathDefs.h
+++ b/Source/Urho3D/Math/MathDefs.h
@@ -272,6 +272,15 @@ inline float HalfToFloat(unsigned short value)
     return out;
 }
 
+// Returns a representation of the specified floating-point value as a single format bit layout.
+inline unsigned FloatToRawIntBits(float x)
+{
+    unsigned y;
+	memcpy(&y, &x, 4);
+	
+    return y;
+}
+
 /// Calculate both sine and cosine, with angle in degrees.
 URHO3D_API void SinCos(float angle, float& sin, float& cos);
 

--- a/Source/Urho3D/Math/MathDefs.h
+++ b/Source/Urho3D/Math/MathDefs.h
@@ -276,7 +276,7 @@ inline float HalfToFloat(unsigned short value)
 inline unsigned FloatToRawIntBits(float x)
 {
     unsigned y;
-	memcpy(&y, &x, 4);
+    memcpy(&y, &x, 4);
 	
     return y;
 }

--- a/Source/Urho3D/Math/Vector3.h
+++ b/Source/Urho3D/Math/Vector3.h
@@ -23,7 +23,7 @@
 #pragma once
 
 #include "../Math/Vector2.h"
-#incluide "../Math/MathDefs.h"
+#include "../Math/MathDefs.h"
 
 namespace Urho3D
 {

--- a/Source/Urho3D/Math/Vector3.h
+++ b/Source/Urho3D/Math/Vector3.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "../Math/Vector2.h"
+#incluide "../Math/MathDefs.h"
 
 namespace Urho3D
 {
@@ -402,6 +403,17 @@ public:
 
     /// Return as string.
     String ToString() const;
+    
+    /// Return hash value for HashSet & HashMap.
+    unsigned ToHash() const 
+    { 
+        unsigned hash = 37;
+        hash = 37 * hash + FloatToRawIntBits(x_);
+        hash = 37 * hash + FloatToRawIntBits(y_);
+        hash = 37 * hash + FloatToRawIntBits(z_);
+        
+        return hash;
+    }
 
     /// X coordinate.
     float x_;


### PR DESCRIPTION
Useful for creating hashed adjacency lists for navigation meshes.