### PR TITLE
Fixed PBR artifacts

### DIFF
--- a/Source/Samples/42_PBRMaterials/PBRMaterials.cpp
+++ b/Source/Samples/42_PBRMaterials/PBRMaterials.cpp
@@ -220,6 +220,8 @@ void PBRMaterials::SetupViewport()
     SharedPtr<RenderPath> effectRenderPath = viewport->GetRenderPath()->Clone();
     effectRenderPath->Append(cache->GetResource<XMLFile>("PostProcess/FXAA2.xml"));
     effectRenderPath->Append(cache->GetResource<XMLFile>("PostProcess/GammaCorrection.xml"));
+	effectRenderPath->Append(cache->GetResource<XMLFile>("PostProcess/Tonemap.xml"));
+	effectRenderPath->Append(cache->GetResource<XMLFile>("PostProcess/AutoExposure.xml"));
 
     viewport->SetRenderPath(effectRenderPath);
 }

--- a/bin/Autoload/LargeData/Materials/PBR/Check.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/Check.xml
@@ -17,6 +17,7 @@
 	<fill value="solid" />
 	<depthbias constant="0" slopescaled="0" />
 	<alphatocoverage enable="false" />
+	<lineantialias enable="false" />
 	<renderorder value="128" />
 	<occlusion enable="true" />
 </material>

--- a/bin/Autoload/LargeData/Materials/PBR/HighRoughMetallic0.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/HighRoughMetallic0.xml
@@ -3,7 +3,7 @@
 	<technique name="Techniques/PBR/PBRNoTexture.xml" quality="0" loddistance="0" />
 	<parameter name="UOffset" value="1 0 0 0" />
 	<parameter name="VOffset" value="0 1 0 0" />
-	<parameter name="MatDiffColor" value="1 1 1 1" />
+	<parameter name="MatDiffColor" value="0.8 0.3 0.1 1" />
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
@@ -13,5 +13,8 @@
 	<shadowcull value="ccw" />
 	<fill value="solid" />
 	<depthbias constant="0" slopescaled="0" />
+	<alphatocoverage enable="false" />
+	<lineantialias enable="false" />
 	<renderorder value="128" />
+	<occlusion enable="true" />
 </material>

--- a/bin/Autoload/LargeData/Materials/PBR/HighRoughMetallic10.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/HighRoughMetallic10.xml
@@ -3,7 +3,7 @@
 	<technique name="Techniques/PBR/PBRNoTexture.xml" quality="0" loddistance="0" />
 	<parameter name="UOffset" value="1 0 0 0" />
 	<parameter name="VOffset" value="0 1 0 0" />
-	<parameter name="MatDiffColor" value="1 1 1 1" />
+	<parameter name="MatDiffColor" value="0.8 0.3 0.1 1" />
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
@@ -13,5 +13,8 @@
 	<shadowcull value="ccw" />
 	<fill value="solid" />
 	<depthbias constant="0" slopescaled="0" />
+	<alphatocoverage enable="false" />
+	<lineantialias enable="false" />
 	<renderorder value="128" />
+	<occlusion enable="true" />
 </material>

--- a/bin/Autoload/LargeData/Materials/PBR/HighRoughMetallic3.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/HighRoughMetallic3.xml
@@ -3,7 +3,7 @@
 	<technique name="Techniques/PBR/PBRNoTexture.xml" quality="0" loddistance="0" />
 	<parameter name="UOffset" value="1 0 0 0" />
 	<parameter name="VOffset" value="0 1 0 0" />
-	<parameter name="MatDiffColor" value="1 1 1 1" />
+	<parameter name="MatDiffColor" value="0.8 0.3 0.1 1" />
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
@@ -13,5 +13,8 @@
 	<shadowcull value="ccw" />
 	<fill value="solid" />
 	<depthbias constant="0" slopescaled="0" />
+	<alphatocoverage enable="false" />
+	<lineantialias enable="false" />
 	<renderorder value="128" />
+	<occlusion enable="true" />
 </material>

--- a/bin/Autoload/LargeData/Materials/PBR/HighRoughMetallic5.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/HighRoughMetallic5.xml
@@ -3,7 +3,7 @@
 	<technique name="Techniques/PBR/PBRNoTexture.xml" quality="0" loddistance="0" />
 	<parameter name="UOffset" value="1 0 0 0" />
 	<parameter name="VOffset" value="0 1 0 0" />
-	<parameter name="MatDiffColor" value="1 1 1 1" />
+	<parameter name="MatDiffColor" value="0.8 0.3 0.1 1" />
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
@@ -13,5 +13,8 @@
 	<shadowcull value="ccw" />
 	<fill value="solid" />
 	<depthbias constant="0" slopescaled="0" />
+	<alphatocoverage enable="false" />
+	<lineantialias enable="false" />
 	<renderorder value="128" />
+	<occlusion enable="true" />
 </material>

--- a/bin/Autoload/LargeData/Materials/PBR/HighRoughMetallic7.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/HighRoughMetallic7.xml
@@ -3,7 +3,7 @@
 	<technique name="Techniques/PBR/PBRNoTexture.xml" quality="0" loddistance="0" />
 	<parameter name="UOffset" value="1 0 0 0" />
 	<parameter name="VOffset" value="0 1 0 0" />
-	<parameter name="MatDiffColor" value="1 1 1 1" />
+	<parameter name="MatDiffColor" value="0.8 0.3 0.1 1" />
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
@@ -13,5 +13,8 @@
 	<shadowcull value="ccw" />
 	<fill value="solid" />
 	<depthbias constant="0" slopescaled="0" />
+	<alphatocoverage enable="false" />
+	<lineantialias enable="false" />
 	<renderorder value="128" />
+	<occlusion enable="true" />
 </material>

--- a/bin/Autoload/LargeData/Materials/PBR/Metallic0.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/Metallic0.xml
@@ -3,7 +3,7 @@
 	<technique name="Techniques/PBR/PBRNoTexture.xml" quality="0" loddistance="0" />
 	<parameter name="UOffset" value="1 0 0 0" />
 	<parameter name="VOffset" value="0 1 0 0" />
-	<parameter name="MatDiffColor" value="1 0.886 0.608 1" />
+	<parameter name="MatDiffColor" value="0.8 0.3 0.1 1" />
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
@@ -14,6 +14,7 @@
 	<fill value="solid" />
 	<depthbias constant="0" slopescaled="0" />
 	<alphatocoverage enable="false" />
+	<lineantialias enable="false" />
 	<renderorder value="128" />
 	<occlusion enable="true" />
 </material>

--- a/bin/Autoload/LargeData/Materials/PBR/Metallic10.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/Metallic10.xml
@@ -3,7 +3,7 @@
 	<technique name="Techniques/PBR/PBRNoTexture.xml" quality="0" loddistance="0" />
 	<parameter name="UOffset" value="1 0 0 0" />
 	<parameter name="VOffset" value="0 1 0 0" />
-	<parameter name="MatDiffColor" value="1 0.886 0.608 1" />
+	<parameter name="MatDiffColor" value="0.8 0.3 0.1 1" />
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
@@ -14,6 +14,7 @@
 	<fill value="solid" />
 	<depthbias constant="0" slopescaled="0" />
 	<alphatocoverage enable="false" />
+	<lineantialias enable="false" />
 	<renderorder value="128" />
 	<occlusion enable="true" />
 </material>

--- a/bin/Autoload/LargeData/Materials/PBR/Metallic3.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/Metallic3.xml
@@ -3,7 +3,7 @@
 	<technique name="Techniques/PBR/PBRNoTexture.xml" quality="0" loddistance="0" />
 	<parameter name="UOffset" value="1 0 0 0" />
 	<parameter name="VOffset" value="0 1 0 0" />
-	<parameter name="MatDiffColor" value="1 0.886 0.608 1" />
+	<parameter name="MatDiffColor" value="0.8 0.3 0.1 1" />
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
@@ -14,6 +14,7 @@
 	<fill value="solid" />
 	<depthbias constant="0" slopescaled="0" />
 	<alphatocoverage enable="false" />
+	<lineantialias enable="false" />
 	<renderorder value="128" />
 	<occlusion enable="true" />
 </material>

--- a/bin/Autoload/LargeData/Materials/PBR/Metallic5.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/Metallic5.xml
@@ -3,7 +3,7 @@
 	<technique name="Techniques/PBR/PBRNoTexture.xml" quality="0" loddistance="0" />
 	<parameter name="UOffset" value="1 0 0 0" />
 	<parameter name="VOffset" value="0 1 0 0" />
-	<parameter name="MatDiffColor" value="1 0.886 0.608 1" />
+	<parameter name="MatDiffColor" value="0.8 0.3 0.1 1" />
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
@@ -14,6 +14,7 @@
 	<fill value="solid" />
 	<depthbias constant="0" slopescaled="0" />
 	<alphatocoverage enable="false" />
+	<lineantialias enable="false" />
 	<renderorder value="128" />
 	<occlusion enable="true" />
 </material>

--- a/bin/Autoload/LargeData/Materials/PBR/Metallic7.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/Metallic7.xml
@@ -3,7 +3,7 @@
 	<technique name="Techniques/PBR/PBRNoTexture.xml" quality="0" loddistance="0" />
 	<parameter name="UOffset" value="1 0 0 0" />
 	<parameter name="VOffset" value="0 1 0 0" />
-	<parameter name="MatDiffColor" value="1 0.886 0.608 1" />
+	<parameter name="MatDiffColor" value="0.8 0.3 0.1 1" />
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
@@ -14,6 +14,7 @@
 	<fill value="solid" />
 	<depthbias constant="0" slopescaled="0" />
 	<alphatocoverage enable="false" />
+	<lineantialias enable="false" />
 	<renderorder value="128" />
 	<occlusion enable="true" />
 </material>

--- a/bin/Autoload/LargeData/Materials/PBR/MetallicRough0.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/MetallicRough0.xml
@@ -3,7 +3,7 @@
 	<technique name="Techniques/PBR/PBRNoTexture.xml" quality="0" loddistance="0" />
 	<parameter name="UOffset" value="1 0 0 0" />
 	<parameter name="VOffset" value="0 1 0 0" />
-	<parameter name="MatDiffColor" value="1 1 1 1" />
+	<parameter name="MatDiffColor" value="0 0.1 0.5 1" />
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
@@ -13,5 +13,8 @@
 	<shadowcull value="ccw" />
 	<fill value="solid" />
 	<depthbias constant="0" slopescaled="0" />
+	<alphatocoverage enable="false" />
+	<lineantialias enable="false" />
 	<renderorder value="128" />
+	<occlusion enable="true" />
 </material>

--- a/bin/Autoload/LargeData/Materials/PBR/MetallicRough10.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/MetallicRough10.xml
@@ -3,7 +3,7 @@
 	<technique name="Techniques/PBR/PBRNoTexture.xml" quality="0" loddistance="0" />
 	<parameter name="UOffset" value="1 0 0 0" />
 	<parameter name="VOffset" value="0 1 0 0" />
-	<parameter name="MatDiffColor" value="1 1 1 1" />
+	<parameter name="MatDiffColor" value="0 0.1 0.5 1" />
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
@@ -14,6 +14,7 @@
 	<fill value="solid" />
 	<depthbias constant="0" slopescaled="0" />
 	<alphatocoverage enable="false" />
