### PR TITLE
IKEffector target bug fix

### DIFF
--- a/Source/Urho3D/IK/IKEffector.cpp
+++ b/Source/Urho3D/IK/IKEffector.cpp
@@ -246,12 +246,13 @@ bool IKEffector::GetFeature(Feature feature) const
 // ----------------------------------------------------------------------------
 void IKEffector::UpdateTargetNodePosition()
 {
+    if (targetNode_ != NULL || targetName_.Empty())
+        return;
+
+    // Try to find a node with the same name as our target name
+    SetTargetNode(node_->GetScene()->GetChild(targetName_, true));
     if (targetNode_ == NULL)
-    {
-        SetTargetNode(node_->GetScene()->GetChild(targetName_, true));
-        if (targetNode_ == NULL)
-            return;
-    }
+        return;
 
     SetTargetPosition(targetNode_->GetWorldPosition());
     SetTargetRotation(targetNode_->GetWorldRotation());


### PR DESCRIPTION
This should fix the "(0,0,0) effector" bug.

IKEffector can either explicitly be given a target position with ```SetTargetPosition()```, or it can be given a node name to "follow", in which case IKEffector will search the scene for a matching node name right before solving.

The problem was that it would still perform this search, even with an empty node name. This behaviour is clearly wrong.