### PR TITLE
Initial commit of WebP image library

### DIFF
--- a/CMake/Modules/UrhoCommon.cmake
+++ b/CMake/Modules/UrhoCommon.cmake
@@ -141,6 +141,7 @@ option (URHO3D_NAVIGATION "Enable navigation support" TRUE)
 cmake_dependent_option (URHO3D_NETWORK "Enable networking support" TRUE "NOT WEB AND EXCEPTIONS" FALSE)
 option (URHO3D_PHYSICS "Enable physics support" TRUE)
 option (URHO3D_URHO2D "Enable 2D graphics and physics support" TRUE)
+option (URHO3D_WEBP "Enable WebP support" FALSE)
 if (ARM AND NOT ANDROID AND NOT RPI AND NOT APPLE)
     set (ARM_ABI_FLAGS "" CACHE STRING "Specify ABI compiler flags (ARM on Linux platform only); e.g. Orange-Pi Mini 2 could use '-mcpu=cortex-a7 -mfpu=neon-vfpv4'")
 endif ()
@@ -389,7 +390,8 @@ if (URHO3D_CLANG_TOOLS)
             URHO3D_NETWORK
             URHO3D_PHYSICS
             URHO3D_PROFILING
-            URHO3D_URHO2D)
+            URHO3D_URHO2D
+            URHO3D_WEBP)
         set (${OPT} 1)
     endforeach ()
     foreach (OPT URHO3D_TESTING URHO3D_LUAJIT URHO3D_DATABASE_ODBC)
@@ -443,6 +445,7 @@ foreach (OPT
         URHO3D_PROFILING
         URHO3D_THREADING
         URHO3D_URHO2D
+        URHO3D_WEBP
         URHO3D_WIN32_CONSOLE)
     if (${OPT})
         add_definitions (-D${OPT})

--- a/Docs/GettingStarted.dox
+++ b/Docs/GettingStarted.dox
@@ -123,6 +123,7 @@ A number of build options can be defined when invoking the build scripts or when
 |URHO3D_PCH           |1|Enable PCH support|
 |URHO3D_DATABASE_ODBC |0|Enable %Database support with ODBC, requires vendor-specific ODBC driver|
 |URHO3D_DATABASE_SQLITE|0|Enable %Database support with SQLite embedded|
+|URHO3D_WEBP          |0|Enable WebP support|
 |URHO3D_C++11         |0|Enable use of C++11 standard; it is not enabled by default, but certain build option combinations will force it enabled internally, such as: URHO3D_ANGELSCRIPT on Web platform and Android/ARM platforms that use aarch64 architecture, and URHO3D_DATABASE_ODBC on all platforms|
 |URHO3D_MMX           |0|Enable MMX instruction set (32-bit Linux platform only); the MMX is effectively enabled when 3DNow! or SSE is enabled; should only be used for older CPU with MMX support|
 |URHO3D_3DNOW         |0|Enable 3DNow! instruction set (Linux platform only); should only be used for older CPU with (legacy) 3DNow! support|

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -112,6 +112,10 @@ if (URHO3D_URHO2D)
     endif ()
 endif ()
 
+if (URHO3D_WEBP)
+    add_subdirectory (ThirdParty/WebP)
+endif ()
+
 if (URHO3D_PHYSICS)
     add_subdirectory (ThirdParty/Bullet)
 endif ()

--- a/Source/Urho3D/CMakeLists.txt
+++ b/Source/Urho3D/CMakeLists.txt
@@ -99,7 +99,7 @@ if (WIN32)
 endif ()
 
 # Define source files
-foreach (DIR IK Navigation Network Physics Urho2D)
+foreach (DIR IK Navigation Network Physics Urho2D WebP)
     string (TOUPPER URHO3D_${DIR} OPT)
     if (NOT ${OPT})
         list (APPEND EXCLUDED_SOURCE_DIRS ${DIR})

--- a/Source/Urho3D/Resource/Image.cpp
+++ b/Source/Urho3D/Resource/Image.cpp
@@ -35,6 +35,8 @@
 #include <STB/stb_image.h>
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include <STB/stb_image_write.h>
+#include <webp/decode.h>
+#include <webp/encode.h>
 
 #include "../DebugNew.h"
 
@@ -733,6 +735,75 @@ bool Image::BeginLoad(Deserializer& source)
         source.Read(data_.Get(), dataSize);
         SetMemoryUse(dataSize);
     }
