### PR TITLE
Add UI.FontHintLevel property

### DIFF
--- a/Source/Samples/47_Typography/Typography.h
+++ b/Source/Samples/47_Typography/Typography.h
@@ -51,9 +51,11 @@ private:
     SharedPtr<UIElement> uielement_;
 
     void CreateText();
-    void CreateCheckbox(const String& label, EventHandler* handler);
+    SharedPtr<CheckBox> CreateCheckbox(const String& label, EventHandler* handler);
+    SharedPtr<DropDownList> CreateMenu(const String& label, const char** items, EventHandler* handler);
 
     void HandleWhiteBackground(StringHash eventType, VariantMap& eventData);
     void HandleSRGB(StringHash eventType, VariantMap& eventData);
     void HandleForceAutoHint(StringHash eventType, VariantMap& eventData);
+    void HandleFontHintLevel(StringHash eventType, VariantMap& eventData);
 };

--- a/Source/Urho3D/AngelScript/UIAPI.cpp
+++ b/Source/Urho3D/AngelScript/UIAPI.cpp
@@ -732,6 +732,11 @@ static CScriptArray* UIGetDragElements(UI* ptr)
 
 static void RegisterUI(asIScriptEngine* engine)
 {
+    engine->RegisterEnum("FontHintLevel");
+    engine->RegisterEnumValue("FontHintLevel", "FONT_HINT_LEVEL_NONE", FONT_HINT_LEVEL_NONE);
+    engine->RegisterEnumValue("FontHintLevel", "FONT_HINT_LEVEL_LIGHT", FONT_HINT_LEVEL_LIGHT);
+    engine->RegisterEnumValue("FontHintLevel", "FONT_HINT_LEVEL_NORMAL", FONT_HINT_LEVEL_NORMAL);
+
     RegisterObject<UI>(engine, "UI");
     engine->RegisterObjectMethod("UI", "void Clear()", asMETHOD(UI, Clear), asCALL_THISCALL);
     engine->RegisterObjectMethod("UI", "void DebugDraw(UIElement@+)", asMETHOD(UI, DebugDraw), asCALL_THISCALL);
@@ -782,6 +787,8 @@ static void RegisterUI(asIScriptEngine* engine)
     engine->RegisterObjectMethod("UI", "bool get_useMutableGlyphs() const", asMETHOD(UI, GetUseMutableGlyphs), asCALL_THISCALL);
     engine->RegisterObjectMethod("UI", "void set_forceAutoHint(bool)", asMETHOD(UI, SetForceAutoHint), asCALL_THISCALL);
     engine->RegisterObjectMethod("UI", "bool get_forceAutoHint() const", asMETHOD(UI, GetForceAutoHint), asCALL_THISCALL);
+    engine->RegisterObjectMethod("UI", "void set_fontHintLevel(FontHintLevel)", asMETHOD(UI, SetFontHintLevel), asCALL_THISCALL);
+    engine->RegisterObjectMethod("UI", "FontHintLevel get_fontHintLevel() const", asMETHOD(UI, GetFontHintLevel), asCALL_THISCALL);
     engine->RegisterObjectMethod("UI", "void set_scale(float value)", asMETHOD(UI, SetScale), asCALL_THISCALL);
     engine->RegisterObjectMethod("UI", "float get_scale() const", asMETHOD(UI, GetScale), asCALL_THISCALL);
     engine->RegisterObjectMethod("UI", "void set_customSize(const IntVector2&in)", asMETHODPR(UI, SetCustomSize, (const IntVector2&), void), asCALL_THISCALL);

--- a/Source/Urho3D/LuaScript/pkgs/UI/UI.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/UI/UI.pkg
@@ -1,5 +1,12 @@
 $#include "UI/UI.h"
 
+enum FontHintLevel
+{
+    FONT_HINT_LEVEL_NONE = 0,
+    FONT_HINT_LEVEL_LIGHT,
+    FONT_HINT_LEVEL_NORMAL,
+};
+
 class UI : public Object
 {
     void SetCursor(Cursor* cursor);
@@ -23,6 +30,7 @@ class UI : public Object
     void SetUseScreenKeyboard(bool enable);
     void SetUseMutableGlyphs(bool enable);
     void SetForceAutoHint(bool enable);
+    void SetFontHintLevel(FontHintLevel level);
     void SetScale(float scale);
     void SetWidth(float width);
     void SetHeight(float height);
@@ -50,6 +58,7 @@ class UI : public Object
     bool GetUseScreenKeyboard() const;
     bool GetUseMutableGlyphs() const;
     bool GetForceAutoHint() const;
+    FontHintLevel GetFontHintLevel() const;
     bool HasModalElement() const;
     bool IsDragging() const;
     float GetScale() const;

--- a/Source/Urho3D/UI/FontFaceFreeType.cpp
+++ b/Source/Urho3D/UI/FontFaceFreeType.cpp
@@ -158,7 +158,20 @@ bool FontFaceFreeType::Load(const unsigned char* fontData, unsigned fontDataSize
     }
 
     // Load each of the glyphs to see the sizes & store other information
-    loadMode_ = (int)(ui->GetForceAutoHint() ? FT_LOAD_FORCE_AUTOHINT : FT_LOAD_DEFAULT);
+    loadMode_ = FT_LOAD_DEFAULT;
+    if (ui->GetForceAutoHint())
+    {
+        loadMode_ |= FT_LOAD_FORCE_AUTOHINT;
+    }
+    if (ui->GetFontHintLevel() == FONT_HINT_LEVEL_NONE)
+    {
+        loadMode_ |= FT_LOAD_NO_HINTING;
+    }
+    if (ui->GetFontHintLevel() == FONT_HINT_LEVEL_LIGHT)
+    {
+        loadMode_ |= FT_LOAD_TARGET_LIGHT;
+    }
+
     ascender_ = RoundToPixels(face->size->metrics.ascender);
     rowHeight_ = RoundToPixels(face->size->metrics.height);
     pointSize_ = pointSize;

--- a/Source/Urho3D/UI/UI.cpp
+++ b/Source/Urho3D/UI/UI.cpp
@@ -106,6 +106,7 @@ UI::UI(Context* context) :
 #endif
     useMutableGlyphs_(false),
     forceAutoHint_(false),
+    fontHintLevel_(FONT_HINT_LEVEL_NORMAL),
     uiRendered_(false),
     nonModalBatchSize_(0),
     dragElementsCount_(0),
@@ -601,6 +602,15 @@ void UI::SetForceAutoHint(bool enable)
     if (enable != forceAutoHint_)
     {
         forceAutoHint_ = enable;
+        ReleaseFontFaces();
+    }
+}
+
+void UI::SetFontHintLevel(FontHintLevel level)
+{
+    if (level != fontHintLevel_)
+    {
+        fontHintLevel_ = level;
         ReleaseFontFaces();
     }
 }

--- a/Source/Urho3D/UI/UI.h
+++ b/Source/Urho3D/UI/UI.h
@@ -29,6 +29,19 @@
 namespace Urho3D
 {
 
+/// Font hinting level (only used for FreeType fonts)
+enum FontHintLevel
+{
+    /// Completely disable font hinting. Output will be blurrier but more "correct".
+    FONT_HINT_LEVEL_NONE = 0,
+
+    /// Light hinting. FreeType will pixel-align fonts vertically, but not horizontally.
+    FONT_HINT_LEVEL_LIGHT,
+
+    /// Full hinting, using either the font's own hinting or FreeType's auto-hinter.
+    FONT_HINT_LEVEL_NORMAL
+};
+
 class Cursor;
 class Graphics;
 class ResourceCache;
@@ -95,6 +108,8 @@ public:
     void SetUseMutableGlyphs(bool enable);
     /// Set whether to force font autohinting instead of using FreeType's TTF bytecode interpreter.
     void SetForceAutoHint(bool enable);
+    /// Set the hinting level used by FreeType fonts.
+    void SetFontHintLevel(FontHintLevel level);
     /// Set %UI scale. 1.0 is default (pixel perfect). Resize the root element to match.
     void SetScale(float scale);
     /// Scale %UI to the specified width in pixels.
@@ -167,6 +182,9 @@ public:
 
     /// Return whether is using forced autohinting.
     bool GetForceAutoHint() const { return forceAutoHint_; }
+
+    /// Return the current FreeType font hinting level.
+    FontHintLevel GetFontHintLevel() const { return fontHintLevel_; }
 
     /// Return true when UI has modal element(s).
     bool HasModalElement() const;
@@ -331,6 +349,8 @@ private:
     bool useMutableGlyphs_;
     /// Flag for forcing FreeType auto hinting.
     bool forceAutoHint_;
+    /// FreeType hinting level (default is FONT_HINT_LEVEL_NORMAL).
+    FontHintLevel fontHintLevel_;
     /// Flag for UI already being rendered this frame.
     bool uiRendered_;
     /// Non-modal batch size (used internally for rendering).

--- a/bin/Data/LuaScripts/47_Typography.lua
+++ b/bin/Data/LuaScripts/47_Typography.lua
@@ -34,16 +34,28 @@ function Start()
 
     -- Add a checkbox to toggle the background color.
     CreateCheckbox("White background", "HandleWhiteBackground")
+        :SetChecked(false)
 
     -- Add a checkbox for the global ForceAutoHint setting. This affects character spacing.
     CreateCheckbox("UI::SetForceAutoHint", "HandleForceAutoHint")
+        :SetChecked(ui:GetForceAutoHint())
 
     -- Add a checkbox to toggle SRGB output conversion (if available).
     -- This will give more correct text output for FreeType fonts, as the FreeType rasterizer
     -- outputs linear coverage values rather than SRGB values. However, this feature isn't
     -- available on all platforms.
     CreateCheckbox("Graphics::SetSRGB", "HandleSRGB")
+        :SetChecked(graphics:GetSRGB())
 
+    -- Add a drop-down menu to control the font hinting level.
+    local items = {
+        "FONT_HINT_LEVEL_NONE",
+        "FONT_HINT_LEVEL_LIGHT",
+        "FONT_HINT_LEVEL_NORMAL"
+    }
+    CreateMenu("UI::SetFontHintLevel", items, "HandleFontHintLevel")
+        :SetSelection(ui:GetFontHintLevel())
+    
     -- Set the mouse mode to use in the sample
     SampleInitMouseMode(MM_FREE)
 end
@@ -82,6 +94,38 @@ function CreateCheckbox(label, handler)
     text:AddTag(TEXT_TAG)
 
     SubscribeToEvent(box, "Toggled", handler)
+    return box
+end
+
+function CreateMenu(label, items, handler)
+    local container = UIElement:new()
+    container:SetAlignment(HA_LEFT, VA_TOP)
+    container:SetLayout(LM_HORIZONTAL, 8)
+    uielement:AddChild(container)
+    
+    local text = Text:new()
+    container:AddChild(text)
+    text.text = label
+    text:SetStyleAuto()
+    text:AddTag(TEXT_TAG)
+
+    local list = DropDownList:new()
+    container:AddChild(list)
+    list:SetStyleAuto()
+    
+    for i, item in ipairs(items) do
+        local t = Text:new()
+        list:AddItem(t)
+        t.text = item
+        t:SetStyleAuto()
+        t:AddTag(TEXT_TAG) 
+    end
+
+    text:SetMaxWidth(text:GetRowWidth(0))
+    list:SetMaxWidth(text:GetRowWidth(0) * 1.5)
+    
+    SubscribeToEvent(list, "ItemSelected", handler)
+    return list
 end
 
 function HandleWhiteBackground(eventType, eventData)
@@ -115,6 +159,13 @@ function HandleSRGB(eventType, eventData)
     else
         log:Write(LOG_WARNING, "graphics:GetSRGBWriteSupport returned false")
     end
+end
+
+function HandleFontHintLevel(eventType, eventData)
+    local list = eventData["Element"]:GetPtr("DropDownList")
+    local i = list:GetSelection()
+
+    ui:SetFontHintLevel(i)
 end
 
 -- Create XML patch instructions for screen joystick layout specific to this sample app


### PR DESCRIPTION
There are three levels: NORMAL (the default), LIGHT and NONE.
The LIGHT level makes FreeType align font outlines to pixel
boundaries vertically, but not horizontally.

This is needed for #1953, as subpixel character positioning doesn't make sense with fully-hinted glyphs -- the whole point of hinting is to align glyphs to the pixel grid.