+	<lineantialias enable="false" />
 	<renderorder value="128" />
 	<occlusion enable="true" />
 </material>

--- a/bin/Autoload/LargeData/Materials/PBR/MetallicRough3.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/MetallicRough3.xml
@@ -3,7 +3,7 @@
 	<technique name="Techniques/PBR/PBRNoTexture.xml" quality="0" loddistance="0" />
 	<parameter name="UOffset" value="1 0 0 0" />
 	<parameter name="VOffset" value="0 1 0 0" />
-	<parameter name="MatDiffColor" value="1 1 1 1" />
+	<parameter name="MatDiffColor" value="0 0.1 0.5 1" />
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
@@ -13,5 +13,8 @@
 	<shadowcull value="ccw" />
 	<fill value="solid" />
 	<depthbias constant="0" slopescaled="0" />
+	<alphatocoverage enable="false" />
+	<lineantialias enable="false" />
 	<renderorder value="128" />
+	<occlusion enable="true" />
 </material>

--- a/bin/Autoload/LargeData/Materials/PBR/MetallicRough5.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/MetallicRough5.xml
@@ -3,7 +3,7 @@
 	<technique name="Techniques/PBR/PBRNoTexture.xml" quality="0" loddistance="0" />
 	<parameter name="UOffset" value="1 0 0 0" />
 	<parameter name="VOffset" value="0 1 0 0" />
-	<parameter name="MatDiffColor" value="1 1 1 1" />
+	<parameter name="MatDiffColor" value="0 0.1 0.5 1" />
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
@@ -13,5 +13,8 @@
 	<shadowcull value="ccw" />
 	<fill value="solid" />
 	<depthbias constant="0" slopescaled="0" />
+	<alphatocoverage enable="false" />
+	<lineantialias enable="false" />
 	<renderorder value="128" />
+	<occlusion enable="true" />
 </material>

--- a/bin/Autoload/LargeData/Materials/PBR/MetallicRough7.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/MetallicRough7.xml
@@ -3,7 +3,7 @@
 	<technique name="Techniques/PBR/PBRNoTexture.xml" quality="0" loddistance="0" />
 	<parameter name="UOffset" value="1 0 0 0" />
 	<parameter name="VOffset" value="0 1 0 0" />
-	<parameter name="MatDiffColor" value="1 1 1 1" />
+	<parameter name="MatDiffColor" value="0 0.1 0.5 1" />
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
@@ -14,6 +14,7 @@
 	<fill value="solid" />
 	<depthbias constant="0" slopescaled="0" />
 	<alphatocoverage enable="false" />
+	<lineantialias enable="false" />
 	<renderorder value="128" />
 	<occlusion enable="true" />
 </material>

--- a/bin/Autoload/LargeData/Materials/PBR/Mud.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/Mud.xml
@@ -10,13 +10,14 @@
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
-	<parameter name="Roughness" value="-0.12" />
+	<parameter name="Roughness" value="0" />
 	<parameter name="Metallic" value="0" />
 	<cull value="ccw" />
 	<shadowcull value="ccw" />
 	<fill value="solid" />
 	<depthbias constant="0" slopescaled="0" />
 	<alphatocoverage enable="false" />
+	<lineantialias enable="false" />
 	<renderorder value="128" />
 	<occlusion enable="true" />
 </material>

--- a/bin/Autoload/LargeData/Materials/PBR/Roughness0.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/Roughness0.xml
@@ -3,7 +3,7 @@
 	<technique name="Techniques/PBR/PBRNoTexture.xml" quality="0" loddistance="0" />
 	<parameter name="UOffset" value="1 0 0 0" />
 	<parameter name="VOffset" value="0 1 0 0" />
-	<parameter name="MatDiffColor" value="0.034 0.101 0.589 1" />
+	<parameter name="MatDiffColor" value="0 0.1 0.5 1" />
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
@@ -14,6 +14,7 @@
 	<fill value="solid" />
 	<depthbias constant="0" slopescaled="0" />
 	<alphatocoverage enable="false" />
+	<lineantialias enable="false" />
 	<renderorder value="128" />
 	<occlusion enable="true" />
 </material>

--- a/bin/Autoload/LargeData/Materials/PBR/Roughness10.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/Roughness10.xml
@@ -3,7 +3,7 @@
 	<technique name="Techniques/PBR/PBRNoTexture.xml" quality="0" loddistance="0" />
 	<parameter name="UOffset" value="1 0 0 0" />
 	<parameter name="VOffset" value="0 1 0 0" />
-	<parameter name="MatDiffColor" value="0.034 0.101 0.589 1" />
+	<parameter name="MatDiffColor" value="0 0.1 0.5 1" />
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
@@ -14,6 +14,7 @@
 	<fill value="solid" />
 	<depthbias constant="0" slopescaled="0" />
 	<alphatocoverage enable="false" />
+	<lineantialias enable="false" />
 	<renderorder value="128" />
 	<occlusion enable="true" />
 </material>

--- a/bin/Autoload/LargeData/Materials/PBR/Roughness3.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/Roughness3.xml
@@ -3,7 +3,7 @@
 	<technique name="Techniques/PBR/PBRNoTexture.xml" quality="0" loddistance="0" />
 	<parameter name="UOffset" value="1 0 0 0" />
 	<parameter name="VOffset" value="0 1 0 0" />
-	<parameter name="MatDiffColor" value="0.034 0.101 0.589 1" />
+	<parameter name="MatDiffColor" value="0 0.1 0.5 1" />
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
@@ -14,6 +14,7 @@
 	<fill value="solid" />
 	<depthbias constant="0" slopescaled="0" />
 	<alphatocoverage enable="false" />
+	<lineantialias enable="false" />
 	<renderorder value="128" />
 	<occlusion enable="true" />
 </material>

--- a/bin/Autoload/LargeData/Materials/PBR/Roughness5.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/Roughness5.xml
@@ -3,7 +3,7 @@
 	<technique name="Techniques/PBR/PBRNoTexture.xml" quality="0" loddistance="0" />
 	<parameter name="UOffset" value="1 0 0 0" />
 	<parameter name="VOffset" value="0 1 0 0" />
-	<parameter name="MatDiffColor" value="0.034 0.101 0.589 1" />
+	<parameter name="MatDiffColor" value="0 0.1 0.5 1" />
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
@@ -14,6 +14,7 @@
 	<fill value="solid" />
 	<depthbias constant="0" slopescaled="0" />
 	<alphatocoverage enable="false" />
+	<lineantialias enable="false" />
 	<renderorder value="128" />
 	<occlusion enable="true" />
 </material>

--- a/bin/Autoload/LargeData/Materials/PBR/Roughness7.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/Roughness7.xml
@@ -3,7 +3,7 @@
 	<technique name="Techniques/PBR/PBRNoTexture.xml" quality="0" loddistance="0" />
 	<parameter name="UOffset" value="1 0 0 0" />
 	<parameter name="VOffset" value="0 1 0 0" />
-	<parameter name="MatDiffColor" value="0.034 0.101 0.589 1" />
+	<parameter name="MatDiffColor" value="0 0.1 0.5 1" />
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
@@ -14,6 +14,7 @@
 	<fill value="solid" />
 	<depthbias constant="0" slopescaled="0" />
 	<alphatocoverage enable="false" />
+	<lineantialias enable="false" />
 	<renderorder value="128" />
 	<occlusion enable="true" />
 </material>

--- a/bin/Autoload/LargeData/Materials/PBR/Tile.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/Tile.xml
@@ -17,6 +17,7 @@
 	<fill value="solid" />
 	<depthbias constant="0" slopescaled="0" />
 	<alphatocoverage enable="false" />
+	<lineantialias enable="false" />
 	<renderorder value="128" />
 	<occlusion enable="true" />
 </material>

--- a/bin/CoreData/Shaders/GLSL/BRDF.glsl
+++ b/bin/CoreData/Shaders/GLSL/BRDF.glsl
@@ -53,13 +53,19 @@
         return 0.5 / (lambdaV + lambdaL);
     }
 
+    float NeumannVisibility(float NdotV, float NdotL) 
+    {
+        return NdotL * NdotV / max(1e-7, max(NdotL, NdotV));
+    }
+
     // Get Visibility
     // NdotL        = the dot product of the normal and direction to the light
     // NdotV        = the dot product of the normal and the camera view direction
     // roughness    = the roughness of the pixel
     float Visibility(float NdotL, float NdotV, float roughness)
     {
-        return SmithGGXSchlickVisibility(NdotL, NdotV, roughness);
+        return NeumannVisibility(NdotV, NdotL);
+        //return SmithGGXSchlickVisibility(NdotL, NdotV, roughness);
     }
 
     // Blinn Distribution
@@ -149,7 +155,7 @@
     // VdotH        = the camera view direction dot with the half vector
     vec3 Diffuse(vec3 diffuseColor, float roughness, float NdotV, float NdotL, float VdotH)
     {
-        //return LambertianDiffuse(diffuseColor, NdotL);
+        //return LambertianDiffuse(diffuseColor);
         return CustomLambertianDiffuse(diffuseColor, NdotV, roughness);
         //return BurleyDiffuse(diffuseColor, roughness, NdotV, NdotL, VdotH);
     }

--- a/bin/CoreData/Shaders/GLSL/BRDF.glsl
+++ b/bin/CoreData/Shaders/GLSL/BRDF.glsl
@@ -21,12 +21,23 @@
         return specular + (vec3(1.0, 1.0, 1.0) - specular) * sphericalGaussian;
     }
 
+    vec3 SchlickFresnelCustom(vec3 specular, float LdotH)
+    {
+        float ior = 0.25;
+        float airIor = 1.000277;
+        float f0 = (ior - airIor) / (ior + airIor);
+        float max_ior = 2.5;
+        f0 = clamp(f0 * f0, 0.0, (max_ior - airIor) / (max_ior + airIor));
+        return specular * (f0   + (1 - f0) * pow(2, (-5.55473 * LdotH - 6.98316) * LdotH));
+    }
+
     //Get Fresnel
     //specular  = the rgb specular color value of the pixel
     //VdotH     = the dot product of the camera view direction and the half vector 
-    vec3 Fresnel(vec3 specular, float VdotH)
+    vec3 Fresnel(vec3 specular, float VdotH, float LdotH)
     {
-        return SchlickFresnel(specular, VdotH);
+        return SchlickFresnelCustom(specular, LdotH);
+        //return SchlickFresnel(specular, VdotH);
     }
 
     // Smith GGX corrected Visibility
@@ -96,9 +107,20 @@
     // NdotV        = the normal dot with the camera view direction
     // NdotL        = the normal dot with the light direction
     // VdotH        = the camera view direction dot with the half vector
