### PR TITLE
Fix kerning pairs (#2003)

### DIFF
--- a/Source/Urho3D/UI/FontFaceFreeType.cpp
+++ b/Source/Urho3D/UI/FontFaceFreeType.cpp
@@ -268,8 +268,8 @@ bool FontFaceFreeType::Load(const unsigned char* fontData, unsigned fontDataSize
                         unsigned rightIndex = deserializer.ReadUShort();
                         short amount = FixedToFloat(deserializer.ReadShort());
 
-                        unsigned leftCharCode = leftIndex < numGlyphs ? charCodes[leftIndex] : 0;
-                        unsigned rightCharCode = rightIndex < numGlyphs ? charCodes[rightIndex] : 0;
+                        unsigned leftCharCode = leftIndex < numGlyphs ? charCodes[leftIndex + 1] : 0;
+                        unsigned rightCharCode = rightIndex < numGlyphs ? charCodes[rightIndex + 1] : 0;
                         if (leftCharCode != 0 && rightCharCode != 0)
                         {
                             unsigned value = (leftCharCode << 16) + rightCharCode;


### PR DESCRIPTION
Kerning values were being associated with the wrong char codes.
This was broken in commit 39930c9a, which moved some code around
to ensure that the space character is always the first one loaded.