### PR TITLE
Add configurable oversampling to improve subpixel font rendering (#1953)

### DIFF
--- a/Docs/Reference.dox
+++ b/Docs/Reference.dox
@@ -2234,6 +2234,18 @@ For FreeType fonts, it is possible to adjust the positioning of the font glyphs.
 </font>
 \endcode
 
+The \ref UI "UI" class has various global configuration options for font rendering. The default settings are similar to Windows-style rendering, with crisp characters but uneven spacing. For macOS-style rendering, with accurate spacing but slightly blurrier outlines, call \ref UI::SetFontHintLevel "UI::SetFontHintLevel(FONT_HINT_LEVEL_NONE)". Use the Typography sample to explore these options and find the best configuration for your game.
+
+By default, outline fonts will be hinted (aligned to pixel boundaries), using the font's embedded hints if possible. Call \ref UI::SetForceAutoHint "SetForceAutoHint()" to use FreeType's standard auto-hinter rather than each font's embedded hints.
+
+To adjust hinting, call \ref UI::SetFontHintLevel "SetFontHintLevel()". If the level is set to FONT_HINT_LEVEL_LIGHT, fonts will be aligned to the pixel grid vertically, but not horizontally. At FONT_HINT_LEVEL_NONE, hinting is completely disabled.
+
+Hint levels LIGHT and NONE allow for subpixel glyph positioning, which greatly improves spacing, especially at small font sizes. By default, subpixel positioning is only used at sizes up to 12 points; at larger sizes, each glyph is pixel-aligned. Call \ref UI::SetFontSubpixelThreshold "SetFontSubpixelThreshold" to change this threshold.
+
+When textures aren't pixel-aligned, bilinear texture filtering makes them appear blurry. Therefore, subpixel font textures are oversampled (stretched horizontally) to reduce this blurriness, at the cost of extra memory usage. By default, subpixel fonts use 2x oversampling. Call \ref UI::SetFontOversampling "SetFontOversampling" to change this.
+
+Subpixel positioning only operates horizontally. Text is always pixel-aligned vertically.
+
 \section UI_Sprites Sprites
 
 Sprites are a special kind of %UI element that allow subpixel (float) positioning and scaling, as well as rotation, while the other elements use integer positioning for pixel-perfect display. Sprites can be used to implement rotating HUD elements such as minimaps or speedometer needles.

--- a/Source/Samples/47_Typography/Typography.cpp
+++ b/Source/Samples/47_Typography/Typography.cpp
@@ -71,7 +71,7 @@ void Typography::Start()
     // (Don't modify the root directly, as the base Sample class uses it)
     uielement_ = new UIElement(context_);
     uielement_->SetAlignment(HA_CENTER, VA_CENTER);
-    uielement_->SetLayout(LM_VERTICAL, 20, IntRect(20, 40, 20, 40));
+    uielement_->SetLayout(LM_VERTICAL, 10, IntRect(20, 40, 20, 40));
     root->AddChild(uielement_);
 
     // Add some sample text.
@@ -92,19 +92,45 @@ void Typography::Start()
     CreateCheckbox("UI::SetForceAutoHint", URHO3D_HANDLER(Typography, HandleForceAutoHint))
         ->SetChecked(ui->GetForceAutoHint());
 
-    // Add a checkbox for the global SubpixelGlyphPositions setting. This affects character spacing.
-    CreateCheckbox("UI::SetSubpixelGlyphPositions", URHO3D_HANDLER(Typography, HandleSubpixelGlyphPositions))
-        ->SetChecked(ui->GetSubpixelGlyphPositions());
-
     // Add a drop-down menu to control the font hinting level.
-    const char* items[] = {
+    const char* levels[] = {
         "FONT_HINT_LEVEL_NONE",
         "FONT_HINT_LEVEL_LIGHT",
         "FONT_HINT_LEVEL_NORMAL",
         NULL
     };
-    CreateMenu("UI::SetFontHintLevel", items, URHO3D_HANDLER(Typography, HandleFontHintLevel))
+    CreateMenu("UI::SetFontHintLevel", levels, URHO3D_HANDLER(Typography, HandleFontHintLevel))
         ->SetSelection(ui->GetFontHintLevel());
+
+    // Add a drop-down menu to control the subpixel threshold.
+    const char* thresholds[] = {
+        "0",
+        "3",
+        "6",
+        "9",
+        "12",
+        "15",
+        "18",
+        "21",
+        NULL
+    };
+    CreateMenu("UI::SetFontSubpixelThreshold", thresholds, URHO3D_HANDLER(Typography, HandleFontSubpixel))
+        ->SetSelection(ui->GetFontSubpixelThreshold() / 3);
+
+    // Add a drop-down menu to control oversampling.
+    const char* limits[] = {
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        NULL
+    };
+    CreateMenu("UI::SetFontOversampling", limits, URHO3D_HANDLER(Typography, HandleFontOversampling))
+        ->SetSelection(ui->GetFontOversampling() - 1);
 
     // Set the mouse mode to use in the sample
     Sample::InitMouseMode(MM_FREE);
@@ -174,11 +200,11 @@ SharedPtr<DropDownList> Typography::CreateMenu(const String& label, const char**
         list->AddItem(item);
         item->SetText(items[i]);
         item->SetStyleAuto();
+        item->SetMinWidth(item->GetRowWidth(0) + 10);
         item->AddTag(TEXT_TAG);
     }
 
     text->SetMaxWidth(text->GetRowWidth(0));
-    list->SetMaxWidth(text->GetRowWidth(0) * 1.5);
 
     SubscribeToEvent(list, E_ITEMSELECTED, handler);
     return list;
@@ -229,16 +255,23 @@ void Typography::HandleSRGB(StringHash eventType, VariantMap& eventData)
     }
 }
 
