### PR TITLE
Several tilemap improvements

### DIFF
--- a/Source/Urho3D/AngelScript/Urho2DAPI.cpp
+++ b/Source/Urho3D/AngelScript/Urho2DAPI.cpp
@@ -299,6 +299,12 @@ static void RegisterTileMapLayer2D(asIScriptEngine* engine)
     engine->RegisterObjectMethod("TileMapLayer2D", "Node@+ get_imageNode() const", asMETHOD(TileMapLayer2D, GetImageNode), asCALL_THISCALL);
 }
 
+static CScriptArray* TileMap2DGetTileCollisionShapes(int gid, TileMap2D* tileMap)
+{
+    Vector<SharedPtr<TileMapObject2D> > result = tileMap->GetTileCollisionShapes(gid);
+    return VectorToArray<SharedPtr<TileMapObject2D> >(result, "Array<TileMapObject2D@>@");
+}
+
 static void RegisterTileMap2D(asIScriptEngine* engine)
 {
     engine->RegisterObjectMethod("TileMap2D", "void set_tmxFile(TmxFile2D@+)", asMETHOD(TileMap2D, SetTmxFile), asCALL_THISCALL);
@@ -308,6 +314,7 @@ static void RegisterTileMap2D(asIScriptEngine* engine)
     engine->RegisterObjectMethod("TileMap2D", "TileMapLayer2D@+ GetLayer(uint) const", asMETHOD(TileMap2D, GetLayer), asCALL_THISCALL);
     engine->RegisterObjectMethod("TileMap2D", "Vector2 TileIndexToPosition(int, int) const", asMETHOD(TileMap2D, TileIndexToPosition), asCALL_THISCALL);
     engine->RegisterObjectMethod("TileMap2D", "bool PositionToTileIndex(int&out x, int &out y, const Vector2&in) const", asMETHOD(TileMap2D, PositionToTileIndex), asCALL_THISCALL);
+    engine->RegisterObjectMethod("TileMap2D", "Array<TileMapObject2D@>@ GetTileCollisionShapes(int) const", asFUNCTION(TileMap2DGetTileCollisionShapes), asCALL_CDECL_OBJLAST);
 }
 
 static void RegisterRigidBody2D(asIScriptEngine* engine)

--- a/Source/Urho3D/Urho2D/TileMap2D.cpp
+++ b/Source/Urho3D/Urho2D/TileMap2D.cpp
@@ -57,40 +57,43 @@ void TileMap2D::RegisterObject(Context* context)
         AM_DEFAULT);
 }
 
