### PR TITLE
Add a 'Typography' sample program

### DIFF
--- a/Source/Samples/47_Typography/CMakeLists.txt
+++ b/Source/Samples/47_Typography/CMakeLists.txt
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2008-2017 the Urho3D project.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+# Define target name
+set (TARGET_NAME 47_Typography)
+
+# Define source files
+define_source_files (EXTRA_H_FILES ${COMMON_SAMPLE_H_FILES})
+
+# Setup target with resource copying
+setup_main_executable ()
+
+# Setup test cases
+setup_test ()

--- a/Source/Samples/47_Typography/Typography.cpp
+++ b/Source/Samples/47_Typography/Typography.cpp
@@ -1,0 +1,177 @@
+//
+// Copyright (c) 2008-2017 the Urho3D project.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include <Urho3D/Core/CoreEvents.h>
+#include <Urho3D/Core/ProcessUtils.h>
+#include <Urho3D/Graphics/RenderPath.h>
+#include <Urho3D/Graphics/Zone.h>
+#include <Urho3D/Input/Input.h>
+#include <Urho3D/UI/CheckBox.h>
+#include <Urho3D/UI/Font.h>
+#include <Urho3D/UI/Text.h>
+#include <Urho3D/UI/UI.h>
+#include <Urho3D/UI/UIEvents.h>
+
+#include "Typography.h"
+
+#include <Urho3D/DebugNew.h>
+
+// Expands to this example's entry-point
+URHO3D_DEFINE_APPLICATION_MAIN(Typography)
+
+namespace
+{
+    // Tag used to find all Text elements
+    const String TEXT_TAG("Typography_text_tag");
+}
+
+Typography::Typography(Context* context) :
+    Sample(context)
+{
+}
+
+void Typography::Start()
+{
+    // Execute base class startup
+    Sample::Start();
+
+    // Enable OS cursor
+    GetSubsystem<Input>()->SetMouseVisible(true);
+
+    // Load XML file containing default UI style sheet
+    ResourceCache* cache = GetSubsystem<ResourceCache>();
+    XMLFile* style = cache->GetResource<XMLFile>("UI/DefaultStyle.xml");
+
+    // Set the loaded style as default style
+    UIElement* root = GetSubsystem<UI>()->GetRoot();
+    root->SetDefaultStyle(style);
+
+    // Create a UIElement to hold all our content
+    // (Don't modify the root directly, as the base Sample class uses it)
+    uielement_ = new UIElement(context_);
+    uielement_->SetAlignment(HA_CENTER, VA_CENTER);
+    uielement_->SetLayout(LM_VERTICAL, 20, IntRect(20, 40, 20, 40));
+    root->AddChild(uielement_);
+
+    // Add some sample text.
+    CreateText();
+
+    // Add a checkbox to toggle the background color.
+    CreateCheckbox("White background", URHO3D_HANDLER(Typography, HandleWhiteBackground));
+
+    // Add a checkbox for the global ForceAutoHint setting. This affects character spacing.
+    CreateCheckbox("UI::SetForceAutoHint", URHO3D_HANDLER(Typography, HandleForceAutoHint));
+
+    // Add a checkbox to toggle SRGB output conversion (if available).
+    // This will give more correct text output for FreeType fonts, as the FreeType rasterizer
+    // outputs linear coverage values rather than SRGB values. However, this feature isn't
+    // available on all platforms.
+    CreateCheckbox("Graphics::SetSRGB", URHO3D_HANDLER(Typography, HandleSRGB));
+
+    // Set the mouse mode to use in the sample
+    Sample::InitMouseMode(MM_FREE);
+}
+
+void Typography::CreateText()
+{
+    SharedPtr<UIElement> container(new UIElement(context_));
+    container->SetAlignment(HA_LEFT, VA_TOP);
+    container->SetLayout(LM_VERTICAL);
+    uielement_->AddChild(container);
+
+    ResourceCache* cache = GetSubsystem<ResourceCache>();
+    Font* font = cache->GetResource<Font>("Fonts/BlueHighway.ttf");
+
+    for (int size = 1; size <= 24; ++size)
+    {
+        SharedPtr<Text> text(new Text(context_));
+        text->SetText(String("The quick brown fox jumps over the lazy dog (") + String(size) + String("pt)"));
+        text->SetFont(font, size);
+        text->AddTag(TEXT_TAG);
+        container->AddChild(text);
+    }
+}
+
+void Typography::CreateCheckbox(const String& label, EventHandler* handler)
+{
+    SharedPtr<UIElement> container(new UIElement(context_));
+    container->SetAlignment(HA_LEFT, VA_TOP);
+    container->SetLayout(LM_HORIZONTAL, 8);
+    uielement_->AddChild(container);
+
+    SharedPtr<CheckBox> box(new CheckBox(context_));
+    container->AddChild(box);
+    box->SetStyleAuto();
+
+    SharedPtr<Text> text(new Text(context_));
+    container->AddChild(text);
+    text->SetText(label);
+    text->SetStyleAuto();
+    text->AddTag(TEXT_TAG);
+
+    SubscribeToEvent(box, E_TOGGLED, handler);
+}
+
+void Typography::HandleWhiteBackground(StringHash eventType, VariantMap& eventData)
+{
+    CheckBox* box = static_cast<CheckBox*>(eventData[Toggled::P_ELEMENT].GetPtr());
+    bool checked = box->IsChecked();
+
+    Color fg = checked ? Color::BLACK : Color::WHITE;
+    Color bg = checked ? Color::WHITE : Color::BLACK;
+
+    Renderer* renderer = GetSubsystem<Renderer>();
+    Zone* zone = renderer->GetDefaultZone();
+    zone->SetFogColor(bg);
+
+    PODVector<UIElement*> text = uielement_->GetChildrenWithTag(TEXT_TAG, true);
+    for (int i = 0; i < text.Size(); i++)
+    {
+        text[i]->SetColor(fg);
+    }
+}
+
+void Typography::HandleForceAutoHint(StringHash eventType, VariantMap& eventData)
+{
+    CheckBox* box = static_cast<CheckBox*>(eventData[Toggled::P_ELEMENT].GetPtr());
+    bool checked = box->IsChecked();
+    GetSubsystem<UI>()->SetForceAutoHint(checked);
+}
+
+void Typography::HandleSRGB(StringHash eventType, VariantMap& eventData)
+{
+    CheckBox* box = static_cast<CheckBox*>(eventData[Toggled::P_ELEMENT].GetPtr());
+    bool checked = box->IsChecked();
+
+    Graphics* graphics = GetSubsystem<Graphics>();
+    if (graphics->GetSRGBWriteSupport())
+    {
+        graphics->SetSRGB(checked);
+    }
+    else
+    {
+        URHO3D_LOGWARNING("Graphics::GetSRGBWriteSupport returned false");
+
+        // Note: PostProcess/GammaCorrection.xml implements SRGB conversion.
+        // However, post-processing filters don't affect the UI layer.
+    }
+}