-void Typography::HandleSubpixelGlyphPositions(StringHash eventType, VariantMap& eventData)
-{
-    CheckBox* box = static_cast<CheckBox*>(eventData[Toggled::P_ELEMENT].GetPtr());
-    bool checked = box->IsChecked();
-    GetSubsystem<UI>()->SetSubpixelGlyphPositions(checked);
-}
-
 void Typography::HandleFontHintLevel(StringHash eventType, VariantMap& eventData)
 {
     DropDownList* list = static_cast<DropDownList*>(eventData[Toggled::P_ELEMENT].GetPtr());
     unsigned i = list->GetSelection();
     GetSubsystem<UI>()->SetFontHintLevel((FontHintLevel)i);
+}
+
+void Typography::HandleFontSubpixel(StringHash eventType, VariantMap& eventData)
+{
+    DropDownList* list = static_cast<DropDownList*>(eventData[Toggled::P_ELEMENT].GetPtr());
+    unsigned i = list->GetSelection();
+    GetSubsystem<UI>()->SetFontSubpixelThreshold(i * 3);
+}
+
+void Typography::HandleFontOversampling(StringHash eventType, VariantMap& eventData)
+{
+    DropDownList* list = static_cast<DropDownList*>(eventData[Toggled::P_ELEMENT].GetPtr());
+    unsigned i = list->GetSelection();
+    GetSubsystem<UI>()->SetFontOversampling(i + 1);
 }

--- a/Source/Samples/47_Typography/Typography.h
+++ b/Source/Samples/47_Typography/Typography.h
@@ -58,5 +58,6 @@ private:
     void HandleSRGB(StringHash eventType, VariantMap& eventData);
     void HandleForceAutoHint(StringHash eventType, VariantMap& eventData);
     void HandleFontHintLevel(StringHash eventType, VariantMap& eventData);
-    void HandleSubpixelGlyphPositions(StringHash eventType, VariantMap& eventData);
+    void HandleFontSubpixel(StringHash eventType, VariantMap& eventData);
+    void HandleFontOversampling(StringHash eventType, VariantMap& eventData);
 };

