### PR TITLE
Change font size to a float (closes #1952)

### DIFF
--- a/Source/Samples/47_Typography/Typography.cpp
+++ b/Source/Samples/47_Typography/Typography.cpp
@@ -116,7 +116,7 @@ void Typography::CreateText()
     ResourceCache* cache = GetSubsystem<ResourceCache>();
     Font* font = cache->GetResource<Font>("Fonts/BlueHighway.ttf");
 
-    for (int size = 1; size <= 24; ++size)
+    for (float size = 1; size <= 18; size += 0.5)
     {
         SharedPtr<Text> text(new Text(context_));
         text->SetText(String("The quick brown fox jumps over the lazy dog (") + String(size) + String("pt)"));

--- a/Source/Urho3D/AngelScript/UIAPI.cpp
+++ b/Source/Urho3D/AngelScript/UIAPI.cpp
@@ -377,12 +377,12 @@ static void RegisterText(asIScriptEngine* engine)
 
     RegisterUIElement<Text>(engine, "Text");
     engine->RegisterObjectMethod("Text", "bool SetFont(const String&in, int)", asMETHODPR(Text, SetFont, (const String&, int), bool), asCALL_THISCALL);
-    engine->RegisterObjectMethod("Text", "bool SetFont(Font@+, int)", asMETHODPR(Text, SetFont, (Font*, int), bool), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Text", "bool SetFont(Font@+, float)", asMETHODPR(Text, SetFont, (Font*, float), bool), asCALL_THISCALL);
     engine->RegisterObjectMethod("Text", "void SetSelection(uint, uint arg1 = M_MAX_UNSIGNED)", asMETHOD(Text, SetSelection), asCALL_THISCALL);
     engine->RegisterObjectMethod("Text", "void ClearSelection()", asMETHOD(Text, ClearSelection), asCALL_THISCALL);
     engine->RegisterObjectMethod("Text", "Font@+ get_font() const", asMETHOD(Text, GetFont), asCALL_THISCALL);
-    engine->RegisterObjectMethod("Text", "bool set_fontSize(int)", asMETHOD(Text, SetFontSize), asCALL_THISCALL);
-    engine->RegisterObjectMethod("Text", "int get_fontSize() const", asMETHOD(Text, GetFontSize), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Text", "bool set_fontSize(float)", asMETHOD(Text, SetFontSize), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Text", "float get_fontSize() const", asMETHOD(Text, GetFontSize), asCALL_THISCALL);
     engine->RegisterObjectMethod("Text", "void set_text(const String&in)", asMETHOD(Text, SetText), asCALL_THISCALL);
     engine->RegisterObjectMethod("Text", "const String& get_text() const", asMETHOD(Text, GetText), asCALL_THISCALL);
     engine->RegisterObjectMethod("Text", "void set_textAlignment(HorizontalAlignment)", asMETHOD(Text, SetTextAlignment), asCALL_THISCALL);
@@ -420,12 +420,12 @@ static void RegisterText(asIScriptEngine* engine)
 static void RegisterText3D(asIScriptEngine* engine)
 {
     RegisterDrawable<Text3D>(engine, "Text3D");
-    engine->RegisterObjectMethod("Text3D", "bool SetFont(const String&in, int)", asMETHODPR(Text3D, SetFont, (const String&, int), bool), asCALL_THISCALL);
-    engine->RegisterObjectMethod("Text3D", "bool SetFont(Font@+, int)", asMETHODPR(Text3D, SetFont, (Font*, int), bool), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Text3D", "bool SetFont(const String&in, float)", asMETHODPR(Text3D, SetFont, (const String&, float), bool), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Text3D", "bool SetFont(Font@+, float)", asMETHODPR(Text3D, SetFont, (Font*, float), bool), asCALL_THISCALL);
     engine->RegisterObjectMethod("Text3D", "void SetAlignment(HorizontalAlignment, VerticalAlignment)", asMETHOD(Text3D, SetAlignment), asCALL_THISCALL);
     engine->RegisterObjectMethod("Text3D", "Font@+ get_font() const", asMETHOD(Text3D, GetFont), asCALL_THISCALL);
-    engine->RegisterObjectMethod("Text3D", "bool set_fontSize(int)", asMETHOD(Text3D, SetFontSize), asCALL_THISCALL);
-    engine->RegisterObjectMethod("Text3D", "int get_fontSize() const", asMETHOD(Text3D, GetFontSize), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Text3D", "bool set_fontSize(float)", asMETHOD(Text3D, SetFontSize), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Text3D", "float get_fontSize() const", asMETHOD(Text3D, GetFontSize), asCALL_THISCALL);
     engine->RegisterObjectMethod("Text3D", "void set_material(Material@+)", asMETHOD(Text3D, SetMaterial), asCALL_THISCALL);
     engine->RegisterObjectMethod("Text3D", "Material@+ get_material() const", asMETHOD(Text3D, GetMaterial), asCALL_THISCALL);
     engine->RegisterObjectMethod("Text3D", "void set_text(const String&in)", asMETHOD(Text3D, SetText), asCALL_THISCALL);

--- a/Source/Urho3D/LuaScript/pkgs/UI/Text.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/UI/Text.pkg
@@ -12,9 +12,9 @@ class Text : public UIElement
     Text();
     virtual ~Text();
 
-    bool SetFont(const String fontName, int size = DEFAULT_FONT_SIZE);
-    bool SetFont(Font* font, int size = DEFAULT_FONT_SIZE);
-    bool SetFontSize(int size);
+    bool SetFont(const String fontName, float size = DEFAULT_FONT_SIZE);
+    bool SetFont(Font* font, float size = DEFAULT_FONT_SIZE);
+    bool SetFontSize(float size);
 
     void SetText(const String text);
 
@@ -35,7 +35,7 @@ class Text : public UIElement
     void SetAutoLocalizable(bool enable);
 
     Font* GetFont() const;
-    int GetFontSize() const;
+    float GetFontSize() const;
     const String GetText() const;
     HorizontalAlignment GetTextAlignment() const;
     float GetRowSpacing() const;
@@ -60,7 +60,7 @@ class Text : public UIElement
     float GetEffectDepthBias() const;
 
     tolua_property__get_set Font* font;
-    tolua_property__get_set int fontSize;
+    tolua_property__get_set float fontSize;
     tolua_property__get_set String text;
     tolua_property__get_set HorizontalAlignment textAlignment;
     tolua_property__get_set float rowSpacing;

--- a/Source/Urho3D/LuaScript/pkgs/UI/Text3D.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/UI/Text3D.pkg
@@ -17,9 +17,9 @@ class Text3D : public Drawable
     Text3D();
     ~Text3D();
 
-    bool SetFont(const String fontName, int size = DEFAULT_FONT_SIZE);
-    bool SetFont(Font* font, int size = DEFAULT_FONT_SIZE);
-    bool SetFontSize(int size);
+    bool SetFont(const String fontName, float size = DEFAULT_FONT_SIZE);
+    bool SetFont(Font* font, float size = DEFAULT_FONT_SIZE);
+    bool SetFontSize(float size);
 
     void SetMaterial(Material* material);
 
@@ -46,7 +46,7 @@ class Text3D : public Drawable
 
     Font* GetFont() const;
     Material* GetMaterial() const;
-    int GetFontSize() const;
+    float GetFontSize() const;
     const String GetText() const;
     HorizontalAlignment GetTextAlignment() const;
     HorizontalAlignment GetHorizontalAlignment() const;
@@ -74,7 +74,7 @@ class Text3D : public Drawable
 
     tolua_property__get_set Font* font;
     tolua_property__get_set Material* material;
-    tolua_property__get_set int fontSize;
+    tolua_property__get_set float fontSize;
     tolua_property__get_set String text;
     tolua_property__get_set HorizontalAlignment textAlignment;
     tolua_property__get_set HorizontalAlignment horizontalAlignment;

--- a/Source/Urho3D/UI/Font.cpp
+++ b/Source/Urho3D/UI/Font.cpp
@@ -39,8 +39,17 @@
 namespace Urho3D
 {
 
-static const int MIN_POINT_SIZE = 1;
-static const int MAX_POINT_SIZE = 96;
+namespace
+{
+    /// Convert float to 26.6 fixed-point (as used internally by FreeType)
+    inline int FloatToFixed(float value)
+    {
+        return (int)(value * 64);
+    }
+}
+
+static const float MIN_POINT_SIZE = 1;
+static const float MAX_POINT_SIZE = 96;
 
 Font::Font(Context* context) :
     Resource(context),
@@ -127,7 +136,7 @@ void Font::SetScaledGlyphOffset(const Vector2& offset)
     scaledOffset_ = offset;
 }
 
-FontFace* Font::GetFace(int pointSize)
+FontFace* Font::GetFace(float pointSize)
 {
     // In headless mode, always return null
     Graphics* graphics = GetSubsystem<Graphics>();
@@ -140,7 +149,9 @@ FontFace* Font::GetFace(int pointSize)
     else
         pointSize = Clamp(pointSize, MIN_POINT_SIZE, MAX_POINT_SIZE);
 
-    HashMap<int, SharedPtr<FontFace> >::Iterator i = faces_.Find(pointSize);
+    // For outline fonts, we return the nearest size in 1/64th increments, as that's what FreeType supports.
+    int key = FloatToFixed(pointSize);
+    HashMap<int, SharedPtr<FontFace> >::Iterator i = faces_.Find(key);
     if (i != faces_.End())
     {
         if (!i->second_->IsDataLost())
@@ -209,23 +220,25 @@ void Font::LoadParameters()
     }
 }
 
-FontFace* Font::GetFaceFreeType(int pointSize)
+FontFace* Font::GetFaceFreeType(float pointSize)
 {
     SharedPtr<FontFace> newFace(new FontFaceFreeType(this));
     if (!newFace->Load(&fontData_[0], fontDataSize_, pointSize))
         return 0;
 
-    faces_[pointSize] = newFace;
+    int key = FloatToFixed(pointSize);
+    faces_[key] = newFace;
     return newFace;
 }
 
-FontFace* Font::GetFaceBitmap(int pointSize)
+FontFace* Font::GetFaceBitmap(float pointSize)
 {
     SharedPtr<FontFace> newFace(new FontFaceBitmap(this));
     if (!newFace->Load(&fontData_[0], fontDataSize_, pointSize))
         return 0;
 
-    faces_[pointSize] = newFace;
+    int key = FloatToFixed(pointSize);
+    faces_[key] = newFace;
     return newFace;
 }
 

--- a/Source/Urho3D/UI/Font.h
+++ b/Source/Urho3D/UI/Font.h
@@ -65,7 +65,7 @@ public:
     void SetScaledGlyphOffset(const Vector2& offset);
 
     /// Return font face. Pack and render to a texture if not rendered yet. Return null on error.
-    FontFace* GetFace(int pointSize);
+    FontFace* GetFace(float pointSize);
 
     /// Return font type.
     FontType GetFontType() const { return fontType_; }
@@ -89,9 +89,9 @@ private:
     /// Load font glyph offset parameters from an optional XML file. Called internally when loading TrueType fonts.
     void LoadParameters();
     /// Return font face using FreeType. Called internally. Return null on error.
-    FontFace* GetFaceFreeType(int pointSize);
+    FontFace* GetFaceFreeType(float pointSize);
     /// Return bitmap font face. Called internally. Return null on error.
-    FontFace* GetFaceBitmap(int pointSize);
+    FontFace* GetFaceBitmap(float pointSize);
 
     /// Created faces.
     HashMap<int, SharedPtr<FontFace> > faces_;

--- a/Source/Urho3D/UI/FontFace.h
+++ b/Source/Urho3D/UI/FontFace.h
@@ -71,7 +71,7 @@ public:
     ~FontFace();
 
     /// Load font face.
-    virtual bool Load(const unsigned char* fontData, unsigned fontDataSize, int pointSize) = 0;
+    virtual bool Load(const unsigned char* fontData, unsigned fontDataSize, float pointSize) = 0;
     /// Return pointer to the glyph structure corresponding to a character. Return null if glyph not found.
     virtual const FontGlyph* GetGlyph(unsigned c);
 
@@ -84,7 +84,7 @@ public:
     bool IsDataLost() const;
 
     /// Return point size.
-    int GetPointSize() const { return pointSize_; }
+    float GetPointSize() const { return pointSize_; }
 
     /// Return row height.
     int GetRowHeight() const { return rowHeight_; }
@@ -108,7 +108,7 @@ protected:
     /// Glyph texture pages.
     Vector<SharedPtr<Texture2D> > textures_;
     /// Point size.
-    int pointSize_;
+    float pointSize_;
     /// Row height.
     int rowHeight_;
 };

--- a/Source/Urho3D/UI/FontFaceBitmap.cpp
+++ b/Source/Urho3D/UI/FontFaceBitmap.cpp
@@ -48,7 +48,7 @@ FontFaceBitmap::~FontFaceBitmap()
 {
 }
 
-bool FontFaceBitmap::Load(const unsigned char* fontData, unsigned fontDataSize, int pointSize)
+bool FontFaceBitmap::Load(const unsigned char* fontData, unsigned fontDataSize, float pointSize)
 {
     Context* context = font_->GetContext();
 

--- a/Source/Urho3D/UI/FontFaceBitmap.h
+++ b/Source/Urho3D/UI/FontFaceBitmap.h
@@ -40,7 +40,7 @@ public:
     ~FontFaceBitmap();
 
     /// Load font face.
-    virtual bool Load(const unsigned char* fontData, unsigned fontDataSize, int pointSize);
+    virtual bool Load(const unsigned char* fontData, unsigned fontDataSize, float pointSize);
     /// Load from existed font face, pack used glyphs into smallest texture size and smallest number of texture.
     bool Load(FontFace* fontFace, bool usedGlyphs);
     /// Save as a new bitmap font type in XML format. Return true if successful.

--- a/Source/Urho3D/UI/FontFaceFreeType.cpp
+++ b/Source/Urho3D/UI/FontFaceFreeType.cpp
@@ -91,7 +91,7 @@ FontFaceFreeType::~FontFaceFreeType()
     }
 }
 
-bool FontFaceFreeType::Load(const unsigned char* fontData, unsigned fontDataSize, int pointSize)
+bool FontFaceFreeType::Load(const unsigned char* fontData, unsigned fontDataSize, float pointSize)
 {
     Context* context = font_->GetContext();
 
@@ -139,7 +139,7 @@ bool FontFaceFreeType::Load(const unsigned char* fontData, unsigned fontDataSize
     face_ = face;
 
     unsigned numGlyphs = (unsigned)face->num_glyphs;
-    URHO3D_LOGDEBUGF("Font face %s (%dpt) has %d glyphs", GetFileName(font_->GetName()).CString(), pointSize, numGlyphs);
+    URHO3D_LOGDEBUGF("Font face %s (%fpt) has %d glyphs", GetFileName(font_->GetName()).CString(), pointSize, numGlyphs);
 
     PODVector<unsigned> charCodes(numGlyphs + 1, 0);
 

--- a/Source/Urho3D/UI/FontFaceFreeType.h
+++ b/Source/Urho3D/UI/FontFaceFreeType.h
@@ -40,7 +40,7 @@ public:
     ~FontFaceFreeType();
 
     /// Load font face.
-    virtual bool Load(const unsigned char* fontData, unsigned fontDataSize, int pointSize);
+    virtual bool Load(const unsigned char* fontData, unsigned fontDataSize, float pointSize);
     /// Return pointer to the glyph structure corresponding to a character. Return null if glyph not found.
     virtual const FontGlyph* GetGlyph(unsigned c);
 

--- a/Source/Urho3D/UI/Text.cpp
+++ b/Source/Urho3D/UI/Text.cpp
@@ -86,7 +86,7 @@ void Text::RegisterObject(Context* context)
     URHO3D_COPY_BASE_ATTRIBUTES(UIElement);
     URHO3D_UPDATE_ATTRIBUTE_DEFAULT_VALUE("Use Derived Opacity", false);
     URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Font", GetFontAttr, SetFontAttr, ResourceRef, ResourceRef(Font::GetTypeStatic()), AM_FILE);
-    URHO3D_ATTRIBUTE("Font Size", int, fontSize_, DEFAULT_FONT_SIZE, AM_FILE);
+    URHO3D_ATTRIBUTE("Font Size", float, fontSize_, DEFAULT_FONT_SIZE, AM_FILE);
     URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Text", GetTextAttr, SetTextAttr, String, String::EMPTY, AM_FILE);
     URHO3D_ENUM_ATTRIBUTE("Text Alignment", textAlignment_, horizontalAlignments, HA_LEFT, AM_FILE);
     URHO3D_ATTRIBUTE("Row Spacing", float, rowSpacing_, 1.0f, AM_FILE);
@@ -273,7 +273,7 @@ bool Text::SetFont(const String& fontName, int size)
     return SetFont(cache->GetResource<Font>(fontName), size);
 }
 
-bool Text::SetFont(Font* font, int size)
+bool Text::SetFont(Font* font, float size)
 {
     if (!font)
     {
@@ -291,7 +291,7 @@ bool Text::SetFont(Font* font, int size)
     return true;
 }
 
-bool Text::SetFontSize(int size)
+bool Text::SetFontSize(float size)
 {
     // Initial font must be set
     if (!font_)

--- a/Source/Urho3D/UI/Text.h
+++ b/Source/Urho3D/UI/Text.h
@@ -27,7 +27,7 @@
 namespace Urho3D
 {
 
-static const int DEFAULT_FONT_SIZE = 12;
+static const float DEFAULT_FONT_SIZE = 12;
 
 class Font;
 class FontFace;
@@ -96,9 +96,9 @@ public:
     /// Set font by looking from resource cache by name and font size. Return true if successful.
     bool SetFont(const String& fontName, int size = DEFAULT_FONT_SIZE);
     /// Set font and font size. Return true if successful.
-    bool SetFont(Font* font, int size = DEFAULT_FONT_SIZE);
+    bool SetFont(Font* font, float size = DEFAULT_FONT_SIZE);
     /// Set font size only while retaining the existing font. Return true if successful.
-    bool SetFontSize(int size);
+    bool SetFontSize(float size);
     /// Set text. Text is assumed to be either ASCII or UTF8-encoded.
     void SetText(const String& text);
     /// Set row alignment.
@@ -132,7 +132,7 @@ public:
     Font* GetFont() const { return font_; }
 
     /// Return font size.
-    int GetFontSize() const { return fontSize_; }
+    float GetFontSize() const { return fontSize_; }
 
     /// Return text.
     const String& GetText() const { return text_; }
@@ -228,7 +228,7 @@ protected:
     /// Current face.
     WeakPtr<FontFace> fontFace_;
     /// Font size.
-    int fontSize_;
+    float fontSize_;
     /// UTF-8 encoded text.
     String text_;
     /// Row alignment.

--- a/Source/Urho3D/UI/Text3D.cpp
+++ b/Source/Urho3D/UI/Text3D.cpp
@@ -76,7 +76,7 @@ void Text3D::RegisterObject(Context* context)
     URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Font", GetFontAttr, SetFontAttr, ResourceRef, ResourceRef(Font::GetTypeStatic()), AM_DEFAULT);
     URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Material", GetMaterialAttr, SetMaterialAttr, ResourceRef, ResourceRef(Material::GetTypeStatic()),
         AM_DEFAULT);
-    URHO3D_ATTRIBUTE("Font Size", int, text_.fontSize_, DEFAULT_FONT_SIZE, AM_DEFAULT);
+    URHO3D_ATTRIBUTE("Font Size", float, text_.fontSize_, DEFAULT_FONT_SIZE, AM_DEFAULT);
     URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Text", GetTextAttr, SetTextAttr, String, String::EMPTY, AM_DEFAULT);
     URHO3D_ENUM_ATTRIBUTE("Text Alignment", text_.textAlignment_, horizontalAlignments, HA_LEFT, AM_DEFAULT);
     URHO3D_ATTRIBUTE("Row Spacing", float, text_.rowSpacing_, 1.0f, AM_DEFAULT);
@@ -187,7 +187,7 @@ void Text3D::SetMaterial(Material* material)
     UpdateTextMaterials(true);
 }
 
-bool Text3D::SetFont(const String& fontName, int size)
+bool Text3D::SetFont(const String& fontName, float size)
 {
     bool success = text_.SetFont(fontName, size);
 
@@ -200,7 +200,7 @@ bool Text3D::SetFont(const String& fontName, int size)
     return success;
 }
 
-bool Text3D::SetFont(Font* font, int size)
+bool Text3D::SetFont(Font* font, float size)
 {
     bool success = text_.SetFont(font, size);
 
@@ -211,7 +211,7 @@ bool Text3D::SetFont(Font* font, int size)
     return success;
 }
 
-bool Text3D::SetFontSize(int size)
+bool Text3D::SetFontSize(float size)
 {
     bool success = text_.SetFontSize(size);
 
@@ -392,7 +392,7 @@ Font* Text3D::GetFont() const
     return text_.GetFont();
 }
 
-int Text3D::GetFontSize() const
+float Text3D::GetFontSize() const
 {
     return text_.GetFontSize();
 }

--- a/Source/Urho3D/UI/Text3D.h
+++ b/Source/Urho3D/UI/Text3D.h
@@ -55,11 +55,11 @@ public:
     virtual UpdateGeometryType GetUpdateGeometryType();
 
     /// Set font by looking from resource cache by name and font size. Return true if successful.
-    bool SetFont(const String& fontName, int size = DEFAULT_FONT_SIZE);
+    bool SetFont(const String& fontName, float size = DEFAULT_FONT_SIZE);
     /// Set font and font size. Return true if successful.
-    bool SetFont(Font* font, int size = DEFAULT_FONT_SIZE);
+    bool SetFont(Font* font, float size = DEFAULT_FONT_SIZE);
     /// Set font size only while retaining the existing font. Return true if successful.
-    bool SetFontSize(int size);
+    bool SetFontSize(float size);
     /// Set material.
     void SetMaterial(Material* material);
     /// Set text. Text is assumed to be either ASCII or UTF8-encoded.
@@ -104,7 +104,7 @@ public:
     /// Return font.
     Font* GetFont() const;
     /// Return font size.
-    int GetFontSize() const;
+    float GetFontSize() const;
     /// Return material.
     Material* GetMaterial() const;
     /// Return text.

--- a/bin/Data/LuaScripts/47_Typography.lua
+++ b/bin/Data/LuaScripts/47_Typography.lua
@@ -68,7 +68,7 @@ function CreateText()
 
     local font = cache:GetResource("Font", "Fonts/BlueHighway.ttf")
 
-    for size = 1, 24 do
+    for size = 1, 18, 0.5 do
         local text = Text:new()
         text.text = "The quick brown fox jumps over the lazy dog (" .. size .. "pt)"
         text:SetFont(font, size)

--- a/bin/Data/Scripts/47_Typography.as
+++ b/bin/Data/Scripts/47_Typography.as
@@ -70,7 +70,7 @@ void CreateText()
     
     Font@ font = cache.GetResource("Font", "Fonts/BlueHighway.ttf");
     
-    for (int size = 1; size <= 24; ++size)
+    for (float size = 1; size <= 18; size += 0.5)
     {
         Text@ text = Text();
         text.text = "The quick brown fox jumps over the lazy dog (" + size + "pt)";


### PR DESCRIPTION
This commit changes the 'pointSize' parameter in Font, Text
and Text3D from an int to a float, allowing e.g. 14.5pt text.
Note that when hinting is enabled, font metrics are snapped
to pixel boundaries, so the effect may be hard to see unless
you also set UI.FontHintLevel to LIGHT or NONE.

This is a change to the public API, but existing code (including
scripts) should compile and run as before.