--- a/Source/Samples/47_Typography/Typography.h
+++ b/Source/Samples/47_Typography/Typography.h
@@ -1,0 +1,59 @@
+//
+// Copyright (c) 2008-2017 the Urho3D project.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+#include "Sample.h"
+
+/// Text rendering example.
+/// Displays text at various sizes, with checkboxes to change the rendering parameters.
+class Typography : public Sample
+{
+    URHO3D_OBJECT(Typography, Sample);
+
+public:
+    /// Construct.
+    Typography(Context* context);
+
+    /// Setup after engine initialization and before running the main loop.
+    virtual void Start();
+
+protected:
+    /// Return XML patch instructions for screen joystick layout for a specific sample app, if any.
+    virtual String GetScreenJoystickPatchString() const { return
+        "<patch>"
+        "    <add sel=\"/element/element[./attribute[@name='Name' and @value='Hat0']]\">"
+        "        <attribute name=\"Is Visible\" value=\"false\" />"
+        "    </add>"
+        "</patch>";
+    }
+
+private:
+    SharedPtr<UIElement> uielement_;
+
+    void CreateText();
+    void CreateCheckbox(const String& label, EventHandler* handler);
+
+    void HandleWhiteBackground(StringHash eventType, VariantMap& eventData);
+    void HandleSRGB(StringHash eventType, VariantMap& eventData);
+    void HandleForceAutoHint(StringHash eventType, VariantMap& eventData);
+};

