### PR TITLE
fixed loading user defined tile properties from tileset-file.

### DIFF
--- a/Source/Urho3D/Urho2D/TmxFile2D.cpp
+++ b/Source/Urho3D/Urho2D/TmxFile2D.cpp
@@ -578,11 +578,16 @@ bool TmxFile2D::LoadTileSet(const XMLElement& element)
 
     for (XMLElement tileElem = tileSetElem.GetChild("tile"); tileElem; tileElem = tileElem.GetNext("tile"))
     {
-        if (tileElem.HasChild("properties"))
+        if(tileElem.HasChild("objectgroup"))
         {
-            SharedPtr<PropertySet2D> propertySet(new PropertySet2D());
-            propertySet->Load(tileElem.GetChild("properties"));
-            gidToPropertySetMapping_[firstgid + tileElem.GetInt("id")] = propertySet;
+            XMLElement objectGroup = tileElem.GetChild("objectgroup");
+
+            if (objectGroup.HasChild("properties"))
+            {
+                SharedPtr<PropertySet2D> propertySet(new PropertySet2D());
+                propertySet->Load(objectGroup.GetChild("properties"));
+                gidToPropertySetMapping_[firstgid + tileElem.GetInt("id")] = propertySet;
+            }
         }
     }
 


### PR DESCRIPTION
i've added a user-defined property to a tile in tileset-file (of course via tiled editor). this property was placed within a \<objectgroup\> tag not directly beneath \<tile\> tag as existing code assumed it.

here is the tileset file produced from tiled. i've added the property named "blocked" at tile with id=1.

```
<?xml version="1.0" encoding="UTF-8"?>
<tileset name="Tiles" tilewidth="8" tileheight="8" tilecount="6" columns="3">
 <image source="Tiles.png" width="24" height="16"/>
 <tile id="0">
  <objectgroup draworder="index"/>
 </tile>
 <tile id="1">
  <objectgroup draworder="index">
   <properties>
    <property name="blocked" type="bool" value="true"/>
   </properties>
  </objectgroup>
 </tile>
</tileset>
```