--- a/Source/Urho3D/AngelScript/UIAPI.cpp
+++ b/Source/Urho3D/AngelScript/UIAPI.cpp
@@ -789,8 +789,10 @@ static void RegisterUI(asIScriptEngine* engine)
     engine->RegisterObjectMethod("UI", "bool get_forceAutoHint() const", asMETHOD(UI, GetForceAutoHint), asCALL_THISCALL);
     engine->RegisterObjectMethod("UI", "void set_fontHintLevel(FontHintLevel)", asMETHOD(UI, SetFontHintLevel), asCALL_THISCALL);
     engine->RegisterObjectMethod("UI", "FontHintLevel get_fontHintLevel() const", asMETHOD(UI, GetFontHintLevel), asCALL_THISCALL);
-    engine->RegisterObjectMethod("UI", "void set_subpixelGlyphPositions(bool)", asMETHOD(UI, SetSubpixelGlyphPositions), asCALL_THISCALL);
-    engine->RegisterObjectMethod("UI", "bool get_subpixelGlyphPositions() const", asMETHOD(UI, GetSubpixelGlyphPositions), asCALL_THISCALL);
+    engine->RegisterObjectMethod("UI", "void set_fontSubpixelThreshold(float)", asMETHOD(UI, SetFontSubpixelThreshold), asCALL_THISCALL);
+    engine->RegisterObjectMethod("UI", "float get_fontSubpixelThreshold() const", asMETHOD(UI, GetFontSubpixelThreshold), asCALL_THISCALL);
+    engine->RegisterObjectMethod("UI", "void set_fontOversampling(int)", asMETHOD(UI, SetFontOversampling), asCALL_THISCALL);
+    engine->RegisterObjectMethod("UI", "int get_fontOversampling() const", asMETHOD(UI, GetFontOversampling), asCALL_THISCALL);
     engine->RegisterObjectMethod("UI", "void set_scale(float value)", asMETHOD(UI, SetScale), asCALL_THISCALL);
     engine->RegisterObjectMethod("UI", "float get_scale() const", asMETHOD(UI, GetScale), asCALL_THISCALL);
     engine->RegisterObjectMethod("UI", "void set_customSize(const IntVector2&in)", asMETHODPR(UI, SetCustomSize, (const IntVector2&), void), asCALL_THISCALL);

--- a/Source/Urho3D/LuaScript/pkgs/UI/UI.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/UI/UI.pkg
@@ -31,7 +31,8 @@ class UI : public Object
     void SetUseMutableGlyphs(bool enable);
     void SetForceAutoHint(bool enable);
     void SetFontHintLevel(FontHintLevel level);
-    void SetSubpixelGlyphPositions(bool enable);
+    void SetFontSubpixelThreshold(float threshold);
+    void SetFontOversampling(int limit);
     void SetScale(float scale);
     void SetWidth(float width);
     void SetHeight(float height);
@@ -60,7 +61,8 @@ class UI : public Object
     bool GetUseMutableGlyphs() const;
     bool GetForceAutoHint() const;
     FontHintLevel GetFontHintLevel() const;
-    bool GetSubpixelGlyphPositions() const;
+    float GetFontSubpixelThreshold() const;
+    int GetFontOversampling() const;
     bool HasModalElement() const;
     bool IsDragging() const;
     float GetScale() const;
@@ -85,7 +87,8 @@ class UI : public Object
     tolua_property__get_set bool useMutableGlyphs;
     tolua_property__get_set bool forceAutoHint;
     tolua_property__get_set FontHintLevel fontHintLevel;
-    tolua_property__get_set bool subpixelGlyphPositions;
+    tolua_property__get_set float fontSubpixelThreshold;
+    tolua_property__get_set int fontOversampling;
     tolua_readonly tolua_property__has_set bool modalElement;
     tolua_property__get_set float scale;
     tolua_property__get_set IntVector2& customSize;

--- a/Source/Urho3D/UI/FontFace.h
+++ b/Source/Urho3D/UI/FontFace.h
@@ -43,14 +43,18 @@ struct URHO3D_API FontGlyph
     short x_;
     /// Y position in texture.
     short y_;