-    vec3 LambertianDiffuse(vec3 diffuseColor, float NdotL)
+    vec3 LambertianDiffuse(vec3 diffuseColor)
     {
-        return diffuseColor * NdotL;
+        return diffuseColor * (1.0 / M_PI) ;
+    }
+
+    // Custom Lambertian Diffuse
+    // diffuseColor = the rgb color value of the pixel
+    // roughness    = the roughness of the pixel
+    // NdotV        = the normal dot with the camera view direction
+    // NdotL        = the normal dot with the light direction
+    // VdotH        = the camera view direction dot with the half vector
+    vec3 CustomLambertianDiffuse(vec3 diffuseColor, float NdotV, float roughness)
+    {
+        return diffuseColor * (1.0 / M_PI) * pow(NdotV, 0.5 + 0.3 * roughness);
     }
 
     // Burley Diffuse
@@ -128,7 +150,8 @@
     vec3 Diffuse(vec3 diffuseColor, float roughness, float NdotV, float NdotL, float VdotH)
     {
         //return LambertianDiffuse(diffuseColor, NdotL);
-        return BurleyDiffuse(diffuseColor, roughness, NdotV, NdotL, VdotH);
+        return CustomLambertianDiffuse(diffuseColor, NdotV, roughness);
+        //return BurleyDiffuse(diffuseColor, roughness, NdotV, NdotL, VdotH);
     }
 
   #endif

--- a/bin/CoreData/Shaders/GLSL/Constants.glsl
+++ b/bin/CoreData/Shaders/GLSL/Constants.glsl
@@ -2,6 +2,6 @@
 #define M_EPSILON 0.0001
 
 #ifdef PBR
-#define ROUGHNESS_FLOOR 0.003
+#define ROUGHNESS_FLOOR 0.004
 #define METALNESS_FLOOR 0.03
 #endif

--- a/bin/CoreData/Shaders/GLSL/IBL.glsl
+++ b/bin/CoreData/Shaders/GLSL/IBL.glsl
@@ -229,17 +229,16 @@
     ///     normal: surface normal
     ///     reflection: vector of reflection off of the surface
     ///     roughness: surface roughness
-    vec3 GetSpecularDominantDir(vec3 normal, vec3 reflection, float roughness)
-    {
-        float smoothness = 1.0 - roughness;
-        float lerpFactor = smoothness * (sqrt(smoothness) + roughness);
-        return mix(normal, reflection, lerpFactor);
-    }
+    // vec3 GetSpecularDominantDir(vec3 normal, vec3 reflection, float roughness)
+    // {
+    //     float smoothness = 1.0 - roughness;
+    //     float lerpFactor = smoothness * (sqrt(smoothness) + roughness);
+    //     return mix(normal, reflection, lerpFactor);
+    // }
 
     float GetMipFromRoughness(float roughness)
     {
-        float Level = 3 - 1.15 * log2( roughness );
-        return 9.0 - 1 - Level;
+        return (roughness * 12.0 - pow(roughness, 6.0) * 1.5);
     }
 
 
@@ -273,6 +272,7 @@
     ///     ambientOcclusion: ambient occlusion
     vec3 ImageBasedLighting(vec3 reflectVec, vec3 tangent, vec3 bitangent, vec3 wsNormal, vec3 toCamera, vec3 diffColor, vec3 specColor, float roughness, inout vec3 reflectionCubeColor)
     {
+        roughness = max(roughness, 0.08);
         reflectVec = GetSpecularDominantDir(wsNormal, reflectVec, roughness);
         float ndv = clamp(dot(-toCamera, wsNormal), 0.0, 1.0);
 

--- a/bin/CoreData/Shaders/GLSL/PBR.glsl
+++ b/bin/CoreData/Shaders/GLSL/PBR.glsl
@@ -63,8 +63,8 @@
 
     vec3 TubeLight(vec3 worldPos, vec3 lightVec, vec3 normal, vec3 toCamera, float roughness, vec3 specColor, vec3 diffColor, out float ndl)
     {
-        float radius      = cLightRad;
-        float len         = cLightLength; 
+        float radius      = cLightRad / 100;
+        float len         = cLightLength / 10; 
         vec3 pos         = (cLightPosPS.xyz - worldPos);
         vec3 reflectVec  = reflect(-toCamera, normal);
         
@@ -92,22 +92,22 @@
         vec3 l = normalize(closestPoint);
         vec3 h = normalize(toCamera + l);
 
-        ndl       =  clamp(dot(normal, lightVec), 0.0, 1.0);
+        ndl       = clamp(dot(normal, lightVec), 0.0, 1.0);
         float hdn = clamp(dot(h, normal), 0.0, 1.0);
         float hdv = dot(h, toCamera);
-        float ndv = clamp(dot(normal, toCamera), 0.0 ,1.0);
+        float ndv = clamp(dot(normal, toCamera), 0.0, 1.0);
         float hdl = clamp(dot(h, lightVec), 0.0, 1.0);
 
         float distL      = length(closestPoint);
         float alpha      = max(roughness, 0.08) * max(roughness, 0.08);
         float alphaPrime = clamp(radius / (distL * 2.0) + alpha, 0.0, 1.0);
 
-       vec3 diffuseFactor = Diffuse(diffColor, roughness, ndv, ndl, hdv)  * ndl;
-       vec3 fresnelTerm = Fresnel(specColor, hdv, hdl) ;
-       float distTerm = Distribution(hdn, roughness);
-       float visTerm = Visibility(ndl, ndv, roughness);
-       vec3 specularFactor = distTerm * visTerm * fresnelTerm * ndl/ M_PI;
-       return diffuseFactor + specularFactor;
+        vec3 diffuseFactor = Diffuse(diffColor, roughness, ndv, ndl, hdv)  * ndl;
+        vec3 fresnelTerm = Fresnel(specColor, hdv, hdl) ;
+        float distTerm = Distribution(hdn, roughness);
+        float visTerm = Visibility(ndl, ndv, roughness);
+        vec3 specularFactor = distTerm * visTerm * fresnelTerm * ndl/ M_PI;
+        return diffuseFactor + specularFactor;
     }
 
 	//Return the PBR BRDF value

--- a/bin/CoreData/Shaders/GLSL/PBR.glsl
+++ b/bin/CoreData/Shaders/GLSL/PBR.glsl
@@ -125,7 +125,7 @@
         float ndh = clamp(dot(normal, Hn), M_EPSILON, 1.0);
         float ndl = clamp(dot(normal, lightVec), M_EPSILON, 1.0);
         float ldh = clamp(dot(lightVec, Hn), M_EPSILON, 1.0);
-        float ndv = clamp(dot(normal, toCamera), M_EPSILON, 1.0);
+        float ndv = abs(dot(normal, toCamera)) + 1e-5;
 
         vec3 diffuseFactor = Diffuse(diffColor, roughness, ndv, ndl, vdh);
         vec3 specularFactor = vec3(0.0, 0.0, 0.0);

--- a/bin/CoreData/Shaders/GLSL/PBR.glsl
+++ b/bin/CoreData/Shaders/GLSL/PBR.glsl
@@ -1,35 +1,67 @@
 #include "BRDF.glsl"
 #ifdef COMPILEPS
-
-    vec3 SphereLight(vec3 worldPos, vec3 lightVec, vec3 normal, vec3 toCamera, float roughness, vec3 specColor, out float ndl)
+#line 100
+    vec3 GetSpecularDominantDir(vec3 normal, vec3 reflection, float roughness)
     {
-        vec3 pos   = (cLightPosPS.xyz - worldPos);
-        float radius = cLightRad;
-
-        vec3 reflectVec   = reflect(-toCamera, normal);
-        vec3 centreToRay  = dot(pos, reflectVec) * reflectVec - pos;
-        vec3 closestPoint = pos + centreToRay * clamp(radius / length(centreToRay), 0.0, 1.0);
-
-        vec3 l = normalize(closestPoint);
-        vec3 h = normalize(toCamera + l);
-
-        ndl       = clamp(dot(normal, l), 0.0, 1.0);
-        float hdn = clamp(dot(h, normal), 0.0, 1.0);
-        float hdv = dot(h, toCamera);
-        float ndv = clamp(dot(normal, toCamera), 0.0, 1.0);
-
-        float distL      = length(pos);
-        float alpha      = roughness * roughness;
-        float alphaPrime = clamp(radius / (distL * 2.0) + alpha, 0.0, 1.0);
-
-        vec3 fresnelTerm = Fresnel(specColor, hdv) ;
-        float distTerm     = Distribution(hdn, alphaPrime);
-        float visTerm      = Visibility(ndl, ndv, roughness);
-
-        return distTerm * visTerm * fresnelTerm ;
+        float smoothness = 1.0 - roughness;
+        float lerpFactor = smoothness * (sqrt(smoothness) + roughness);
+        return mix(normal, reflection, lerpFactor);
     }
 
-    vec3 TubeLight(vec3 worldPos, vec3 lightVec, vec3 normal, vec3 toCamera, float roughness, vec3 specColor, out float ndl)
+    vec3 SphereLight(vec3 worldPos, vec3 lightVec, vec3 normal, vec3 toCamera, float roughness, vec3 specColor, vec3 diffColor, out float ndl)
+    {
+        float specEnergy = 1.0f;
+
+        float radius = cLightRad / 100;
+        float rough2 = max(roughness, 0.08);
+        rough2 *= rough2;
+
+        float radius2           = radius * radius;
+        float distToLightSqrd   = dot(lightVec,lightVec);
+        float invDistToLight    = inversesqrt(distToLightSqrd);
+        float sinAlphaSqr       = clamp(radius2 / distToLightSqrd, 0.0, 1.0);
+        float sinAlpha          = sqrt(sinAlphaSqr);
+
+        ndl       = dot(normal, (lightVec * invDistToLight));
+
+        if(ndl < sinAlpha)
+        {
+            ndl = max(ndl, -sinAlpha);
+            ndl = ((sinAlpha + ndl) * (sinAlpha + ndl)) / (4 * sinAlpha);
+        }
+
+        float sphereAngle = clamp(radius * invDistToLight, 0.0, 1.0);
+                            
+        specEnergy = rough2 / (rough2 + 0.5f * sphereAngle);
+        specEnergy *= specEnergy;                           
+
+        vec3 R = 2 * dot(toCamera, normal) * normal - toCamera;
+        R = GetSpecularDominantDir(normal, R, roughness);
+
+        // Find closest point on sphere to ray
+        vec3 closestPointOnRay = dot(lightVec, R) * R;
+        vec3 centerToRay = closestPointOnRay - lightVec;
+        float invDistToRay = inversesqrt(dot(centerToRay, centerToRay));
+        vec3 closestPointOnSphere = lightVec + centerToRay * clamp(radius * invDistToRay, 0.0, 1.0);
+
+        lightVec = closestPointOnSphere;
+        vec3 L = normalize(lightVec);
+
+        vec3 h = normalize(toCamera + L);
+        float hdn = clamp(dot(h, normal), 0.0, 1.0);
+        float hdv = dot(h, toCamera);
+        float ndv = clamp(dot(normal, toCamera),0.0, 1.0);
+        float hdl = clamp(dot(h, lightVec), 0.0, 1.0);
+
+        vec3 diffuseFactor = Diffuse(diffColor, roughness, ndv, ndl, hdv)  * ndl;
+        vec3 fresnelTerm = Fresnel(specColor, hdv, hdl) ;
+        float distTerm = Distribution(hdn, roughness);
+        float visTerm = Visibility(ndl, ndv, roughness);
+        vec3 specularFactor = distTerm * visTerm * fresnelTerm * ndl/ M_PI;
+        return diffuseFactor + specularFactor;
+    }
+
+    vec3 TubeLight(vec3 worldPos, vec3 lightVec, vec3 normal, vec3 toCamera, float roughness, vec3 specColor, vec3 diffColor, out float ndl)
     {
         float radius      = cLightRad;
         float len         = cLightLength; 
@@ -64,16 +96,18 @@
         float hdn = clamp(dot(h, normal), 0.0, 1.0);
         float hdv = dot(h, toCamera);
         float ndv = clamp(dot(normal, toCamera), 0.0 ,1.0);
+        float hdl = clamp(dot(h, lightVec), 0.0, 1.0);
 
         float distL      = length(closestPoint);
-        float alpha      = roughness * roughness;
+        float alpha      = max(roughness, 0.08) * max(roughness, 0.08);
         float alphaPrime = clamp(radius / (distL * 2.0) + alpha, 0.0, 1.0);
 
-        vec3 fresnelTerm = Fresnel(specColor, hdv) ;
-        float distTerm     = Distribution(hdn, alphaPrime);
-        float visTerm      = Visibility(ndl, ndv, roughness);
-
-        return distTerm * visTerm * fresnelTerm ;
+       vec3 diffuseFactor = Diffuse(diffColor, roughness, ndv, ndl, hdv)  * ndl;
+       vec3 fresnelTerm = Fresnel(specColor, hdv, hdl) ;
+       float distTerm = Distribution(hdn, roughness);
+       float visTerm = Visibility(ndl, ndv, roughness);
+       vec3 specularFactor = distTerm * visTerm * fresnelTerm * ndl/ M_PI;
+       return diffuseFactor + specularFactor;
     }
 
 	//Return the PBR BRDF value
@@ -87,10 +121,11 @@
 	vec3 GetBRDF(vec3 worldPos, vec3 lightDir, vec3 lightVec, vec3 toCamera, vec3 normal, float roughness, vec3 diffColor, vec3 specColor)
 	{
         vec3 Hn = normalize(toCamera + lightDir);
-        float vdh = clamp((dot(toCamera, Hn)), M_EPSILON, 1.0);
-        float ndh = clamp((dot(normal, Hn)), M_EPSILON, 1.0);
-        float ndl = clamp((dot(normal, lightVec)), M_EPSILON, 1.0);
-        float ndv = clamp((dot(normal, toCamera)), M_EPSILON, 1.0);
+        float vdh = clamp(dot(toCamera, Hn), M_EPSILON, 1.0);
+        float ndh = clamp(dot(normal, Hn), M_EPSILON, 1.0);
+        float ndl = clamp(dot(normal, lightVec), M_EPSILON, 1.0);
+        float ldh = clamp(dot(lightVec, Hn), M_EPSILON, 1.0);
+        float ndv = clamp(dot(normal, toCamera), M_EPSILON, 1.0);
 
         vec3 diffuseFactor = Diffuse(diffColor, roughness, ndv, ndl, vdh);
         vec3 specularFactor = vec3(0.0, 0.0, 0.0);
@@ -100,22 +135,23 @@
             {
                 if(cLightLength > 0.0)
                 {
-                    specularFactor = TubeLight(worldPos, lightVec, normal, toCamera, roughness, specColor, ndl);
+                    specularFactor = TubeLight(worldPos, lightVec, normal, toCamera, roughness, specColor, diffColor, ndl);
                     specularFactor *= ndl;
                 }
                 else
                 {
-                    specularFactor = SphereLight(worldPos, lightVec, normal, toCamera, roughness, specColor, ndl);
+                    specularFactor = SphereLight(worldPos, lightVec, normal, toCamera, roughness, specColor, diffColor, ndl);
                     specularFactor *= ndl;
                 }
             }
             else
             {
-                vec3 fresnelTerm = Fresnel(specColor, vdh) ;
+                vec3 fresnelTerm = Fresnel(specColor, vdh, ldh) ;
                 float distTerm = Distribution(ndh, roughness);
                 float visTerm = Visibility(ndl, ndv, roughness);
 
                 specularFactor = fresnelTerm * distTerm * visTerm  / M_PI;
+                return diffuseFactor + specularFactor;
             }
         #endif
 

--- a/bin/CoreData/Shaders/HLSL/BRDF.hlsl
+++ b/bin/CoreData/Shaders/HLSL/BRDF.hlsl
@@ -26,7 +26,7 @@
     //VdotH     = the dot product of the camera view direction and the half vector 
     float3 Fresnel(float3 specular, float VdotH)
     {
-        return SchlickFresnel(specular, VdotH);
+        return SchlickGaussianFresnel(specular, VdotH);
     }
 
     // Smith GGX corrected Visibility

--- a/bin/CoreData/Shaders/HLSL/BRDF.hlsl
+++ b/bin/CoreData/Shaders/HLSL/BRDF.hlsl
@@ -21,12 +21,24 @@
         return specular + (float3(1.0, 1.0, 1.0) - specular) * sphericalGaussian;
     }
 
+    float3 SchlickFresnelCustom(float3 specular, float LdotH)
+    {
+        float ior = 0.25;
+        float airIor = 1.000277;
+        float f0 = (ior - airIor) / (ior + airIor);
+        // Clamp between ior of 1 and 2.5
+        const float max_ior = 2.5;
+        f0 = clamp(f0 * f0, 0.0, (max_ior - airIor) / (max_ior + airIor)); // should get optimized out
+        return specular * (f0   + (1 - f0) * pow(2, (-5.55473 * LdotH - 6.98316) * LdotH));
+    }
+
     //Get Fresnel
     //specular  = the rgb specular color value of the pixel
     //VdotH     = the dot product of the camera view direction and the half vector 
-    float3 Fresnel(float3 specular, float VdotH)
+    float3 Fresnel(float3 specular, float VdotH, float LdotH)
     {
-        return SchlickGaussianFresnel(specular, VdotH);
+        return SchlickFresnelCustom(specular, LdotH);
+        //return SchlickFresnel(specular, VdotH);
     }
 
     // Smith GGX corrected Visibility
@@ -96,9 +108,20 @@
     // NdotV        = the normal dot with the camera view direction
     // NdotL        = the normal dot with the light direction
     // VdotH        = the camera view direction dot with the half vector
-    float3 LambertianDiffuse(float3 diffuseColor, float NdotL)
+    float3 LambertianDiffuse(float3 diffuseColor)
     {
-        return diffuseColor * NdotL;
+        return diffuseColor * (1.0 / M_PI) ;
+    }
+
+    // Custom Lambertian Diffuse
+    // diffuseColor = the rgb color value of the pixel
+    // roughness    = the roughness of the pixel
+    // NdotV        = the normal dot with the camera view direction
+    // NdotL        = the normal dot with the light direction
+    // VdotH        = the camera view direction dot with the half vector
+    float3 CustomLambertianDiffuse(float3 diffuseColor, float NdotV, float roughness)
+    {
+        return diffuseColor * (1.0 / M_PI) * pow(NdotV, 0.5 + 0.3 * roughness);
     }
 
     // Burley Diffuse
@@ -127,8 +150,9 @@
     // VdotH        = the camera view direction dot with the half vector
     float3 Diffuse(float3 diffuseColor, float roughness, float NdotV, float NdotL, float VdotH)
     {
-        //return LambertianDiffuse(diffuseColor, NdotL);
-        return BurleyDiffuse(diffuseColor, roughness, NdotV, NdotL, VdotH);
+        //return LambertianDiffuse(diffuseColor);
+        return CustomLambertianDiffuse(diffuseColor, NdotV, roughness);
+        //return BurleyDiffuse(diffuseColor, roughness, NdotV, NdotL, VdotH);
     }
 
   #endif

--- a/bin/CoreData/Shaders/HLSL/BRDF.hlsl
+++ b/bin/CoreData/Shaders/HLSL/BRDF.hlsl
@@ -26,9 +26,8 @@
         float ior = 0.25;
         float airIor = 1.000277;
         float f0 = (ior - airIor) / (ior + airIor);
-        // Clamp between ior of 1 and 2.5
         const float max_ior = 2.5;
-        f0 = clamp(f0 * f0, 0.0, (max_ior - airIor) / (max_ior + airIor)); // should get optimized out
+        f0 = clamp(f0 * f0, 0.0, (max_ior - airIor) / (max_ior + airIor));
         return specular * (f0   + (1 - f0) * pow(2, (-5.55473 * LdotH - 6.98316) * LdotH));
     }
 

