### PR TITLE
Bat-files use current path instead sources/bin when launched through symlinks

### DIFF
--- a/bin/Editor.bat
+++ b/bin/Editor.bat
@@ -1,4 +1,4 @@
 @echo off
-if exist "%~dp0Urho3DPlayer.exe" (set "DEBUG=") else (set "DEBUG=_d")
+if exist Urho3DPlayer.exe (set "DEBUG=") else (set "DEBUG=_d")
 if [%1] == [] (set "OPT1=-w -s") else (set "OPT1=")
-start "" "%~dp0Urho3DPlayer%DEBUG%" Scripts/Editor.as %OPT1% %*
+start "" Urho3DPlayer%DEBUG% Scripts/Editor.as %OPT1% %*

--- a/bin/NinjaSnowWar.bat
+++ b/bin/NinjaSnowWar.bat
@@ -10,5 +10,5 @@
 ::   Start the client on the same host with "NinjaSnowWar -w -nobgm -address <put-your-host-name-here>"
 ::
 @echo off
-if exist "%~dp0Urho3DPlayer.exe" (set "DEBUG=") else (set "DEBUG=_d")
-"%~dp0Urho3DPlayer%DEBUG%" Scripts/NinjaSnowWar.as %*
+if exist Urho3DPlayer.exe (set "DEBUG=") else (set "DEBUG=_d")
+Urho3DPlayer%DEBUG% Scripts/NinjaSnowWar.as %*

--- a/bin/PBRDemo.bat
+++ b/bin/PBRDemo.bat
@@ -1,3 +1,3 @@
 @echo off
-if exist "%~dp0Urho3DPlayer.exe" (set "DEBUG=") else (set "DEBUG=_d")
-"%~dp0Urho3DPlayer%DEBUG%" Scripts/42_PBRMaterials.as %*
+if exist Urho3DPlayer.exe (set "DEBUG=") else (set "DEBUG=_d")
+Urho3DPlayer%DEBUG% Scripts/42_PBRMaterials.as %*

--- a/bin/PBRDemoDeferred.bat
+++ b/bin/PBRDemoDeferred.bat
@@ -1,3 +1,3 @@
 @echo off
-if exist "%~dp0Urho3DPlayer.exe" (set "DEBUG=") else (set "DEBUG=_d")
-"%~dp0Urho3DPlayer%DEBUG%" Scripts/42_PBRMaterials.as -renderpath CoreData/RenderPaths/PBRDeferred.xml %*
+if exist Urho3DPlayer.exe (set "DEBUG=") else (set "DEBUG=_d")
+Urho3DPlayer%DEBUG% Scripts/42_PBRMaterials.as -renderpath CoreData/RenderPaths/PBRDeferred.xml %*

--- a/bin/PBRDemoDeferredHWDepth.bat
+++ b/bin/PBRDemoDeferredHWDepth.bat
@@ -1,3 +1,3 @@
 @echo off
-if exist "%~dp0Urho3DPlayer.exe" (set "DEBUG=") else (set "DEBUG=_d")
-"%~dp0Urho3DPlayer%DEBUG%" Scripts/42_PBRMaterials.as -renderpath CoreData/RenderPaths/PBRDeferredHWDepth.xml %*
+if exist Urho3DPlayer.exe (set "DEBUG=") else (set "DEBUG=_d")
+Urho3DPlayer%DEBUG% Scripts/42_PBRMaterials.as -renderpath CoreData/RenderPaths/PBRDeferredHWDepth.xml %*


### PR DESCRIPTION
It is normal situation when bat files used after cd.

But is some problem with ConvertModels.bat (I did not change it). This file does not work never.
```
cd /d "%~dp0"
tool/OgreImporter ../SourceAssets/Jack.mesh.xml Data/Models/Jack.mdl -t
tool/OgreImporter ../SourceAssets/Level.mesh.xml Data/Models/NinjaSnowWar/Level.mdl -t
tool/OgreImporter ../SourceAssets/Mushroom.mesh.xml Data/Models/Mushroom.mdl -t
tool/OgreImporter ../SourceAssets/Ninja.mesh.xml Data/Models/NinjaSnowWar/Ninja.mdl -t
tool/OgreImporter ../SourceAssets/Potion.mesh.xml Data/Models/NinjaSnowWar/Potion.mdl -t
tool/OgreImporter ../SourceAssets/SnowBall.mesh.xml Data/Models/NinjaSnowWar/SnowBall.mdl -t
tool/OgreImporter ../SourceAssets/SnowCrate.mesh.xml Data/Models/NinjaSnowWar/SnowCrate.mdl -t
```

If %~dp0 is builded/bin then not exists path  ../SourceAssets/
if %~dp0 is sources/bin then not founded tool/OgreImporter that placed in builded/bin
It will be work only when builded/bin is added to enveronment variable