-    /// Width.
-    short width_;
-    /// Height.
-    short height_;
+    /// X position in texture.
+    short texWidth_;
+    /// Y position in texture.
+    short texHeight_;
+    /// Width on screen.
+    float width_;
+    /// Height on screen.
+    float height_;
     /// Glyph X offset from origin.
-    short offsetX_;
+    float offsetX_;
     /// Glyph Y offset from origin.
-    short offsetY_;
+    float offsetY_;
     /// Horizontal advance.
     float advanceX_;
     /// Texture page. M_MAX_UNSIGNED if not yet resident on any texture.

--- a/Source/Urho3D/UI/FontFaceFreeType.h
+++ b/Source/Urho3D/UI/FontFaceFreeType.h
@@ -52,6 +52,8 @@ private:
     bool SetupNextTexture(int textureWidth, int textureHeight);
     /// Load char glyph.
     bool LoadCharGlyph(unsigned charCode, Image* image = 0);
+    /// Smooth one row of a horizontally oversampled glyph image.
+    void BoxFilter(unsigned char* dest, size_t destSize, const unsigned char* src, size_t srcSize);
 
     /// FreeType library.
     SharedPtr<FreeTypeLibrary> freeType_;
@@ -59,6 +61,10 @@ private:
     void* face_;
     /// Load mode.
     int loadMode_;
+    /// Use subpixel glyph positioning?
+    bool subpixel_;
+    /// Oversampling level.
+    int oversampling_;
     /// Ascender.
     float ascender_;
     /// Has mutable glyph.

--- a/Source/Urho3D/UI/Text.cpp
+++ b/Source/Urho3D/UI/Text.cpp
@@ -821,7 +821,7 @@ void Text::ConstructBatch(UIBatch& pageBatch, const PODVector<GlyphLocation>& pa
         const GlyphLocation& glyphLocation = pageGlyphLocation[i];
         const FontGlyph& glyph = *glyphLocation.glyph_;
         pageBatch.AddQuad(dx + glyphLocation.x_ + glyph.offsetX_, dy + glyphLocation.y_ + glyph.offsetY_, glyph.width_,
-            glyph.height_, glyph.x_, glyph.y_);
+            glyph.height_, glyph.x_, glyph.y_, glyph.texWidth_, glyph.texHeight_);
     }
 
     if (depthBias != 0.0f)

--- a/Source/Urho3D/UI/UI.cpp
+++ b/Source/Urho3D/UI/UI.cpp
@@ -57,6 +57,7 @@
 #include "../UI/Window.h"
 #include "../UI/View3D.h"
 
+#include <assert.h>
 #include <SDL/SDL.h>
 
 #include "../DebugNew.h"
@@ -107,7 +108,8 @@ UI::UI(Context* context) :
     useMutableGlyphs_(false),
     forceAutoHint_(false),
     fontHintLevel_(FONT_HINT_LEVEL_NORMAL),
-    subpixelGlyphPositions_(false),
+    fontSubpixelThreshold_(12),
+    fontOversampling_(2),
     uiRendered_(false),
     nonModalBatchSize_(0),
     dragElementsCount_(0),
@@ -616,11 +618,23 @@ void UI::SetFontHintLevel(FontHintLevel level)
     }
 }
 
-void UI::SetSubpixelGlyphPositions(bool enable)
+void UI::SetFontSubpixelThreshold(float threshold)
 {
-    if (enable != subpixelGlyphPositions_)
+    assert(threshold >= 0);
+    if (threshold != fontSubpixelThreshold_)
     {
-        subpixelGlyphPositions_ = enable;
+        fontSubpixelThreshold_ = threshold;
+        ReleaseFontFaces();
+    }
+}
+
+void UI::SetFontOversampling(int oversampling)
+{
+    assert(oversampling >= 1);
+    oversampling = Clamp(oversampling, 1, 8);
+    if (oversampling != fontOversampling_)
+    {
+        fontOversampling_ = oversampling;
         ReleaseFontFaces();
     }
 }

