### PR TITLE
Background loading: add resource into cache before sending E_RESOURCE…

### DIFF
--- a/Source/Urho3D/Resource/BackgroundLoader.cpp
+++ b/Source/Urho3D/Resource/BackgroundLoader.cpp
@@ -290,6 +290,10 @@ void BackgroundLoader::FinishBackgroundLoading(BackgroundLoadItem& item)
         owner_->SendEvent(E_LOADFAILED, eventData);
     }
 
+    // Store to the cache just before sending the event; use same mechanism as for manual resources
+    if (success || owner_->GetReturnFailedResources())
+        owner_->AddManualResource(resource);
+
     // Send event, either success or failure
     {
         using namespace ResourceBackgroundLoaded;
@@ -300,10 +304,6 @@ void BackgroundLoader::FinishBackgroundLoading(BackgroundLoadItem& item)
         eventData[P_RESOURCE] = resource;
         owner_->SendEvent(E_RESOURCEBACKGROUNDLOADED, eventData);
     }
-
-    // Store to the cache; use same mechanism as for manual resources
-    if (success || owner_->GetReturnFailedResources())
-        owner_->AddManualResource(resource);
 }
 
 }


### PR DESCRIPTION
Hello! I found that E_BACKGROUNDLOADED listeners are not able to use just loaded resources becouse of resources are not exist in the cache when event is raised. So, where is a fix, as i tough. Hope, it will be merged. Thanx.