--- a/bin/Data/LuaScripts/47_Typography.lua
+++ b/bin/Data/LuaScripts/47_Typography.lua
@@ -1,0 +1,128 @@
+-- Text rendering example.
+-- Displays text at various sizes, with checkboxes to change the rendering parameters.
+
+require "LuaScripts/Utilities/Sample"
+
+-- Tag used to find all Text elements
+local TEXT_TAG = "Typography_text_tag"
+
+-- Top-level container for this sample's UI
+local uielement = nil
+
+function Start()
+    -- Execute the common startup for samples
+    SampleStart()
+
+    -- Enable OS cursor
+    input.mouseVisible = true
+
+    -- Load XML file containing default UI style sheet
+    local style = cache:GetResource("XMLFile", "UI/DefaultStyle.xml")
+
+    -- Set the loaded style as default style
+    ui.root.defaultStyle = style
+
+    -- Create a UIElement to hold all our content
+    -- (Don't modify the root directly, as the base Sample class uses it)
+    uielement = UIElement:new()
+    uielement:SetAlignment(HA_CENTER, VA_CENTER)
+    uielement:SetLayout(LM_VERTICAL, 20, IntRect(20, 40, 20, 40))
+    ui.root:AddChild(uielement)
+
+    -- Add some sample text
+    CreateText()
+
+    -- Add a checkbox to toggle the background color.
+    CreateCheckbox("White background", "HandleWhiteBackground")
+
+    -- Add a checkbox for the global ForceAutoHint setting. This affects character spacing.
+    CreateCheckbox("UI::SetForceAutoHint", "HandleForceAutoHint")
+
+    -- Add a checkbox to toggle SRGB output conversion (if available).
+    -- This will give more correct text output for FreeType fonts, as the FreeType rasterizer
+    -- outputs linear coverage values rather than SRGB values. However, this feature isn't
+    -- available on all platforms.
+    CreateCheckbox("Graphics::SetSRGB", "HandleSRGB")
+
+    -- Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE)
+end
+
+function CreateText()
+    local container = UIElement:new()
+    container:SetAlignment(HA_LEFT, VA_TOP)
+    container:SetLayout(LM_VERTICAL)
+    uielement:AddChild(container)
+
+    local font = cache:GetResource("Font", "Fonts/BlueHighway.ttf")
+
+    for size = 1, 24 do
+        local text = Text:new()
+        text.text = "The quick brown fox jumps over the lazy dog (" .. size .. "pt)"
+        text:SetFont(font, size)
+        text:AddTag(TEXT_TAG)
+        container:AddChild(text)
+    end
+end
+
+function CreateCheckbox(label, handler)
+    local container = UIElement:new()
+    container:SetAlignment(HA_LEFT, VA_TOP)
+    container:SetLayout(LM_HORIZONTAL, 8)
+    uielement:AddChild(container)
+    
+    local box = CheckBox:new()
+    container:AddChild(box)
+    box:SetStyleAuto()
+    
+    local text = Text:new()
+    container:AddChild(text)
+    text.text = label
+    text:SetStyleAuto()
+    text:AddTag(TEXT_TAG)
+
+    SubscribeToEvent(box, "Toggled", handler)
+end
+
+function HandleWhiteBackground(eventType, eventData)
+    local box = eventData["Element"]:GetPtr("CheckBox")
+    local checked = box:IsChecked()
+
+    local fg = checked and Color.BLACK or Color.WHITE
+    local bg = checked and Color.WHITE or Color.BLACK
+    
+    renderer.defaultZone.fogColor = bg
+
+    local elements = uielement:GetChildrenWithTag(TEXT_TAG, true)
+    for i, element in ipairs(elements) do
+        element.color = fg
+    end
+end
+
+function HandleForceAutoHint(eventType, eventData)
+    local box = eventData["Element"]:GetPtr("CheckBox")
+    local checked = box:IsChecked()
+
+    ui:SetForceAutoHint(checked)
+end
+
+function HandleSRGB(eventType, eventData)
+    local box = eventData["Element"]:GetPtr("CheckBox")
+    local checked = box:IsChecked()
+
+    if graphics:GetSRGBWriteSupport() then
+        graphics:SetSRGB(checked)
+    else
+        log:Write(LOG_WARNING, "graphics:GetSRGBWriteSupport returned false")
+    end
+end
+
+-- Create XML patch instructions for screen joystick layout specific to this sample app
+function GetScreenJoystickPatchString()
+    return
+        "<patch>" ..
+        "    <add sel=\"/element/element[./attribute[@name='Name' and @value='Hat0']]\">" ..
+        "        <attribute name=\"Is Visible\" value=\"false\" />" ..
+        "    </add>" ..
+        "</patch>"
+end

