### PR TITLE
Minor incoherence fix

### DIFF
--- a/Source/Urho3D/Core/ProcessUtils.cpp
+++ b/Source/Urho3D/Core/ProcessUtils.cpp
@@ -540,7 +540,7 @@ String GetLoginName()
 {
 #if defined(__linux__) && !defined(__ANDROID__)
     struct passwd *p = getpwuid(getuid());
-    if (p) 
+    if (p != NULL) 
         return p->pw_name;
 #elif defined(_WIN32)
     char name[UNLEN + 1];
@@ -580,7 +580,7 @@ String GetHostName()
     if (GetComputerName(buffer, &len))
         return buffer;
 #endif
-    return String::EMPTY; 
+    return "(?)"; 
 }
 
 // Disable Windows OS version functionality when compiling mini version for Web, see https://github.com/urho3d/Urho3D/issues/1998
@@ -626,7 +626,7 @@ String GetOSVersion()
     else if (r.dwMajorVersion == 10 && r.dwMinorVersion == 0) 
         return "Windows 10/Windows Server 2016"; 
     else 
-        return "Windows Unidentified";
+        return "Windows Unknown";
 #elif defined(__APPLE__)
     char kernel_r[256]; 
     size_t size = sizeof(kernel_r); 
@@ -702,7 +702,7 @@ String GetOSVersion()
         return version + " (Darwin kernel " + kernel_version[0] + "." + kernel_version[1] + "." + kernel_version[2] + ")"; 
     }
 #endif
-    return String::EMPTY; 
+    return "(?)"; 
 }
 
 }


### PR DESCRIPTION
Different platform-specific functions return different values upon failure, for example one returns `String::EMPTY` while another returns `(?)`. From now on everything will return `(?)` if the function doesn't succeed. 