### PR TITLE
Add CSV and Base64 encodings for TmxFile (#1325)

### DIFF
--- a/Source/Urho3D/Core/StringUtils.cpp
+++ b/Source/Urho3D/Core/StringUtils.cpp
@@ -31,6 +31,11 @@
 namespace Urho3D
 {
 
+static const String base64_chars =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        "abcdefghijklmnopqrstuvwxyz"
+        "0123456789+/";
+
 unsigned CountElements(const char* buffer, char separator)
 {
     if (!buffer)
@@ -751,6 +756,51 @@ String GetFileSizeString(unsigned long long memorySize)
     }
 
     return output;
+}
+
+static inline bool isBase64(char c) {
+    return (isalnum(c) || (c == '+') || (c == '/'));
+}
+
+PODVector<unsigned char> DecodeBase64(String encoded_string) {
+    int in_len = encoded_string.Length();
+    int i = 0;
+    int j = 0;
+    int in_ = 0;
+    unsigned char char_array_4[4], char_array_3[3];
+    PODVector<unsigned char> ret;
+
+    while (in_len-- && (encoded_string[in_] != '=') && isBase64(encoded_string[in_])) {
+        char_array_4[i++] = encoded_string[in_]; in_++;
+        if (i == 4) {
+            for (i = 0; i <4; i++)
+                char_array_4[i] = base64_chars.Find(char_array_4[i]);
+
+            char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
+            char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
+            char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
+
+            for (i = 0; (i < 3); i++)
+                ret.Push(char_array_3[i]);
+            i = 0;
+        }
+    }
+
+    if (i) {
+        for (j = i; j <4; j++)
+            char_array_4[j] = 0;
+
+        for (j = 0; j <4; j++)
+            char_array_4[j] = base64_chars.Find(char_array_4[j]);
+
+        char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
+        char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
+        char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
+
+        for (j = 0; (j < i - 1); j++) ret.Push(char_array_3[j]);
+    }
+
+    return ret;
 }
 
 }

--- a/Source/Urho3D/Core/StringUtils.h
+++ b/Source/Urho3D/Core/StringUtils.h
@@ -135,6 +135,8 @@ URHO3D_API unsigned ToUpper(unsigned ch);
 URHO3D_API unsigned ToLower(unsigned ch);
 /// Convert a memory size into a formatted size string, of the style "1.5 Mb".
 URHO3D_API String GetFileSizeString(unsigned long long memorySize);
+/// Decode a base64-encoded string into buffer
+URHO3D_API PODVector<unsigned char> DecodeBase64(String encoded_string);
 /// Parse type from a C string.
 template <class T> T FromString(const char* source);
 

--- a/Source/Urho3D/Urho2D/TmxFile2D.cpp
+++ b/Source/Urho3D/Urho2D/TmxFile2D.cpp
@@ -90,6 +90,12 @@ TmxTileLayer2D::TmxTileLayer2D(TmxFile2D* tmxFile) :
 {
 }
 
+enum LayerEncoding {
+    XML,
+    CSV,
+    Base64,
+};
+
 bool TmxTileLayer2D::Load(const XMLElement& element, const TileMapInfo2D& info)
 {
     LoadInfo(element);
@@ -101,33 +107,105 @@ bool TmxTileLayer2D::Load(const XMLElement& element, const TileMapInfo2D& info)
         return false;
     }
 
-    if (dataElem.HasAttribute("encoding") && dataElem.GetAttribute("encoding") != "xml")
+    LayerEncoding encoding;
+    if (dataElem.HasAttribute("compression"))
     {
-        URHO3D_LOGERROR("Encoding not support now");
+        URHO3D_LOGERROR("Compression not supported now");
         return false;
     }
 