--- a/bin/Data/Scripts/47_Typography.as
+++ b/bin/Data/Scripts/47_Typography.as
@@ -1,0 +1,137 @@
+// Text rendering example.
+// Displays text at various sizes, with checkboxes to change the rendering parameters.
+
+#include "Scripts/Utilities/Sample.as"
+
+// Tag used to find all Text elements
+String TEXT_TAG = "Typography_text_tag";
+
+// Top-level container for this sample's UI
+UIElement@ uielement;
+
+void Start()
+{
+    // Execute the common startup for samples
+    SampleStart();
+
+    // Enable OS cursor
+    input.mouseVisible = true;
+
+    // Load XML file containing default UI style sheet
+    XMLFile@ style = cache.GetResource("XMLFile", "UI/DefaultStyle.xml");
+
+    // Set the loaded style as default style
+    ui.root.defaultStyle = style;
+
+    // Create a UIElement to hold all our content
+    // (Don't modify the root directly, as the base Sample class uses it)
+    uielement = UIElement();
+    uielement.SetAlignment(HA_CENTER, VA_CENTER);
+    uielement.SetLayout(LM_VERTICAL, 20, IntRect(20, 40, 20, 40));
+    ui.root.AddChild(uielement);
+    
+    // Add some sample text
+    CreateText();
+
+    // Add a checkbox to toggle the background color.
+    CreateCheckbox("White background", "HandleWhiteBackground");
+
+    // Add a checkbox for the global ForceAutoHint setting. This affects character spacing.
+    CreateCheckbox("UI::SetForceAutoHint", "HandleForceAutoHint");
+
+    // Add a checkbox to toggle SRGB output conversion (if available).
+    // This will give more correct text output for FreeType fonts, as the FreeType rasterizer
+    // outputs linear coverage values rather than SRGB values. However, this feature isn't
+    // available on all platforms.
+    CreateCheckbox("Graphics::SetSRGB", "HandleSRGB");
+
+    // Set the mouse mode to use in the sample
+    SampleInitMouseMode(MM_FREE);
+}
+
+void CreateText()
+{
+    UIElement@ container = UIElement();
+    container.SetAlignment(HA_LEFT, VA_TOP);
+    container.SetLayout(LM_VERTICAL);
+    uielement.AddChild(container);
+    
+    Font@ font = cache.GetResource("Font", "Fonts/BlueHighway.ttf");
+    
+    for (int size = 1; size <= 24; ++size)
+    {
+        Text@ text = Text();
+        text.text = "The quick brown fox jumps over the lazy dog (" + size + "pt)";
+        text.SetFont(font, size);
+        text.AddTag(TEXT_TAG);
+        container.AddChild(text);
+    }
+}
+
+void CreateCheckbox(String label, String handler)
+{
+    UIElement@ container = UIElement();
+    container.SetAlignment(HA_LEFT, VA_TOP);
+    container.SetLayout(LM_HORIZONTAL, 8);
+    uielement.AddChild(container);
+    
+    CheckBox@ box = CheckBox();
+    container.AddChild(box);
+    box.SetStyleAuto();
+    
+    Text@ text = Text();
+    container.AddChild(text);
+    text.text = label;
+    text.SetStyleAuto();
+    text.AddTag(TEXT_TAG);
+
+    SubscribeToEvent(box, "Toggled", handler);
+}
+
+void HandleWhiteBackground(StringHash eventType, VariantMap& eventData)
+{
+    CheckBox@ box = eventData["Element"].GetPtr();
+    bool checked = box.checked;
+
+    Color fg = checked ? BLACK : WHITE;
+    Color bg = checked ? WHITE : BLACK;
+    
+    renderer.defaultZone.fogColor = bg;
+
+    Array<UIElement@>@ elements = uielement.GetChildrenWithTag(TEXT_TAG, true);
+    for (int i = 0; i < elements.length; ++i)
+    {
+        elements[i].color = fg;
+    }
+}
+
+void HandleForceAutoHint(StringHash eventType, VariantMap& eventData)
+{
+    CheckBox@ box = eventData["Element"].GetPtr();
+    bool checked = box.checked;
+
+    ui.forceAutoHint = checked;
+}
+
+void HandleSRGB(StringHash eventType, VariantMap& eventData)
+{
+    CheckBox@ box = eventData["Element"].GetPtr();
+    bool checked = box.checked;
+
+    if (graphics.sRGBWriteSupport)
+    {
+        graphics.sRGB = checked;
+    }
+    else
+    {
+        log.Warning("graphics.sRGBWriteSupport is false");
+    }
+}
+
+// Create XML patch instructions for screen joystick layout specific to this sample app
+String patchInstructions =
+        "<patch>" +
+        "    <add sel=\"/element/element[./attribute[@name='Name' and @value='Hat0']]\">" +
+        "        <attribute name=\"Is Visible\" value=\"false\" />" +
+        "    </add>" +
+        "</patch>";


### PR DESCRIPTION
Displays text in various sizes, with checkboxes to play with settings that affect the way text is rendered:
- Color (white-on-black versus black-on-white)
- Autohinter
- SRGB output conversion (not available on all platforms)