+Vector2 TransformNode2D(Matrix3x4 transform, Vector2 local);
+
 void TileMap2D::DrawDebugGeometry(DebugRenderer* debug, bool depthTest)
 {
     const Color& color = Color::RED;
     float mapW = info_.GetMapWidth();
     float mapH = info_.GetMapHeight();
+    const Matrix3x4 transform = GetNode()->GetTransform();
 
     switch (info_.orientation_)
     {
     case O_ORTHOGONAL:
-        debug->AddLine(Vector2(0.0f, 0.0f), Vector2(mapW, 0.0f), color);
-        debug->AddLine(Vector2(mapW, 0.0f), Vector2(mapW, mapH), color);
-        debug->AddLine(Vector2(mapW, mapH), Vector2(0.0f, mapH), color);
-        debug->AddLine(Vector2(0.0f, mapH), Vector2(0.0f, 0.0f), color);
+        debug->AddLine(TransformNode2D(transform, Vector2(0.0f, 0.0f)), TransformNode2D(transform, Vector2(mapW, 0.0f)), color);
+        debug->AddLine(TransformNode2D(transform, Vector2(mapW, 0.0f)), TransformNode2D(transform, Vector2(mapW, mapH)), color);
+        debug->AddLine(TransformNode2D(transform, Vector2(mapW, mapH)), TransformNode2D(transform, Vector2(0.0f, mapH)), color);
+        debug->AddLine(TransformNode2D(transform, Vector2(0.0f, mapH)), TransformNode2D(transform, Vector2(0.0f, 0.0f)), color);
         break;
 
     case O_ISOMETRIC:
-        debug->AddLine(Vector2(0.0f, mapH * 0.5f), Vector2(mapW * 0.5f, 0.0f), color);
-        debug->AddLine(Vector2(mapW * 0.5f, 0.0f), Vector2(mapW, mapH * 0.5f), color);
-        debug->AddLine(Vector2(mapW, mapH * 0.5f), Vector2(mapW * 0.5f, mapH), color);
-        debug->AddLine(Vector2(mapW * 0.5f, mapH), Vector2(0.0f, mapH * 0.5f), color);
+        debug->AddLine(TransformNode2D(transform, Vector2(0.0f, mapH * 0.5f)), TransformNode2D(transform, Vector2(mapW * 0.5f, 0.0f)), color);
+        debug->AddLine(TransformNode2D(transform, Vector2(mapW * 0.5f, 0.0f)), TransformNode2D(transform, Vector2(mapW, mapH * 0.5f)), color);
+        debug->AddLine(TransformNode2D(transform, Vector2(mapW, mapH * 0.5f)), TransformNode2D(transform, Vector2(mapW * 0.5f, mapH)), color);
+        debug->AddLine(TransformNode2D(transform, Vector2(mapW * 0.5f, mapH)), TransformNode2D(transform, Vector2(0.0f, mapH * 0.5f)), color);
         break;
 
     case O_STAGGERED:
-        debug->AddLine(Vector2(0.0f, 0.0f), Vector2(mapW, 0.0f), color);
-        debug->AddLine(Vector2(mapW, 0.0f), Vector2(mapW, mapH), color);
-        debug->AddLine(Vector2(mapW, mapH), Vector2(0.0f, mapH), color);
-        debug->AddLine(Vector2(0.0f, mapH), Vector2(0.0f, 0.0f), color);
+        debug->AddLine(TransformNode2D(transform, Vector2(0.0f, 0.0f)), TransformNode2D(transform, Vector2(mapW, 0.0f)), color);
+        debug->AddLine(TransformNode2D(transform, Vector2(mapW, 0.0f)), TransformNode2D(transform, Vector2(mapW, mapH)), color);
+        debug->AddLine(TransformNode2D(transform, Vector2(mapW, mapH)), TransformNode2D(transform, Vector2(0.0f, mapH)), color);
+        debug->AddLine(TransformNode2D(transform, Vector2(0.0f, mapH)), TransformNode2D(transform, Vector2(0.0f, 0.0f)), color);
         break;
 
     case O_HEXAGONAL:
-        debug->AddLine(Vector2(0.0f, 0.0f), Vector2(mapW, 0.0f), color);
-        debug->AddLine(Vector2(mapW, 0.0f), Vector2(mapW, mapH), color);
-        debug->AddLine(Vector2(mapW, mapH), Vector2(0.0f, mapH), color);
-        debug->AddLine(Vector2(0.0f, mapH), Vector2(0.0f, 0.0f), color);
+        debug->AddLine(TransformNode2D(transform, Vector2(0.0f, 0.0f)), TransformNode2D(transform, Vector2(mapW, 0.0f)), color);
+        debug->AddLine(TransformNode2D(transform, Vector2(mapW, 0.0f)), TransformNode2D(transform, Vector2(mapW, mapH)), color);
+        debug->AddLine(TransformNode2D(transform, Vector2(mapW, mapH)), TransformNode2D(transform, Vector2(0.0f, mapH)), color);
+        debug->AddLine(TransformNode2D(transform, Vector2(0.0f, mapH)), TransformNode2D(transform, Vector2(0.0f, 0.0f)), color);
         break;
     }
 

--- a/Source/Urho3D/Urho2D/TileMap2D.cpp
+++ b/Source/Urho3D/Urho2D/TileMap2D.cpp
@@ -57,7 +57,12 @@ void TileMap2D::RegisterObject(Context* context)
         AM_DEFAULT);
 }
 