--- a/Source/Urho3D/UI/UI.h
+++ b/Source/Urho3D/UI/UI.h
@@ -110,8 +110,10 @@ public:
     void SetForceAutoHint(bool enable);
     /// Set the hinting level used by FreeType fonts.
     void SetFontHintLevel(FontHintLevel level);
-    /// Set whether text glyphs can have fractional positions. Default is false (pixel-aligned).
-    void SetSubpixelGlyphPositions(bool enable);
+    /// Set the font subpixel threshold. Below this size, if the hint level is LIGHT or NONE, fonts will use subpixel positioning plus oversampling for higher-quality rendering. Has no effect at hint level NORMAL.
+    void SetFontSubpixelThreshold(float threshold);
+    /// Set the oversampling (horizonal stretching) used to improve subpixel font rendering. Only affects fonts smaller than the subpixel limit.
+    void SetFontOversampling(int oversampling);
     /// Set %UI scale. 1.0 is default (pixel perfect). Resize the root element to match.
     void SetScale(float scale);
     /// Scale %UI to the specified width in pixels.
@@ -188,8 +190,11 @@ public:
     /// Return the current FreeType font hinting level.
     FontHintLevel GetFontHintLevel() const { return fontHintLevel_; }
 
-    // Return whether text glyphs can have fractional positions.
-    bool GetSubpixelGlyphPositions() const { return subpixelGlyphPositions_; }
+    /// Get the font subpixel threshold. Below this size, if the hint level is LIGHT or NONE, fonts will use subpixel positioning plus oversampling for higher-quality rendering. Has no effect at hint level NORMAL.
+    float GetFontSubpixelThreshold() const { return fontSubpixelThreshold_; }
+
+    /// Get the oversampling (horizonal stretching) used to improve subpixel font rendering. Only affects fonts smaller than the subpixel limit.
+    int GetFontOversampling() const { return fontOversampling_; }
 
     /// Return true when UI has modal element(s).
     bool HasModalElement() const;
@@ -356,8 +361,10 @@ private:
     bool forceAutoHint_;
     /// FreeType hinting level (default is FONT_HINT_LEVEL_NORMAL).
     FontHintLevel fontHintLevel_;
-    /// Flag for subpixel text glyph positions.
-    bool subpixelGlyphPositions_;
+    /// Maxmimum font size for subpixel glyph positioning and oversampling (default is 12).
+    float fontSubpixelThreshold_;
+    /// Horizontal oversampling for subpixel fonts (default is 2).
+    int fontOversampling_;
     /// Flag for UI already being rendered this frame.
     bool uiRendered_;
     /// Non-modal batch size (used internally for rendering).