--- a/bin/CoreData/Shaders/HLSL/BRDF.hlsl
+++ b/bin/CoreData/Shaders/HLSL/BRDF.hlsl
@@ -53,13 +53,19 @@
         return 0.5 / (lambdaV + lambdaL);
     }
 
+    float NeumannVisibility(float NdotV, float NdotL) 
+    {
+        return NdotL * NdotV / max(1e-7, max(NdotL, NdotV));
+    }
+
     // Get Visibility
     // NdotL        = the dot product of the normal and direction to the light
     // NdotV        = the dot product of the normal and the camera view direction
     // roughness    = the roughness of the pixel
     float Visibility(float NdotL, float NdotV, float roughness)
     {
-        return SmithGGXSchlickVisibility(NdotL, NdotV, roughness);
+        return NeumannVisibility(NdotV, NdotL);
+        //return SmithGGXSchlickVisibility(NdotL, NdotV, roughness);
     }
 
     // GGX Distribution

--- a/bin/CoreData/Shaders/HLSL/Constants.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Constants.hlsl
@@ -2,6 +2,6 @@
 #define M_EPSILON 0.0001
 
 #ifdef PBR
-#define ROUGHNESS_FLOOR 0.003
+#define ROUGHNESS_FLOOR 0.004
 #define METALNESS_FLOOR 0.03
 #endif

--- a/bin/CoreData/Shaders/HLSL/IBL.hlsl
+++ b/bin/CoreData/Shaders/HLSL/IBL.hlsl
@@ -220,12 +220,12 @@
     ///     normal: surface normal
     ///     reflection: vector of reflection off of the surface
     ///     roughness: surface roughness