+#ifdef URHO3D_WEBP
+    else if (fileID == "RIFF")
+    {
+        // WebP: https://developers.google.com/speed/webp/docs/api
+
+        // RIFF layout is:
+        //   Offset  tag
+        //   0...3   "RIFF" 4-byte tag
+        //   4...7   size of image data (including metadata) starting at offset 8
+        //   8...11  "WEBP"   our form-type signature
+        const uint8_t TAG_SIZE(4);
+
+        source.Seek(8);
+        uint8_t fourCC[TAG_SIZE];
+        memset(&fourCC, 0, sizeof(uint8_t) * TAG_SIZE);
+
+        unsigned bytesRead(source.Read(&fourCC, TAG_SIZE));
+        if (bytesRead != TAG_SIZE)
+        {
+            // Truncated.
+            URHO3D_LOGERROR("Truncated RIFF data.");
+            return false;
+        }
+        const uint8_t WEBP[TAG_SIZE]({'W', 'E', 'B', 'P'});
+        if (memcmp(fourCC, WEBP, TAG_SIZE))
+        {
+            // VP8_STATUS_BITSTREAM_ERROR
+            URHO3D_LOGERROR("Invalid header.");
+            return false;
+        }
+
+        // Read the file to buffer.
+        size_t dataSize(source.GetSize());
+        SharedArrayPtr<uint8_t> data(new uint8_t[dataSize]);
+
+        memset(data.Get(), 0, sizeof(uint8_t) * dataSize);
+        source.Seek(0);
+        source.Read(data.Get(), dataSize);
+
+        WebPBitstreamFeatures features;
+
+        if (WebPGetFeatures(data.Get(), dataSize, &features) != VP8_STATUS_OK)
+        {
+            URHO3D_LOGERROR("Error reading WebP image: " + source.GetName());
+            return false;
+        }
+
+        size_t imgSize = features.width * features.height * (features.has_alpha ? 4 : 3);
+        SharedArrayPtr<uint8_t> dstImage(new uint8_t[imgSize]);
+
+        bool decodeError(false);
+        if (features.has_alpha)
+        {
+            decodeError = WebPDecodeRGBAInto(data.Get(), dataSize, dstImage.Get(), imgSize, 4 * features.width) == NULL;
+        }
+        else
+        {
+            decodeError = WebPDecodeRGBInto(data.Get(), dataSize, dstImage.Get(), imgSize, 3 * features.width) == NULL;
+        }
+        if (decodeError)
+        {
+            URHO3D_LOGERROR("Error decoding WebP image:" + source.GetName());
+            return false;
+        }
+
+        SetSize(features.width, features.height, features.has_alpha ? 4 : 3);
+        SetData(dstImage);
+    }
+#endif
     else
     {
         // Not DDS, KTX or PVR, use STBImage to load other image formats as uncompressed
@@ -786,6 +857,10 @@ bool Image::SaveFile(const String& fileName) const
         return SaveJPG(fileName, 100);
     else if (fileName.EndsWith(".tga", false))
         return SaveTGA(fileName);
+#ifdef URHO3D_WEBP
+    else if (fileName.EndsWith(".webp", false))
+        return SaveWEBP(fileName);
+#endif
     else
         return SavePNG(fileName);
 }
@@ -1277,6 +1352,14 @@ bool Image::SaveDDS(const String& fileName) const
 
     return true;
 }
+
+#ifdef URHO3D_WEBP
+bool Image::SaveWEBP(const String& fileName) const
+{
+    URHO3D_LOGERROR("SaveWEBP not yet implemented.");
+    return false;
+}
+#endif
 
 Color Image::GetPixel(int x, int y) const
 {

--- a/Source/Urho3D/Resource/Image.h
+++ b/Source/Urho3D/Resource/Image.h
@@ -143,6 +143,10 @@ public:
     bool SaveJPG(const String& fileName, int quality) const;
     /// Save in DDS format. Only uncompressed RGBA images are supported. Return true if successful.
     bool SaveDDS(const String& fileName) const;
+#ifdef URHO3D_WEBP
+    /// Save in WebP format. Return true if successful.
+    bool SaveWEBP(const String& fileName) const;
+#endif
     /// Whether this texture is detected as a cubemap, only relevant for DDS.
     bool IsCubemap() const { return cubemap_; }
     /// Whether this texture has been detected as a volume, only relevant for DDS.


### PR DESCRIPTION
https://developers.google.com/speed/webp/

Urho3D native loading of WebP lossless and lossy formats (*.webp).
Enabled with URHO3D_WEBP cmake build option.
Did basic checks with Valgrind.
SaveWEBP() to be added.