-    XMLElement tileElem = dataElem.GetChild("tile");
-    tiles_.Resize((unsigned)(width_ * height_));
-
-    for (int y = 0; y < height_; ++y)
+    if (dataElem.HasAttribute("encoding"))
     {
-        for (int x = 0; x < width_; ++x)
+        String encodingAttribute = dataElem.GetAttribute("encoding");
+        if (encodingAttribute == "xml") {
+            encoding = XML;
+        } else if (encodingAttribute == "csv") {
+            encoding = CSV;
+        } else if (encodingAttribute == "base64") {
+            encoding = Base64;
+        } else {
+            URHO3D_LOGERROR("Invalid encoding: " + encodingAttribute);
+            return false;
+        }
+    } else {
+        encoding = XML;
+    }
+
+    tiles_.Resize((unsigned)(width_ * height_));
+    if (encoding == XML)
+    {
+        XMLElement tileElem = dataElem.GetChild("tile");
+
+        for (int y = 0; y < height_; ++y)
         {
-            if (!tileElem)
-                return false;
-
-            int gid = tileElem.GetInt("gid");
-            if (gid > 0)
+            for (int x = 0; x < width_; ++x)
             {
-                SharedPtr<Tile2D> tile(new Tile2D());
-                tile->gid_ = gid;
-                tile->sprite_ = tmxFile_->GetTileSprite(gid);
-                tile->propertySet_ = tmxFile_->GetTilePropertySet(gid);
-                tiles_[y * width_ + x] = tile;
-            }
+                if (!tileElem)
+                    return false;
 
-            tileElem = tileElem.GetNext("tile");
+                int gid = tileElem.GetInt("gid");
+                if (gid > 0)
+                {
+                    SharedPtr<Tile2D> tile(new Tile2D());
+                    tile->gid_ = gid;
+                    tile->sprite_ = tmxFile_->GetTileSprite(gid);
+                    tile->propertySet_ = tmxFile_->GetTilePropertySet(gid);
+                    tiles_[y * width_ + x] = tile;
+                }
+
+                tileElem = tileElem.GetNext("tile");
+            }
+        }
+    }
+    else if (encoding == CSV)
+    {
+        String dataValue = dataElem.GetValue();
+        Vector<String> gidVector = dataValue.Split(',');
+        int currentIndex = 0;
+        for (int y = 0; y < height_; ++y)
+        {
+            for (int x = 0; x < width_; ++x)
+            {
+                gidVector[currentIndex].Replace("\n", "");
+                int gid = ToInt(gidVector[currentIndex]);
+                if (gid > 0)
+                {
+                    SharedPtr<Tile2D> tile(new Tile2D());
+                    tile->gid_ = gid;
+                    tile->sprite_ = tmxFile_->GetTileSprite(gid);
+                    tile->propertySet_ = tmxFile_->GetTilePropertySet(gid);
+                    tiles_[y * width_ + x] = tile;
+                }
+                ++currentIndex;
+            }
+        }
+    }
+    else if (encoding == Base64)
+    {
+        String dataValue = dataElem.GetValue();
+        int startPosition = 0;
+        while (!IsAlpha(dataValue[startPosition]) && !IsDigit(dataValue[startPosition])
+              && dataValue[startPosition] != '+' && dataValue[startPosition] != '/') ++startPosition;
+        dataValue = dataValue.Substring(startPosition);
+        PODVector<unsigned char> buffer = DecodeBase64(dataValue);
+        int currentIndex = 0;
+        for (int y = 0; y < height_; ++y)
+        {
+            for (int x = 0; x < width_; ++x)
+            {
+                // buffer contains 32-bit integers in little-endian format
+                int gid = (buffer[currentIndex+3] << 24) | (buffer[currentIndex+2] << 16)
+                        | (buffer[currentIndex+1] << 8) | buffer[currentIndex];
+                if (gid > 0)
+                {
+                    SharedPtr<Tile2D> tile(new Tile2D());
+                    tile->gid_ = gid;
+                    tile->sprite_ = tmxFile_->GetTileSprite(gid);
+                    tile->propertySet_ = tmxFile_->GetTilePropertySet(gid);
+                    tiles_[y * width_ + x] = tile;
+                }
+                currentIndex += 4;
+            }
         }
     }
 


### PR DESCRIPTION
TmxFile currently supports only deprecated XML layer format. This PR adds support for CSV and Base64 formats. I'm not sure it fixes #1325, since compression is still not supported (zlib nor gzip). Base64 decompression snippet taken from https://stackoverflow.com/a/13935718 with some minor modifications to work with Urho's containers instead of std