-    float3 GetSpecularDominantDir(float3 normal, float3 reflection, float roughness)
-    {
-        const float smoothness = 1.0 - roughness;
-        const float lerpFactor = smoothness * (sqrt(smoothness) + roughness);
-        return lerp(normal, reflection, lerpFactor);
-    }
+    // float3 GetSpecularDominantDir(float3 normal, float3 reflection, float roughness)
+    // {
+    //     const float smoothness = 1.0 - roughness;
+    //     const float lerpFactor = smoothness * (sqrt(smoothness) + roughness);
+    //     return lerp(normal, reflection, lerpFactor);
+    // }
 
     float GetMipFromRoughness(float roughness)
     {

--- a/bin/CoreData/Shaders/HLSL/IBL.hlsl
+++ b/bin/CoreData/Shaders/HLSL/IBL.hlsl
@@ -229,7 +229,7 @@
 
     float GetMipFromRoughness(float roughness)
     {
-        float Level = 3 - 1.15 * log2( roughness );
+        float Level = 3 - 1.15 * log2(roughness);
         return 9.0 - 1 - Level;
     }
 
@@ -264,6 +264,7 @@
     ///     ambientOcclusion: ambient occlusion
     float3 ImageBasedLighting(in float3 reflectVec, in float3 tangent, in float3 bitangent, in float3 wsNormal, in float3 toCamera, in float3 diffColor, in float3 specColor, in float roughness, inout float3 reflectionCubeColor)
     { 
+        roughness = max(roughness, 0.08);
         reflectVec = GetSpecularDominantDir(wsNormal, reflectVec, roughness);
         const float ndv = saturate(dot(-toCamera, wsNormal));
 

--- a/bin/CoreData/Shaders/HLSL/IBL.hlsl
+++ b/bin/CoreData/Shaders/HLSL/IBL.hlsl
@@ -229,8 +229,7 @@
 
     float GetMipFromRoughness(float roughness)
     {
-        float Level = 3 - 1.15 * log2(roughness);
-        return 9.0 - 1 - Level;
+        return (roughness * 12.0 - pow(roughness, 6.0) * 1.5);
     }
 
 

--- a/bin/CoreData/Shaders/HLSL/PBR.hlsl
+++ b/bin/CoreData/Shaders/HLSL/PBR.hlsl
@@ -51,9 +51,10 @@
         float hdn = saturate(dot(h, normal));
         float hdv = dot(h, toCamera);
         float ndv = saturate(dot(normal, toCamera));
+        float hdl = saturate(dot(h, lightVec));
 
         const float3 diffuseFactor = Diffuse(diffColor, roughness, ndv, ndl, hdv)  * ndl;
-        const float3 fresnelTerm = Fresnel(specColor, hdv) ;
+        const float3 fresnelTerm = Fresnel(specColor, hdv, hdl) ;
         const float distTerm = Distribution(hdn, roughness);
         const float visTerm = Visibility(ndl, ndv, roughness);
         float3 specularFactor = distTerm * visTerm * fresnelTerm * ndl/ M_PI;
@@ -96,13 +97,14 @@
         float hdn = saturate(dot(h, normal));
         float hdv = dot(h, toCamera);
         float ndv = saturate(dot(normal, toCamera));
+        float hdl = saturate(dot(h, lightVec));
 
         float distL      = length(closestPoint);
         float alpha      = max(roughness, 0.08) * max(roughness, 0.08);
         float alphaPrime = saturate(radius / (distL * 2.0) + alpha);
 
        const float3 diffuseFactor = Diffuse(diffColor, roughness, ndv, ndl, hdv)  * ndl;
-       const float3 fresnelTerm = Fresnel(specColor, hdv) ;
+       const float3 fresnelTerm = Fresnel(specColor, hdv, hdl) ;
        const float distTerm = Distribution(hdn, roughness);
        const float visTerm = Visibility(ndl, ndv, roughness);
        float3 specularFactor = distTerm * visTerm * fresnelTerm * ndl/ M_PI;
@@ -125,6 +127,7 @@
         const float ndh = clamp((dot(normal, Hn)), M_EPSILON, 1.0);
         float ndl = clamp((dot(normal, lightVec)), M_EPSILON, 1.0);
         const float ndv = clamp((dot(normal, toCamera)), M_EPSILON, 1.0);
+        const float ldh = clamp((dot(lightVec, Hn)), M_EPSILON, 1.0);
 
         const float3 diffuseFactor = Diffuse(diffColor, roughness, ndv, ndl, vdh)  * ndl;
         float3 specularFactor = 0;
@@ -144,7 +147,7 @@
             }
             else
             {
-                const float3 fresnelTerm = Fresnel(specColor, vdh) ;
+                const float3 fresnelTerm = Fresnel(specColor, vdh, ldh) ;
                 const float distTerm = Distribution(ndh, roughness);
                 const float visTerm = Visibility(ndl, ndv, roughness);
                 specularFactor = distTerm * visTerm * fresnelTerm * ndl/ M_PI;

--- a/bin/CoreData/Shaders/HLSL/PBR.hlsl
+++ b/bin/CoreData/Shaders/HLSL/PBR.hlsl
@@ -13,6 +13,8 @@
         float specEnergy = 1.0f;
 
         float radius = cLightRad / 100;
+        float rough2 = max(roughness, 0.08);
+        rough2 *= rough2;
 
         float radius2           = radius * radius;
         float distToLightSqrd   = dot(lightVec,lightVec);
@@ -30,7 +32,7 @@
 
         float sphereAngle = saturate(radius * invDistToLight);
                             
-        specEnergy = (roughness * roughness) / saturate((roughness * roughness) + 0.5f * sphereAngle);
+        specEnergy = rough2 / (rough2 + 0.5f * sphereAngle);
         specEnergy *= specEnergy;                           
 
         float3 R = 2 * dot(toCamera, normal) * normal - toCamera;
@@ -96,7 +98,7 @@
         float ndv = saturate(dot(normal, toCamera));
 
         float distL      = length(closestPoint);
-        float alpha      = roughness * roughness;
+        float alpha      = max(roughness, 0.08) * max(roughness, 0.08);
         float alphaPrime = saturate(radius / (distL * 2.0) + alpha);
 
        const float3 diffuseFactor = Diffuse(diffColor, roughness, ndv, ndl, hdv)  * ndl;

--- a/bin/Data/LuaScripts/42_PBRMaterials.lua
+++ b/bin/Data/LuaScripts/42_PBRMaterials.lua
@@ -155,6 +155,8 @@ function SetupViewport()
     local effectRenderPath = viewport:GetRenderPath():Clone()
     effectRenderPath:Append(cache:GetResource("XMLFile", "PostProcess/FXAA2.xml"))
     effectRenderPath:Append(cache:GetResource("XMLFile", "PostProcess/GammaCorrection.xml"))
+    effectRenderPath:Append(cache:GetResource("XMLFile", "PostProcess/Tonemap.xml"))
+    effectRenderPath:Append(cache:GetResource("XMLFile", "PostProcess/AutoExposure.xml"))
 
     viewport.renderPath = effectRenderPath;
 end

--- a/bin/Data/Scenes/PBRExample.xml
+++ b/bin/Data/Scenes/PBRExample.xml
@@ -7,8 +7,8 @@
 	<attribute name="Elapsed Time" value="152.788" />
 	<attribute name="Next Replicated Node ID" value="408" />
 	<attribute name="Next Replicated Component ID" value="428" />
-	<attribute name="Next Local Node ID" value="16777275" />
-	<attribute name="Next Local Component ID" value="16777901" />
+	<attribute name="Next Local Node ID" value="16777276" />
+	<attribute name="Next Local Component ID" value="16777913" />
 	<attribute name="Variables" />
 	<attribute name="Variable Names" value="" />
 	<component type="Octree" id="1" />
@@ -1835,8 +1835,8 @@
 		<component type="Light" id="251">
 			<attribute name="Brightness Multiplier" value="1700" />
 			<attribute name="Use Physical Values" value="true" />
-			<attribute name="Radius" value="0.11" />
-			<attribute name="Length" value="6.53" />
+			<attribute name="Radius" value="22.79" />
+			<attribute name="Length" value="55.25" />
 			<attribute name="Range" value="7.61" />
 			<attribute name="Spot FOV" value="62.08" />
 			<attribute name="Light Shape Texture" value="TextureCube;" />
@@ -3995,7 +3995,7 @@
 		<attribute name="Is Enabled" value="true" />
 		<attribute name="Name" value="" />
 		<attribute name="Tags" />
-		<attribute name="Position" value="6.54564 5.37075 -0.065205" />
+		<attribute name="Position" value="6.15174 5.37075 -0.609303" />
 		<attribute name="Rotation" value="1 0 0 0" />
 		<attribute name="Scale" value="0.648644 0.648644 0.648644" />
 		<attribute name="Variables" />

--- a/bin/Data/Scenes/PBRExample.xml
+++ b/bin/Data/Scenes/PBRExample.xml
@@ -7,8 +7,8 @@
 	<attribute name="Elapsed Time" value="152.788" />
 	<attribute name="Next Replicated Node ID" value="465" />
 	<attribute name="Next Replicated Component ID" value="485" />
-	<attribute name="Next Local Node ID" value="16777279" />
-	<attribute name="Next Local Component ID" value="16777949" />
+	<attribute name="Next Local Node ID" value="16777280" />
+	<attribute name="Next Local Component ID" value="16777961" />
 	<attribute name="Variables" />
 	<attribute name="Variable Names" value="" />
 	<component type="Octree" id="1" />
@@ -1152,7 +1152,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="195">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Metallic0.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Check.xml" />
 		</component>
 	</node>
 	<node id="177">
@@ -1165,7 +1165,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="196">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Metallic0.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Check.xml" />
 		</component>
 	</node>
 	<node id="178">
@@ -1178,7 +1178,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="197">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Metallic0.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Check.xml" />
 		</component>
 	</node>
 	<node id="179">
@@ -1191,7 +1191,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="198">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Metallic0.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Check.xml" />
 		</component>
 	</node>
 	<node id="180">
@@ -1204,7 +1204,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="199">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Metallic0.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Check.xml" />
 		</component>
 	</node>
 	<node id="181">
@@ -1217,7 +1217,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="200">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Metallic0.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Check.xml" />
 		</component>
 	</node>
 	<node id="182">
@@ -1230,7 +1230,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="201">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Metallic0.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Check.xml" />
 		</component>
 	</node>
 	<node id="183">
@@ -1243,7 +1243,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="202">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Metallic0.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Check.xml" />
 		</component>
 	</node>
 	<node id="184">
@@ -1256,7 +1256,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="203">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Metallic0.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Check.xml" />
 		</component>
 	</node>
 	<node id="185">

--- a/bin/Data/Scenes/PBRExample.xml
+++ b/bin/Data/Scenes/PBRExample.xml
@@ -7,8 +7,8 @@
 	<attribute name="Elapsed Time" value="152.788" />
 	<attribute name="Next Replicated Node ID" value="408" />
 	<attribute name="Next Replicated Component ID" value="428" />
-	<attribute name="Next Local Node ID" value="16777274" />
-	<attribute name="Next Local Component ID" value="16777889" />
+	<attribute name="Next Local Node ID" value="16777275" />
+	<attribute name="Next Local Component ID" value="16777901" />
 	<attribute name="Variables" />
 	<attribute name="Variable Names" value="" />
 	<component type="Octree" id="1" />
@@ -925,7 +925,7 @@
 				<attribute name="Font" value="Font;Fonts/BlueHighway.ttf" />
 				<attribute name="Font Size" value="15" />
 				<attribute name="Text" value="Low Roughness" />
-				<attribute name="Width" value="134" />
+				<attribute name="Width" value="135" />
 			</component>
 		</node>
 		<node id="138">
@@ -970,7 +970,7 @@
 				<attribute name="Font" value="Font;Fonts/BlueHighway.ttf" />
 				<attribute name="Font Size" value="15" />
 				<attribute name="Text" value="High Roughness" />
-				<attribute name="Width" value="136" />
+				<attribute name="Width" value="137" />
 			</component>
 		</node>
 		<node id="195">
@@ -1190,7 +1190,8 @@
 				<attribute name="Variables" />
 				<component type="Light" id="4">
 					<attribute name="Light Type" value="Directional" />
-					<attribute name="Brightness Multiplier" value="2" />
+					<attribute name="Brightness Multiplier" value="340" />
+					<attribute name="Use Physical Values" value="true" />
 					<attribute name="Cast Shadows" value="true" />
 					<attribute name="CSM Splits" value="10 20 30 40" />
 				</component>
@@ -1582,7 +1583,7 @@
 			<attribute name="Font" value="Font;Fonts/BlueHighway.ttf" />
 			<attribute name="Font Size" value="15" />
 			<attribute name="Text" value="Roughness Value    &lt;-1.0  -&gt;0.0" />
-			<attribute name="Width" value="262" />
+			<attribute name="Width" value="264" />
 		</component>
 	</node>
 	<node id="215">
@@ -1832,7 +1833,7 @@
 		<attribute name="Scale" value="0.648644 0.648644 0.648644" />
 		<attribute name="Variables" />
 		<component type="Light" id="251">
-			<attribute name="Brightness Multiplier" value="800" />
+			<attribute name="Brightness Multiplier" value="1700" />
 			<attribute name="Use Physical Values" value="true" />
 			<attribute name="Radius" value="0.11" />
 			<attribute name="Length" value="6.53" />
@@ -2764,7 +2765,7 @@
 			<attribute name="Font" value="Font;Fonts/BlueHighway.ttf" />
 			<attribute name="Font Size" value="15" />
 			<attribute name="Text" value="Metallic Value    &lt;-0.0  -&gt;1.0" />
-			<attribute name="Width" value="236" />
+			<attribute name="Width" value="237" />
 		</component>
 	</node>
 	<node id="307">
@@ -3190,7 +3191,7 @@
 			<attribute name="Font" value="Font;Fonts/BlueHighway.ttf" />
 			<attribute name="Font Size" value="15" />
 			<attribute name="Text" value="Sphere Lighting" />
-			<attribute name="Width" value="135" />
+			<attribute name="Width" value="134" />
 		</component>
 	</node>
 	<node id="338">
@@ -3999,9 +4000,9 @@
 		<attribute name="Scale" value="0.648644 0.648644 0.648644" />
 		<attribute name="Variables" />
 		<component type="Light" id="416">
-			<attribute name="Brightness Multiplier" value="800" />
+			<attribute name="Brightness Multiplier" value="1700" />
 			<attribute name="Use Physical Values" value="true" />
-			<attribute name="Radius" value="0.61" />
+			<attribute name="Radius" value="25.6" />
 			<attribute name="Range" value="7.61" />
 			<attribute name="Spot FOV" value="62.08" />
 			<attribute name="Light Shape Texture" value="TextureCube;" />

--- a/bin/Data/Scenes/PBRExample.xml
+++ b/bin/Data/Scenes/PBRExample.xml
@@ -5,10 +5,10 @@
 	<attribute name="Smoothing Constant" value="50" />
 	<attribute name="Snap Threshold" value="5" />
 	<attribute name="Elapsed Time" value="152.788" />
-	<attribute name="Next Replicated Node ID" value="408" />
-	<attribute name="Next Replicated Component ID" value="428" />
-	<attribute name="Next Local Node ID" value="16777276" />
-	<attribute name="Next Local Component ID" value="16777913" />
+	<attribute name="Next Replicated Node ID" value="465" />
+	<attribute name="Next Replicated Component ID" value="485" />
+	<attribute name="Next Local Node ID" value="16777279" />
+	<attribute name="Next Local Component ID" value="16777949" />
 	<attribute name="Variables" />
 	<attribute name="Variable Names" value="" />
 	<component type="Octree" id="1" />
@@ -32,7 +32,7 @@
 			<attribute name="Variables" />
 			<component type="StaticModel" id="3">
 				<attribute name="Model" value="Model;Models/Plane.mdl" />
-				<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+				<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 			</component>
 		</node>
 		<node id="31">
@@ -45,7 +45,7 @@
 			<attribute name="Variables" />
 			<component type="StaticModel" id="33">
 				<attribute name="Model" value="Model;Models/Plane.mdl" />
-				<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+				<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 			</component>
 		</node>
 		<node id="32">
@@ -58,14 +58,14 @@
 			<attribute name="Variables" />
 			<component type="StaticModel" id="34">
 				<attribute name="Model" value="Model;Models/Plane.mdl" />
-				<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+				<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 			</component>
 		</node>
 		<node id="22">
 			<attribute name="Is Enabled" value="true" />
 			<attribute name="Name" value="Box" />
 			<attribute name="Tags" />
-			<attribute name="Position" value="1.16697 1.83612 3.88357" />
+			<attribute name="Position" value="10.667 1.83612 3.88357" />
 			<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
 			<attribute name="Scale" value="3 3 1" />
 			<attribute name="Variables" />
@@ -93,7 +93,7 @@
 			<attribute name="Is Enabled" value="true" />
 			<attribute name="Name" value="Box" />
 			<attribute name="Tags" />
-			<attribute name="Position" value="1.16697 1.83612 -19.9362" />
+			<attribute name="Position" value="10.667 1.83612 -22.9362" />
 			<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
 			<attribute name="Scale" value="3 3 1" />
 			<attribute name="Variables" />
@@ -121,7 +121,7 @@
 			<attribute name="Is Enabled" value="true" />
 			<attribute name="Name" value="Box" />
 			<attribute name="Tags" />
-			<attribute name="Position" value="-4.33303 1.83612 -19.9362" />
+			<attribute name="Position" value="-4.33303 1.83612 -22.9362" />
 			<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
 			<attribute name="Scale" value="3 3 1" />
 			<attribute name="Variables" />
@@ -135,7 +135,7 @@
 			<attribute name="Is Enabled" value="true" />
 			<attribute name="Name" value="Box" />
 			<attribute name="Tags" />
-			<attribute name="Position" value="1.16697 1.83612 0.88357" />
+			<attribute name="Position" value="10.667 1.83612 0.88357" />
 			<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
 			<attribute name="Scale" value="3 3 1" />
 			<attribute name="Variables" />
@@ -149,7 +149,7 @@
 			<attribute name="Is Enabled" value="true" />
 			<attribute name="Name" value="Box" />
 			<attribute name="Tags" />
-			<attribute name="Position" value="-1.33303 1.83612 -19.9362" />
+			<attribute name="Position" value="-1.33303 1.83612 -22.9362" />
 			<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
 			<attribute name="Scale" value="3 3 1" />
 			<attribute name="Variables" />
@@ -191,7 +191,7 @@
 			<attribute name="Is Enabled" value="true" />
 			<attribute name="Name" value="Box" />
 			<attribute name="Tags" />
-			<attribute name="Position" value="1.16697 1.83612 -11.1164" />
+			<attribute name="Position" value="10.667 1.83612 -11.1164" />
 			<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
 			<attribute name="Scale" value="3 3 1" />
 			<attribute name="Variables" />
@@ -219,7 +219,7 @@
 			<attribute name="Is Enabled" value="true" />
 			<attribute name="Name" value="Box" />
 			<attribute name="Tags" />
-			<attribute name="Position" value="0.66697 1.83612 -8.11643" />
+			<attribute name="Position" value="10.667 1.83612 -8.11643" />
 			<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
 			<attribute name="Scale" value="3 3 1" />
 			<attribute name="Variables" />
@@ -257,34 +257,6 @@
 				<attribute name="Cast Shadows" value="true" />
 			</component>
 		</node>
-		<node id="85">
-			<attribute name="Is Enabled" value="true" />
-			<attribute name="Name" value="Box" />
-			<attribute name="Tags" />
-			<attribute name="Position" value="10.6654 1.35842 -9.11643" />
-			<attribute name="Rotation" value="-2.98023e-08 0 1 0" />
-			<attribute name="Scale" value="3 3 1" />
-			<attribute name="Variables" />
-			<component type="StaticModel" id="95">
-				<attribute name="Model" value="Model;Models/Box.mdl" />
-				<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
-				<attribute name="Cast Shadows" value="true" />
-			</component>
-		</node>
-		<node id="86">
-			<attribute name="Is Enabled" value="true" />
-			<attribute name="Name" value="Box" />
-			<attribute name="Tags" />
-			<attribute name="Position" value="10.5963 1.35842 -22.1142" />
-			<attribute name="Rotation" value="-2.98023e-08 0 1 0" />
-			<attribute name="Scale" value="3 3 1" />
-			<attribute name="Variables" />
-			<component type="StaticModel" id="96">
-				<attribute name="Model" value="Model;Models/Box.mdl" />
-				<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
-				<attribute name="Cast Shadows" value="true" />
-			</component>
-		</node>
 		<node id="72">
 			<attribute name="Is Enabled" value="true" />
 			<attribute name="Name" value="Plane" />
@@ -295,7 +267,7 @@
 			<attribute name="Variables" />
 			<component type="StaticModel" id="82">
 				<attribute name="Model" value="Model;Models/Plane.mdl" />
-				<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+				<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 			</component>
 		</node>
 		<node id="73">
@@ -308,7 +280,7 @@
 			<attribute name="Variables" />
 			<component type="StaticModel" id="83">
 				<attribute name="Model" value="Model;Models/Plane.mdl" />
-				<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+				<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 			</component>
 		</node>
 		<node id="74">
@@ -334,7 +306,7 @@
 			<attribute name="Variables" />
 			<component type="StaticModel" id="85">
 				<attribute name="Model" value="Model;Models/Plane.mdl" />
-				<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+				<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 			</component>
 		</node>
 		<node id="76">
@@ -347,7 +319,7 @@
 			<attribute name="Variables" />
 			<component type="StaticModel" id="86">
 				<attribute name="Model" value="Model;Models/Plane.mdl" />
-				<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+				<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 			</component>
 		</node>
 		<node id="77">
@@ -521,7 +493,7 @@
 			<attribute name="Is Enabled" value="true" />
 			<attribute name="Name" value="Box" />
 			<attribute name="Tags" />
-			<attribute name="Position" value="1.16697 1.83612 -5.11643" />
+			<attribute name="Position" value="10.667 1.83612 -5.11643" />
 			<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
 			<attribute name="Scale" value="3 3 1" />
 			<attribute name="Variables" />
@@ -563,27 +535,13 @@
 			<attribute name="Is Enabled" value="true" />
 			<attribute name="Name" value="Box" />
 			<attribute name="Tags" />
-			<attribute name="Position" value="1.16697 1.83612 -2.11643" />
+			<attribute name="Position" value="10.667 1.83612 -2.11643" />
 			<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
 			<attribute name="Scale" value="3 3 1" />
 			<attribute name="Variables" />
 			<component type="StaticModel" id="130">
 				<attribute name="Model" value="Model;Models/Box.mdl" />
 				<attribute name="Material" value="Material;" />
-				<attribute name="Cast Shadows" value="true" />
-			</component>
-		</node>
-		<node id="134">
-			<attribute name="Is Enabled" value="true" />
-			<attribute name="Name" value="Box" />
-			<attribute name="Tags" />
-			<attribute name="Position" value="4.66537 1.35842 -9.11643" />
-			<attribute name="Rotation" value="-2.98023e-08 0 1 0" />
-			<attribute name="Scale" value="3 3 1" />
-			<attribute name="Variables" />
-			<component type="StaticModel" id="152">
-				<attribute name="Model" value="Model;Models/Box.mdl" />
-				<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
 				<attribute name="Cast Shadows" value="true" />
 			</component>
 		</node>
@@ -624,20 +582,6 @@
 			<attribute name="Scale" value="3 3 1" />
 			<attribute name="Variables" />
 			<component type="StaticModel" id="211">
-				<attribute name="Model" value="Model;Models/Box.mdl" />
-				<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
-				<attribute name="Cast Shadows" value="true" />
-			</component>
-		</node>
-		<node id="193">
-			<attribute name="Is Enabled" value="true" />
-			<attribute name="Name" value="Box" />
-			<attribute name="Tags" />
-			<attribute name="Position" value="4.59633 1.35842 -22.1142" />
-			<attribute name="Rotation" value="-2.98023e-08 0 1 0" />
-			<attribute name="Scale" value="3 3 1" />
-			<attribute name="Variables" />
-			<component type="StaticModel" id="212">
 				<attribute name="Model" value="Model;Models/Box.mdl" />
 				<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
 				<attribute name="Cast Shadows" value="true" />
@@ -1190,7 +1134,7 @@
 				<attribute name="Variables" />
 				<component type="Light" id="4">
 					<attribute name="Light Type" value="Directional" />
-					<attribute name="Brightness Multiplier" value="340" />
+					<attribute name="Brightness Multiplier" value="5000" />
 					<attribute name="Use Physical Values" value="true" />
 					<attribute name="Cast Shadows" value="true" />
 					<attribute name="CSM Splits" value="10 20 30 40" />
@@ -1208,7 +1152,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="195">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Check.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Metallic0.xml" />
 		</component>
 	</node>
 	<node id="177">
@@ -1221,7 +1165,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="196">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Check.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Metallic0.xml" />
 		</component>
 	</node>
 	<node id="178">
@@ -1234,7 +1178,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="197">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Check.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Metallic0.xml" />
 		</component>
 	</node>
 	<node id="179">
@@ -1247,7 +1191,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="198">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Check.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Metallic0.xml" />
 		</component>
 	</node>
 	<node id="180">
@@ -1260,7 +1204,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="199">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Check.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Metallic0.xml" />
 		</component>
 	</node>
 	<node id="181">
@@ -1273,7 +1217,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="200">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Check.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Metallic0.xml" />
 		</component>
 	</node>
 	<node id="182">
@@ -1286,7 +1230,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="201">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Check.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Metallic0.xml" />
 		</component>
 	</node>
 	<node id="183">
@@ -1299,7 +1243,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="202">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Check.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Metallic0.xml" />
 		</component>
 	</node>
 	<node id="184">
@@ -1312,7 +1256,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="203">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Check.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Metallic0.xml" />
 		</component>
 	</node>
 	<node id="185">
@@ -1347,7 +1291,7 @@
 		<attribute name="Is Enabled" value="true" />
 		<attribute name="Name" value="Box" />
 		<attribute name="Tags" />
-		<attribute name="Position" value="2.66697 1.35842 -23.1164" />
+		<attribute name="Position" value="11.667 1.35842 -23.1164" />
 		<attribute name="Rotation" value="0.707107 0 0.707107 0" />
 		<attribute name="Scale" value="3 3 1" />
 		<attribute name="Variables" />
@@ -1479,7 +1423,7 @@
 		<attribute name="Variables" />
 		<component type="Light" id="224">
 			<attribute name="Specular Intensity" value="0" />
-			<attribute name="Brightness Multiplier" value="100" />
+			<attribute name="Brightness Multiplier" value="800" />
 			<attribute name="Use Physical Values" value="true" />
 			<attribute name="Range" value="7.97" />
 			<attribute name="Spot FOV" value="62.08" />
@@ -1833,11 +1777,11 @@
 		<attribute name="Scale" value="0.648644 0.648644 0.648644" />
 		<attribute name="Variables" />
 		<component type="Light" id="251">
-			<attribute name="Brightness Multiplier" value="1700" />
+			<attribute name="Brightness Multiplier" value="2100" />
 			<attribute name="Use Physical Values" value="true" />
 			<attribute name="Radius" value="22.79" />
 			<attribute name="Length" value="55.25" />
-			<attribute name="Range" value="7.61" />
+			<attribute name="Range" value="9.17" />
 			<attribute name="Spot FOV" value="62.08" />
 			<attribute name="Light Shape Texture" value="TextureCube;" />
 			<attribute name="Cast Shadows" value="true" />
@@ -2149,7 +2093,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="275">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 		</component>
 	</node>
 	<node id="256">
@@ -2162,7 +2106,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="276">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 		</component>
 	</node>
 	<node id="257">
@@ -2175,7 +2119,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="277">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 		</component>
 	</node>
 	<node id="258">
@@ -2188,7 +2132,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="278">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 		</component>
 	</node>
 	<node id="259">
@@ -2201,7 +2145,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="279">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 		</component>
 	</node>
 	<node id="260">
@@ -2215,34 +2159,6 @@
 		<component type="StaticModel" id="280">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
 			<attribute name="Material" value="Material;Materials/PBR/Metallic10.xml" />
-		</component>
-	</node>
-	<node id="261">
-		<attribute name="Is Enabled" value="true" />
-		<attribute name="Name" value="Box" />
-		<attribute name="Tags" />
-		<attribute name="Position" value="7.66537 1.35842 -9.11643" />
-		<attribute name="Rotation" value="-2.98023e-08 0 1 0" />
-		<attribute name="Scale" value="3 3 1" />
-		<attribute name="Variables" />
-		<component type="StaticModel" id="281">
-			<attribute name="Model" value="Model;Models/Box.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
-			<attribute name="Cast Shadows" value="true" />
-		</component>
-	</node>
-	<node id="262">
-		<attribute name="Is Enabled" value="true" />
-		<attribute name="Name" value="Box" />
-		<attribute name="Tags" />
-		<attribute name="Position" value="7.59633 1.35842 -22.1142" />
-		<attribute name="Rotation" value="-2.98023e-08 0 1 0" />
-		<attribute name="Scale" value="3 3 1" />
-		<attribute name="Variables" />
-		<component type="StaticModel" id="282">
-			<attribute name="Model" value="Model;Models/Box.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
-			<attribute name="Cast Shadows" value="true" />
 		</component>
 	</node>
 	<node id="263">
@@ -2778,7 +2694,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="327">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 		</component>
 	</node>
 	<node id="308">
@@ -2791,7 +2707,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="328">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 		</component>
 	</node>
 	<node id="309">
@@ -2804,7 +2720,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="329">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 		</component>
 	</node>
 	<node id="310">
@@ -2849,20 +2765,6 @@
 			<attribute name="Cast Shadows" value="true" />
 		</component>
 	</node>
-	<node id="313">
-		<attribute name="Is Enabled" value="true" />
-		<attribute name="Name" value="Box" />
-		<attribute name="Tags" />
-		<attribute name="Position" value="10.5963 1.35842 -7.11416" />
-		<attribute name="Rotation" value="-2.98023e-08 0 1 0" />
-		<attribute name="Scale" value="3 3 1" />
-		<attribute name="Variables" />
-		<component type="StaticModel" id="333">
-			<attribute name="Model" value="Model;Models/Box.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
-			<attribute name="Cast Shadows" value="true" />
-		</component>
-	</node>
 	<node id="314">
 		<attribute name="Is Enabled" value="true" />
 		<attribute name="Name" value="Plane" />
@@ -2873,7 +2775,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="334">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 		</component>
 	</node>
 	<node id="315">
@@ -2886,7 +2788,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="335">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 		</component>
 	</node>
 	<node id="316">
@@ -2899,7 +2801,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="336">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 		</component>
 	</node>
 	<node id="317">
@@ -2912,7 +2814,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="337">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 		</component>
 	</node>
 	<node id="318">
@@ -2925,7 +2827,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="338">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 		</component>
 	</node>
 	<node id="319">
@@ -2938,7 +2840,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="339">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 		</component>
 	</node>
 	<node id="320">
@@ -3006,20 +2908,6 @@
 		<attribute name="Scale" value="3 3 1" />
 		<attribute name="Variables" />
 		<component type="StaticModel" id="344">
-			<attribute name="Model" value="Model;Models/Box.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
-			<attribute name="Cast Shadows" value="true" />
-		</component>
-	</node>
-	<node id="325">
-		<attribute name="Is Enabled" value="true" />
-		<attribute name="Name" value="Box" />
-		<attribute name="Tags" />
-		<attribute name="Position" value="4.59633 1.35842 -7.11416" />
-		<attribute name="Rotation" value="-2.98023e-08 0 1 0" />
-		<attribute name="Scale" value="3 3 1" />
-		<attribute name="Variables" />
-		<component type="StaticModel" id="345">
 			<attribute name="Model" value="Model;Models/Box.mdl" />
 			<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
 			<attribute name="Cast Shadows" value="true" />
@@ -3330,7 +3218,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="367">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 		</component>
 	</node>
 	<node id="348">
@@ -3343,7 +3231,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="368">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 		</component>
 	</node>
 	<node id="349">
@@ -3356,7 +3244,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="369">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 		</component>
 	</node>
 	<node id="350">
@@ -3369,7 +3257,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="370">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 		</component>
 	</node>
 	<node id="351">
@@ -3382,7 +3270,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="371">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 		</component>
 	</node>
 	<node id="352">
@@ -3395,7 +3283,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="372">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 		</component>
 	</node>
 	<node id="353">
@@ -3407,20 +3295,6 @@
 		<attribute name="Scale" value="3 3 1" />
 		<attribute name="Variables" />
 		<component type="StaticModel" id="373">
-			<attribute name="Model" value="Model;Models/Box.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
-			<attribute name="Cast Shadows" value="true" />
-		</component>
-	</node>
-	<node id="354">
-		<attribute name="Is Enabled" value="true" />
-		<attribute name="Name" value="Box" />
-		<attribute name="Tags" />
-		<attribute name="Position" value="7.59633 1.35842 -7.11416" />
-		<attribute name="Rotation" value="-2.98023e-08 0 1 0" />
-		<attribute name="Scale" value="3 3 1" />
-		<attribute name="Variables" />
-		<component type="StaticModel" id="374">
 			<attribute name="Model" value="Model;Models/Box.mdl" />
 			<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
 			<attribute name="Cast Shadows" value="true" />
@@ -3710,7 +3584,7 @@
 		<attribute name="Is Enabled" value="true" />
 		<attribute name="Name" value="Box" />
 		<attribute name="Tags" />
-		<attribute name="Position" value="1.16697 1.83612 -13.9362" />
+		<attribute name="Position" value="10.667 1.83612 -13.9362" />
 		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
 		<attribute name="Scale" value="3 3 1" />
 		<attribute name="Variables" />
@@ -3752,7 +3626,7 @@
 		<attribute name="Is Enabled" value="true" />
 		<attribute name="Name" value="Box" />
 		<attribute name="Tags" />
-		<attribute name="Position" value="1.16697 1.83612 -16.9362" />
+		<attribute name="Position" value="10.667 1.83612 -16.9362" />
 		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
 		<attribute name="Scale" value="3 3 1" />
 		<attribute name="Variables" />
@@ -3836,7 +3710,7 @@
 		<attribute name="Is Enabled" value="true" />
 		<attribute name="Name" value="Box" />
 		<attribute name="Tags" />
-		<attribute name="Position" value="2.66697 1.35842 -8.11643" />
+		<attribute name="Position" value="11.667 1.35842 -8.11643" />
 		<attribute name="Rotation" value="0.707107 0 0.707107 0" />
 		<attribute name="Scale" value="3 3 1" />
 		<attribute name="Variables" />
@@ -3943,7 +3817,7 @@
 		<attribute name="Is Enabled" value="true" />
 		<attribute name="Name" value="Plane" />
 		<attribute name="Tags" />
-		<attribute name="Position" value="0.66697 2.35842 -7.11643" />
+		<attribute name="Position" value="10.167 2.35842 -23.1164" />
 		<attribute name="Rotation" value="1 0 0 0" />
 		<attribute name="Scale" value="3 1 3" />
 		<attribute name="Variables" />
@@ -3995,15 +3869,15 @@
 		<attribute name="Is Enabled" value="true" />
 		<attribute name="Name" value="" />
 		<attribute name="Tags" />
-		<attribute name="Position" value="6.15174 5.37075 -0.609303" />
+		<attribute name="Position" value="6.27316 5.37075 -0.609303" />
 		<attribute name="Rotation" value="1 0 0 0" />
 		<attribute name="Scale" value="0.648644 0.648644 0.648644" />
 		<attribute name="Variables" />
 		<component type="Light" id="416">
-			<attribute name="Brightness Multiplier" value="1700" />
+			<attribute name="Brightness Multiplier" value="2100" />
 			<attribute name="Use Physical Values" value="true" />
 			<attribute name="Radius" value="25.6" />
-			<attribute name="Range" value="7.61" />
+			<attribute name="Range" value="11.09" />
 			<attribute name="Spot FOV" value="62.08" />
 			<attribute name="Light Shape Texture" value="TextureCube;" />
 			<attribute name="Cast Shadows" value="true" />
@@ -4047,7 +3921,7 @@
 		<attribute name="Variables" />
 		<component type="Light" id="419">
 			<attribute name="Specular Intensity" value="0" />
-			<attribute name="Brightness Multiplier" value="100" />
+			<attribute name="Brightness Multiplier" value="800" />
 			<attribute name="Use Physical Values" value="true" />
 			<attribute name="Range" value="11.15" />
 			<attribute name="Spot FOV" value="62.08" />
@@ -4083,7 +3957,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="422">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 		</component>
 	</node>
 	<node id="403">
@@ -4096,7 +3970,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="423">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 		</component>
 	</node>
 	<node id="404">
@@ -4109,7 +3983,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="424">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 		</component>
 	</node>
 	<node id="405">
@@ -4149,6 +4023,798 @@
 		<component type="StaticModel" id="427">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
 			<attribute name="Material" value="Material;Materials/PBR/Metallic10.xml" />
+		</component>
+	</node>
+	<node id="408">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="10.667 1.83612 -19.9362" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="428">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="409">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="-4.33303 1.83612 -19.9362" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="429">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="410">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="-1.33303 1.83612 -19.9362" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="430">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="411">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="1.16697 1.83612 3.88357" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="431">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="412">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="1.16697 1.83612 -22.9362" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="432">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="413">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="1.16697 1.83612 0.88357" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="433">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="414">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="1.16697 1.83612 -11.1164" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="434">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="415">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="1.16697 1.83612 -8.11643" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="435">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="416">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="1.16697 1.83612 -5.11643" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="436">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="417">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="1.16697 1.83612 -2.11643" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="437">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="418">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="1.16697 1.83612 -13.9362" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="438">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="419">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="1.16697 1.83612 -16.9362" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="439">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="420">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="1.16697 1.83612 -19.9362" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="440">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="421">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="4.66697 1.83612 3.88357" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="441">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="422">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="4.66697 1.83612 -22.9362" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="442">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="423">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="4.66697 1.83612 0.88357" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="443">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="424">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="4.66697 1.83612 -11.1164" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="444">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="425">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="4.66697 1.83612 -8.11643" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="445">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="426">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="4.66697 1.83612 -5.11643" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="446">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="427">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="4.66697 1.83612 -2.11643" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="447">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="428">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="4.66697 1.83612 -13.9362" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="448">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="429">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="4.66697 1.83612 -16.9362" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="449">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="430">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="4.66697 1.83612 -19.9362" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="450">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="431">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="7.66697 1.83612 3.88357" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="451">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="432">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="7.66697 1.83612 -22.9362" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="452">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="433">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="7.66697 1.83612 0.88357" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="453">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="434">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="7.66697 1.83612 -11.1164" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="454">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="435">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="7.66697 1.83612 -8.11643" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="455">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="436">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="7.66697 1.83612 -5.11643" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="456">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="437">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="7.66697 1.83612 -2.11643" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="457">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="438">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="7.66697 1.83612 -13.9362" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="458">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="439">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="7.66697 1.83612 -16.9362" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="459">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="440">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="7.66697 1.83612 -19.9362" />
+		<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="460">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="441">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Plane" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="0.66697 2.35842 -7.11643" />
+		<attribute name="Rotation" value="1 0 0 0" />
+		<attribute name="Scale" value="3 1 3" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="461">
+			<attribute name="Model" value="Model;Models/Plane.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Roughness3.xml" />
+		</component>
+	</node>
+	<node id="442">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Plane" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="4.16697 2.35842 -23.1164" />
+		<attribute name="Rotation" value="1 0 0 0" />
+		<attribute name="Scale" value="3 1 3" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="462">
+			<attribute name="Model" value="Model;Models/Plane.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Roughness3.xml" />
+		</component>
+	</node>
+	<node id="443">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Plane" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="7.16697 2.35842 -23.1164" />
+		<attribute name="Rotation" value="1 0 0 0" />
+		<attribute name="Scale" value="3 1 3" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="463">
+			<attribute name="Model" value="Model;Models/Plane.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Roughness3.xml" />
+		</component>
+	</node>
+	<node id="444">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Plane" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="10.167 2.35842 -8.11643" />
+		<attribute name="Rotation" value="1 0 0 0" />
+		<attribute name="Scale" value="3 1 3" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="464">
+			<attribute name="Model" value="Model;Models/Plane.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Roughness3.xml" />
+		</component>
+	</node>
+	<node id="445">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Plane" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="4.16697 2.35842 -8.11643" />
+		<attribute name="Rotation" value="1 0 0 0" />
+		<attribute name="Scale" value="3 1 3" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="465">
+			<attribute name="Model" value="Model;Models/Plane.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Roughness3.xml" />
+		</component>
+	</node>
+	<node id="446">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Plane" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="7.16697 2.35842 -8.11643" />
+		<attribute name="Rotation" value="1 0 0 0" />
+		<attribute name="Scale" value="3 1 3" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="466">
+			<attribute name="Model" value="Model;Models/Plane.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Roughness3.xml" />
+		</component>
+	</node>
+	<node id="447">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="2.66697 1.35842 -23.1164" />
+		<attribute name="Rotation" value="0.707107 0 0.707107 0" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="467">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="448">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="3.66697 1.35842 -23.1164" />
+		<attribute name="Rotation" value="0.707107 0 0.707107 0" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="468">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="449">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="4.66697 1.35842 -23.1164" />
+		<attribute name="Rotation" value="0.707107 0 0.707107 0" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="469">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="450">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="5.66697 1.35842 -23.1164" />
+		<attribute name="Rotation" value="0.707107 0 0.707107 0" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="470">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="451">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="6.66697 1.35842 -23.1164" />
+		<attribute name="Rotation" value="0.707107 0 0.707107 0" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="471">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="452">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="7.66697 1.35842 -23.1164" />
+		<attribute name="Rotation" value="0.707107 0 0.707107 0" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="472">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="453">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="8.66697 1.35842 -23.1164" />
+		<attribute name="Rotation" value="0.707107 0 0.707107 0" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="473">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="454">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="9.66697 1.35842 -23.1164" />
+		<attribute name="Rotation" value="0.707107 0 0.707107 0" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="474">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="455">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="10.667 1.35842 -23.1164" />
+		<attribute name="Rotation" value="0.707107 0 0.707107 0" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="475">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="456">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="2.66697 1.35842 -8.11643" />
+		<attribute name="Rotation" value="0.707107 0 0.707107 0" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="476">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="457">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="3.66697 1.35842 -8.11643" />
+		<attribute name="Rotation" value="0.707107 0 0.707107 0" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="477">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="458">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="4.66697 1.35842 -8.11643" />
+		<attribute name="Rotation" value="0.707107 0 0.707107 0" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="478">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="459">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="5.66697 1.35842 -8.11643" />
+		<attribute name="Rotation" value="0.707107 0 0.707107 0" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="479">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="460">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="6.66697 1.35842 -8.11643" />
+		<attribute name="Rotation" value="0.707107 0 0.707107 0" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="480">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="461">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="7.66697 1.35842 -8.11643" />
+		<attribute name="Rotation" value="0.707107 0 0.707107 0" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="481">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="462">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="8.66697 1.35842 -8.11643" />
+		<attribute name="Rotation" value="0.707107 0 0.707107 0" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="482">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="463">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="9.66697 1.35842 -8.11643" />
+		<attribute name="Rotation" value="0.707107 0 0.707107 0" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="483">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="464">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Box" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="10.667 1.35842 -8.11643" />
+		<attribute name="Rotation" value="0.707107 0 0.707107 0" />
+		<attribute name="Scale" value="3 3 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="484">
+			<attribute name="Model" value="Model;Models/Box.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Tile.xml" />
+			<attribute name="Cast Shadows" value="true" />
 		</component>
 	</node>
 </scene>

--- a/bin/Data/Scripts/42_PBRMaterials.as
+++ b/bin/Data/Scripts/42_PBRMaterials.as
@@ -160,6 +160,8 @@ void SetupViewport()
     RenderPath@ effectRenderPath = viewport.renderPath.Clone();
     effectRenderPath.Append(cache.GetResource("XMLFile", "PostProcess/FXAA2.xml"));
     effectRenderPath.Append(cache.GetResource("XMLFile", "PostProcess/GammaCorrection.xml"));
+    effectRenderPath.Append(cache.GetResource("XMLFile", "PostProcess/Tonemap.xml"));
+    effectRenderPath.Append(cache.GetResource("XMLFile", "PostProcess/AutoExposure.xml"));
 
     viewport.renderPath = effectRenderPath;
 }


### PR DESCRIPTION
Fixed the issues noted in https://github.com/urho3d/Urho3D/issues/1916

This was done by rebuilding the sphere lights, changing the visibility model and expanding the diffuse and fresnel models.

The new diffuse model should be more performant due to much less and much more simple math in the shader.

In addition to fixing the issue noted i also resolved another issue i didnt realise existed until tackling this fix, the old PBR implementation didnt correctly match the physical light values, now the light values should map to real world equivalents.