-Vector2 TransformNode2D(Matrix3x4 transform, Vector2 local);
+// Transform vector from node-local space to global space
+static Vector2 TransformNode2D(Matrix3x4 transform, Vector2 local)
+{
+    Vector3 transformed = transform * Vector4(local.x_, local.y_, 0.f, 1.f);
+    return Vector2(transformed.x_, transformed.y_);
+}
 
 void TileMap2D::DrawDebugGeometry(DebugRenderer* debug, bool depthTest)
 {
@@ -69,6 +74,8 @@ void TileMap2D::DrawDebugGeometry(DebugRenderer* debug, bool depthTest)
     switch (info_.orientation_)
     {
     case O_ORTHOGONAL:
+    case O_STAGGERED:
+    case O_HEXAGONAL:
         debug->AddLine(TransformNode2D(transform, Vector2(0.0f, 0.0f)), TransformNode2D(transform, Vector2(mapW, 0.0f)), color);
         debug->AddLine(TransformNode2D(transform, Vector2(mapW, 0.0f)), TransformNode2D(transform, Vector2(mapW, mapH)), color);
         debug->AddLine(TransformNode2D(transform, Vector2(mapW, mapH)), TransformNode2D(transform, Vector2(0.0f, mapH)), color);
@@ -80,20 +87,6 @@ void TileMap2D::DrawDebugGeometry(DebugRenderer* debug, bool depthTest)
         debug->AddLine(TransformNode2D(transform, Vector2(mapW * 0.5f, 0.0f)), TransformNode2D(transform, Vector2(mapW, mapH * 0.5f)), color);
         debug->AddLine(TransformNode2D(transform, Vector2(mapW, mapH * 0.5f)), TransformNode2D(transform, Vector2(mapW * 0.5f, mapH)), color);
         debug->AddLine(TransformNode2D(transform, Vector2(mapW * 0.5f, mapH)), TransformNode2D(transform, Vector2(0.0f, mapH * 0.5f)), color);
-        break;
-
-    case O_STAGGERED:
-        debug->AddLine(TransformNode2D(transform, Vector2(0.0f, 0.0f)), TransformNode2D(transform, Vector2(mapW, 0.0f)), color);
-        debug->AddLine(TransformNode2D(transform, Vector2(mapW, 0.0f)), TransformNode2D(transform, Vector2(mapW, mapH)), color);
-        debug->AddLine(TransformNode2D(transform, Vector2(mapW, mapH)), TransformNode2D(transform, Vector2(0.0f, mapH)), color);
-        debug->AddLine(TransformNode2D(transform, Vector2(0.0f, mapH)), TransformNode2D(transform, Vector2(0.0f, 0.0f)), color);
-        break;
-
-    case O_HEXAGONAL:
-        debug->AddLine(TransformNode2D(transform, Vector2(0.0f, 0.0f)), TransformNode2D(transform, Vector2(mapW, 0.0f)), color);
-        debug->AddLine(TransformNode2D(transform, Vector2(mapW, 0.0f)), TransformNode2D(transform, Vector2(mapW, mapH)), color);
-        debug->AddLine(TransformNode2D(transform, Vector2(mapW, mapH)), TransformNode2D(transform, Vector2(0.0f, mapH)), color);
-        debug->AddLine(TransformNode2D(transform, Vector2(0.0f, mapH)), TransformNode2D(transform, Vector2(0.0f, 0.0f)), color);
         break;
     }
 
@@ -184,6 +177,12 @@ void TileMap2D::SetTmxFileAttr(const ResourceRef& value)
 ResourceRef TileMap2D::GetTmxFileAttr() const
 {
     return GetResourceRef(tmxFile_, TmxFile2D::GetTypeStatic());
+}
+
+Vector<SharedPtr<TileMapObject2D> > TileMap2D::GetTileCollisionShapes(int gid) const
+{
+    Vector<SharedPtr<TileMapObject2D> > shapes;
+    return tmxFile_ ? tmxFile_->GetTileCollisionShapes(gid) : shapes;
 }
 
 }

--- a/Source/Urho3D/Urho2D/TileMap2D.h
+++ b/Source/Urho3D/Urho2D/TileMap2D.h
@@ -72,7 +72,8 @@ public:
     void SetTmxFileAttr(const ResourceRef& value);
     /// Return tile map file attribute.
     ResourceRef GetTmxFileAttr() const;
-
+    ///
+    Vector<SharedPtr<TileMapObject2D> > GetTileCollisionShapes(int gid) const;
 private:
     /// Tmx file.
     SharedPtr<TmxFile2D> tmxFile_;

--- a/Source/Urho3D/Urho2D/TmxFile2D.h
+++ b/Source/Urho3D/Urho2D/TmxFile2D.h
@@ -99,11 +99,11 @@ public:
     Tile2D* GetTile(int x, int y) const;
 
 protected:
-    /// Tile.
+    /// Tiles.
     Vector<SharedPtr<Tile2D> > tiles_;
 };
 