--- a/bin/Data/LuaScripts/47_Typography.lua
+++ b/bin/Data/LuaScripts/47_Typography.lua
@@ -26,7 +26,7 @@ function Start()
     -- (Don't modify the root directly, as the base Sample class uses it)
     uielement = UIElement:new()
     uielement:SetAlignment(HA_CENTER, VA_CENTER)
-    uielement:SetLayout(LM_VERTICAL, 20, IntRect(20, 40, 20, 40))
+    uielement:SetLayout(LM_VERTICAL, 10, IntRect(20, 40, 20, 40))
     ui.root:AddChild(uielement)
 
     -- Add some sample text
@@ -47,19 +47,43 @@ function Start()
     CreateCheckbox("UI::SetForceAutoHint", "HandleForceAutoHint")
         :SetChecked(ui:GetForceAutoHint())
 
-    -- Add a checkbox for the global SubpixelGlyphPositions setting. This affects character spacing.
-    CreateCheckbox("UI::SetSubpixelGlyphPositions", "HandleSubpixelGlyphPositions")
-        :SetChecked(ui:GetSubpixelGlyphPositions())
-
     -- Add a drop-down menu to control the font hinting level.
-    local items = {
+    local levels = {
         "FONT_HINT_LEVEL_NONE",
         "FONT_HINT_LEVEL_LIGHT",
         "FONT_HINT_LEVEL_NORMAL"
     }
-    CreateMenu("UI::SetFontHintLevel", items, "HandleFontHintLevel")
+    CreateMenu("UI::SetFontHintLevel", levels, "HandleFontHintLevel")
         :SetSelection(ui:GetFontHintLevel())
     
+    -- Add a drop-down menu to control the subpixel threshold.
+    local thresholds = {
+        "0",
+        "3",
+        "6",
+        "9",
+        "12",
+        "15",
+        "18",
+        "21"
+    }
+    CreateMenu("UI::SetFontSubpixelThreshold", thresholds, "HandleFontSubpixel")
+        :SetSelection(ui:GetFontSubpixelThreshold() / 3)
+
+    -- Add a drop-down menu to control oversampling.
+    local limits = {
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8"
+    }
+    CreateMenu("UI::SetFontOversampling", limits, "HandleFontOversampling")
+        :SetSelection(ui:GetFontOversampling() - 1)
+
     -- Set the mouse mode to use in the sample
     SampleInitMouseMode(MM_FREE)
 end
@@ -122,11 +146,11 @@ function CreateMenu(label, items, handler)
         list:AddItem(t)
         t.text = item
         t:SetStyleAuto()
+        t:SetMinWidth(t:GetRowWidth(0) + 10);
         t:AddTag(TEXT_TAG) 
     end
 
     text:SetMaxWidth(text:GetRowWidth(0))
-    list:SetMaxWidth(text:GetRowWidth(0) * 1.5)
     
     SubscribeToEvent(list, "ItemSelected", handler)
     return list
@@ -165,18 +189,25 @@ function HandleSRGB(eventType, eventData)
     end
 end
 
-function HandleSubpixelGlyphPositions(eventType, eventData)
-    local box = eventData["Element"]:GetPtr("CheckBox")
-    local checked = box:IsChecked()
-
-    ui:SetSubpixelGlyphPositions(checked)
-end
-
 function HandleFontHintLevel(eventType, eventData)
     local list = eventData["Element"]:GetPtr("DropDownList")
     local i = list:GetSelection()
 
     ui:SetFontHintLevel(i)
+end
+
+function HandleFontSubpixel(eventType, eventData)
+    local list = eventData["Element"]:GetPtr("DropDownList")
+    local i = list:GetSelection()
+
+    ui:SetFontSubpixelThreshold(i * 3)
+end
+
+function HandleFontOversampling(eventType, eventData)
+    local list = eventData["Element"]:GetPtr("DropDownList")
+    local i = list:GetSelection()
+
+    ui:SetFontOversampling(i + 1)
 end
 
 -- Create XML patch instructions for screen joystick layout specific to this sample app

--- a/bin/Data/Scripts/47_Typography.as
+++ b/bin/Data/Scripts/47_Typography.as
@@ -27,7 +27,7 @@ void Start()
     // (Don't modify the root directly, as the base Sample class uses it)
     uielement = UIElement();
     uielement.SetAlignment(HA_CENTER, VA_CENTER);
-    uielement.SetLayout(LM_VERTICAL, 20, IntRect(20, 40, 20, 40));
+    uielement.SetLayout(LM_VERTICAL, 10, IntRect(20, 40, 20, 40));
     ui.root.AddChild(uielement);
     
     // Add some sample text
@@ -48,18 +48,42 @@ void Start()
     CreateCheckbox("UI::SetForceAutoHint", "HandleForceAutoHint")
         .checked = ui.forceAutoHint;
 
-    // Add a checkbox for the global SubpixelGlyphPositions setting. This affects character spacing.
-    CreateCheckbox("UI::SetSubpixelGlyphPositions", "HandleSubpixelGlyphPositions")
-        .checked = ui.subpixelGlyphPositions;
-
     // Add a drop-down menu to control the font hinting level.
-    Array<String> items = {
+    Array<String> levels = {
         "FONT_HINT_LEVEL_NONE",
         "FONT_HINT_LEVEL_LIGHT",
         "FONT_HINT_LEVEL_NORMAL"
     };
-    CreateMenu("UI::SetFontHintLevel", items, "HandleFontHintLevel")
+    CreateMenu("UI::SetFontHintLevel", levels, "HandleFontHintLevel")
         .selection = ui.fontHintLevel;
+
+    // Add a drop-down menu to control the subpixel threshold.
+    Array<String> thresholds = {
+        "0",
+        "3",
+        "6",
+        "9",
+        "12",
+        "15",
+        "18",
+        "21"
+    };
+    CreateMenu("UI::SetFontSubpixelThreshold", thresholds, "HandleFontSubpixel")
+        .selection = ui.fontSubpixelThreshold / 3;
+
+    // Add a drop-down menu to control oversampling.
+    Array<String>  limits = {
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8"
+    };
+    CreateMenu("UI::SetFontOversampling", limits, "HandleFontOversampling")
+        .selection = ui.fontOversampling - 1;
 
     // Set the mouse mode to use in the sample
     SampleInitMouseMode(MM_FREE);
@@ -128,11 +152,11 @@ DropDownList@ CreateMenu(String label, Array<String> items, String handler)
         list.AddItem(t);
         t.text = items[i];
         t.SetStyleAuto();
+        t.minWidth = t.rowWidths[0] + 10;
         t.AddTag(TEXT_TAG);
     }
     
     text.maxWidth = text.rowWidths[0];
-    list.maxWidth = text.rowWidths[0] * 1.5;
     
     SubscribeToEvent(list, "ItemSelected", handler);
     return list;
@@ -178,21 +202,28 @@ void HandleSRGB(StringHash eventType, VariantMap& eventData)
     }
 }
 
