### PR TITLE
Fixed ordered comparsion between pointer and zero in AssetImporter.cpp

### DIFF
--- a/Source/Tools/AssetImporter/AssetImporter.cpp
+++ b/Source/Tools/AssetImporter/AssetImporter.cpp
@@ -1291,7 +1291,7 @@ void BuildAndSaveAnimations(OutModel* model)
                 startTime = Min(startTime, (float)channel->mPositionKeys[0].mTime);
             if (channel->mNumRotationKeys > 0)
                 startTime = Min(startTime, (float)channel->mRotationKeys[0].mTime);
-            if (channel->mScalingKeys > 0)
+            if (channel->mScalingKeys != NULL)
                 startTime = Min(startTime, (float)channel->mScalingKeys[0].mTime);
         }
         if (startTime > thisImportStartTime)


### PR DESCRIPTION
Tried to build Urho3D using clang, got error on that line. Seems like error: `mNumRotationKeys` and `mNumPositionKeys` are `unsigned int`'s while `mScalingKeys` is `C_STRUCT aiVectorKey*`, so comparing this pointer to the inequality with NULL seems more logical.

Hope I did not break anything with that change.