-/// Tmx image layer.
+/// Tmx objects layer.
 class TmxObjectGroup2D : public TmxLayer2D
 {
 public:
@@ -111,6 +111,9 @@ public:
 
     /// Load from XML element.
     bool Load(const XMLElement& element, const TileMapInfo2D& info);
+
+    /// Store object.
+    void StoreObject(XMLElement objectElem, SharedPtr<TileMapObject2D> object, const TileMapInfo2D& info, bool isTile = false);
 
     /// Return number of objects.
     unsigned GetNumObjects() const { return objects_.Size(); }
@@ -183,11 +186,11 @@ public:
     /// Return tile sprite by gid, if not exist return 0.
     Sprite2D* GetTileSprite(int gid) const;
 
+    /// Return tile collision shapes for a given gid.
+    Vector<SharedPtr<TileMapObject2D> > GetTileCollisionShapes(int gid) const;
+
     /// Return tile property set by gid, if not exist return 0.
     PropertySet2D* GetTilePropertySet(int gid) const;
-
-    /// Return collision object group by gid, if not exist return 0.
-    TmxObjectGroup2D* GetCollisionObjectGroup(int gid) const;
 
     /// Return number of layers.
     unsigned GetNumLayers() const { return layers_.Size(); }
@@ -207,17 +210,14 @@ private:
     HashMap<String, SharedPtr<XMLFile> > tsxXMLFiles_;
     /// Tile map information.
     TileMapInfo2D info_;
-    /// Tile set textures.
-    Vector<SharedPtr<Texture2D> > tileSetTextures_;
     /// Gid to tile sprite mapping.
     HashMap<int, SharedPtr<Sprite2D> > gidToSpriteMapping_;
     /// Gid to tile property set mapping.
     HashMap<int, SharedPtr<PropertySet2D> > gidToPropertySetMapping_;
-    /// Gid to collision object group mapping.
-    HashMap<int, SharedPtr<TmxObjectGroup2D> > gidToCollisionObjectGroupMapping_;
+    /// Gid to tile collision shape mapping.
+    HashMap<int, Vector<SharedPtr<TileMapObject2D> > > gidToCollisionShapeMapping_;
     /// Layers.
     Vector<TmxLayer2D*> layers_;
 };
 
 }
-

--- a/Source/Urho3D/Urho2D/TmxFile2D.h
+++ b/Source/Urho3D/Urho2D/TmxFile2D.h
@@ -186,6 +186,9 @@ public:
     /// Return tile property set by gid, if not exist return 0.
     PropertySet2D* GetTilePropertySet(int gid) const;
 
+    /// Return collision object group by gid, if not exist return 0.
+    TmxObjectGroup2D* GetCollisionObjectGroup(int gid) const;
+
     /// Return number of layers.
     unsigned GetNumLayers() const { return layers_.Size(); }
 
@@ -210,6 +213,8 @@ private:
     HashMap<int, SharedPtr<Sprite2D> > gidToSpriteMapping_;
     /// Gid to tile property set mapping.
     HashMap<int, SharedPtr<PropertySet2D> > gidToPropertySetMapping_;
+    /// Gid to collision object group mapping.
+    HashMap<int, SharedPtr<TmxObjectGroup2D> > gidToCollisionObjectGroupMapping_;
     /// Layers.
     Vector<TmxLayer2D*> layers_;
 };


### PR DESCRIPTION
This PR contains several tilemaps improvements and bugfixes:

- Added support for tilesets, based on collections of images
- Added support for tile collision object groups
- Fixed debug drawing of isometric rectangle and circle objects
- Fixed tilemap debug drawing when node is transformed

Actually, this does not seems completed, I wanted to ask your advice on how to make these right:
1. I wrote function TransformNode2D(Vector2), it is simple helper function, which transforms Vector2 from node's local space to global space. It is used in two classes, and now I just declare it in one class and define in another. Where I should put it? I'm not sure, it doesn't looks so generic to put it in Node class.
2. To load tile collision object group, I copy TileMapInfo2D structure into local var and set there custom width and height, based on current tile width and height. Besides it looks hackish, it will work wrong, if tile width is not multiple map's tile width. I see at least two ways how to fix this: a) Create another class, some kind of "abstract objectgroup info", which will delegate position conversion somewhere else, and b) just make width_ and height_ in TileMapInfo2D some floating-point type instead of int. What do you think?