-void HandleSubpixelGlyphPositions(StringHash eventType, VariantMap& eventData)
-{
-    CheckBox@ box = eventData["Element"].GetPtr();
-    bool checked = box.checked;
-
-    ui.subpixelGlyphPositions = checked;
-}
-
-
 void HandleFontHintLevel(StringHash eventType, VariantMap& eventData)
 {
     DropDownList@ list = eventData["Element"].GetPtr();
     int i = list.selection;
 
     ui.fontHintLevel = FontHintLevel(i);    
+}
+
+void HandleFontSubpixel(StringHash eventType, VariantMap& eventData)
+{
+    DropDownList@ list = eventData["Element"].GetPtr();
+    int i = list.selection;
+
+    ui.fontSubpixelThreshold = i * 3;    
+}
+
+void HandleFontOversampling(StringHash eventType, VariantMap& eventData)
+{
+    DropDownList@ list = eventData["Element"].GetPtr();
+    int i = list.selection;
+
+    ui.fontOversampling = i + 1;
 }
 
 // Create XML patch instructions for screen joystick layout specific to this sample app


### PR DESCRIPTION
Subpixel-positioned text looks blurry, due to bilinear filtering of the
underlying texture. The basic idea here is to stretch the font glyphs
horizontally to increase the sharpness at subpixel positions. Note that
the stretched images need to be smoothed to avoid aliasing artifacts;
this is done in the FontFaceFreeType::BoxFilter() method.

Glyphs are always pixel-aligned vertically, so no vertical oversampling
is needed.

To make this feature comprehensible (I hope!) I've removed the
'subpixelGlyphPositions' flag and replaced it with a couple of values:
'fontSubpixelThreshold' sets the point at which subpixel positioning
kicks on, and 'fontOversampleLimit' caps the maximum amount of stretching.

The default values are 12pt text and max 3x oversampling. These are fairly
conservative settings, which should improve small text without wasting
a lot of memory.

Note that when the font hint level is NORMAL (the default), subpixel
positioning and oversampling are both disabled. So, this feature doesn't
change any default behavior, and applies some hopefully sensible values
if the hint level is set to LIGHT or NONE.