### PR TITLE
Static VertexBuffer::UpdateOffsets()

### DIFF
--- a/Source/Urho3D/Graphics/VertexBuffer.cpp
+++ b/Source/Urho3D/Graphics/VertexBuffer.cpp
@@ -202,4 +202,15 @@ unsigned VertexBuffer::GetVertexSize(unsigned elementMask)
     return size;
 }
 
+void VertexBuffer::UpdateOffsets(PODVector<VertexElement>& elements)
+{
+    unsigned elementOffset = 0;
+
+    for (PODVector<VertexElement>::Iterator i = elements.Begin(); i != elements.End(); ++i)
+    {
+        i->offset_ = elementOffset;
+        elementOffset += ELEMENT_TYPESIZES[i->type_];
+    }
+}
+
 }

--- a/Source/Urho3D/Graphics/VertexBuffer.h
+++ b/Source/Urho3D/Graphics/VertexBuffer.h
@@ -129,6 +129,9 @@ public:
     /// Return vertex size for a legacy vertex element bitmask.
     static unsigned GetVertexSize(unsigned elementMask);
 
+    /// Update offsets of vertex elements.
+    static void UpdateOffsets(PODVector<VertexElement>& elements);
+
 private:
     /// Update offsets of vertex elements.
     void UpdateOffsets();


### PR DESCRIPTION
I noticed VertexBuffer has many static functions to handle `PODVector<VertexElement> elements` that are outside VertexBuffer. However, it is missing a static function to update offsets of elements, so static `VertexBuffer::GetElementOffset()` does not work in certain situations. This PR adds a new static function that user can manually call to calculate offsets.

I tested it in one of my projects and it seems to work.

Another option would be to not use precalculated values, and do more manual work in static `VertexBuffer::GetElementOffset()`.