### PR TITLE
3D UI

### DIFF
--- a/Source/Samples/02_HelloGUI/HelloGUI.cpp
+++ b/Source/Samples/02_HelloGUI/HelloGUI.cpp
@@ -24,6 +24,11 @@
 #include <Urho3D/Engine/Engine.h>
 #include <Urho3D/Graphics/Graphics.h>
 #include <Urho3D/Graphics/Texture2D.h>
+#include <Urho3D/Graphics/Zone.h>
+#include <Urho3D/Graphics/StaticModel.h>
+#include <Urho3D/Graphics/Model.h>
+#include <Urho3D/Graphics/Technique.h>
+#include <Urho3D/Graphics/Octree.h>
 #include <Urho3D/Input/Input.h>
 #include <Urho3D/Resource/ResourceCache.h>
 #include <Urho3D/UI/Button.h>
@@ -34,6 +39,8 @@
 #include <Urho3D/UI/UI.h>
 #include <Urho3D/UI/UIEvents.h>
 #include <Urho3D/UI/Window.h>
+#include <Urho3D/UI/ListView.h>
+#include <Urho3D/UI/UIComponent.h>
 
 #include "HelloGUI.h"
 
@@ -44,7 +51,9 @@ URHO3D_DEFINE_APPLICATION_MAIN(HelloGUI)
 HelloGUI::HelloGUI(Context* context) :
     Sample(context),
     uiRoot_(GetSubsystem<UI>()->GetRoot()),
-    dragBeginPosition_(IntVector2::ZERO)
+    dragBeginPosition_(IntVector2::ZERO),
+    animateCube_(true),
+    renderOnCube_(false)
 {
 }
 
@@ -63,6 +72,9 @@ void HelloGUI::Start()
     // Set the loaded style as default style
     uiRoot_->SetDefaultStyle(style);
 
+    // Initialize Scene
+    InitScene();
+
     // Initialize Window
     InitWindow();
 
@@ -71,6 +83,9 @@ void HelloGUI::Start()
 
     // Create a draggable Fish
     CreateDraggableFish();
+
+    // Create 3D UI rendered on a cube.
+    Init3DUI();
 
     // Set the mouse mode to use in the sample
     Sample::InitMouseMode(MM_FREE);
@@ -101,6 +116,11 @@ void HelloGUI::InitControls()
     checkBox->SetStyleAuto();
     button->SetStyleAuto();
     lineEdit->SetStyleAuto();
+
+    instructions_ = new Text(context_);
+    instructions_->SetStyleAuto();
+    instructions_->SetText("[TAB]   - toggle between rendering on screen or cube.\n[Space] - toggle cube rotation.");
+    uiRoot_->AddChild(instructions_);
 }
 
 void HelloGUI::InitWindow()
@@ -137,8 +157,25 @@ void HelloGUI::InitWindow()
     // Add the title bar to the Window
     window_->AddChild(titleBar);
 
+    // Create a list.
+    ListView* list = window_->CreateChild<ListView>();
+    list->SetSelectOnClickEnd(true);
+    list->SetHighlightMode(HM_ALWAYS);
+    list->SetMinHeight(200);
+
+    for (int i = 0; i < 32; i++)
+    {
+        Text* text = new Text(context_);
+        text->SetStyleAuto();
+        text->SetText(ToString("List item %d", i));
+        text->SetName(ToString("Item %d", i));
+        list->AddItem(text);
+    }
+    window_->AddChild(list);
+
     // Apply styles
     window_->SetStyleAuto();
+    list->SetStyleAuto();
     windowTitle->SetStyleAuto();
     buttonClose->SetStyle("CloseButton");
 
@@ -147,6 +184,44 @@ void HelloGUI::InitWindow()
 
     // Subscribe also to all UI mouse clicks just to see where we have clicked
     SubscribeToEvent(E_UIMOUSECLICK, URHO3D_HANDLER(HelloGUI, HandleControlClicked));
+}
+
+void HelloGUI::InitScene()
+{
+    ResourceCache* cache = GetSubsystem<ResourceCache>();
+
+    scene_ = new Scene(context_);
+    scene_->CreateComponent<Octree>();
+    Zone* zone = scene_->CreateComponent<Zone>();
+    zone->SetBoundingBox(BoundingBox(-1000.0f, 1000.0f));
+    zone->SetFogColor(Color::GRAY);
+    zone->SetFogStart(100.0f);
+    zone->SetFogEnd(300.0f);
+
+    // Create a child scene node (at world origin) and a StaticModel component into it.
+    Node* boxNode = scene_->CreateChild("Box");
+    boxNode->SetScale(Vector3(5.0f, 5.0f, 5.0f));
+    boxNode->SetRotation(Quaternion(90, Vector3::LEFT));
+
+    // Create a box model and hide it initially.
+    StaticModel* boxModel = boxNode->CreateComponent<StaticModel>();
+    boxModel->SetModel(cache->GetResource<Model>("Models/Box.mdl"));
+    boxNode->SetEnabled(false);
+
+    // Create a camera.
+    cameraNode_ = scene_->CreateChild("Camera");
+    cameraNode_->CreateComponent<Camera>();
+
+    // Set an initial position for the camera scene node.
+    cameraNode_->SetPosition(Vector3(0.0f, 0.0f, -10.0f));
+
+    // Set up a viewport so 3D scene can be visible.
+    Renderer* renderer = GetSubsystem<Renderer>();
+    SharedPtr<Viewport> viewport(new Viewport(context_, scene_, cameraNode_->GetComponent<Camera>()));
+    renderer->SetViewport(0, viewport);
+
+    // Subscribe to update event and animate cube and handle input.
+    SubscribeToEvent(E_UPDATE, URHO3D_HANDLER(HelloGUI, HandleUpdate));
 }
 
 void HelloGUI::CreateDraggableFish()
@@ -222,4 +297,66 @@ void HelloGUI::HandleControlClicked(StringHash eventType, VariantMap& eventData)
 
     // Update the Window's title text
     windowTitle->SetText("Hello " + name + "!");
+}
+
+void HelloGUI::Init3DUI()
+{
+    ResourceCache* cache = GetSubsystem<ResourceCache>();
+
+    // Element that accts as root element of UI rendered to texture.
+    textureRoot_ = new UIElement(context_);
+    // Set size of root element. This is size of texture as well.
+    textureRoot_->SetSize(512, 512);
+
+    // Node that will get UI rendered on it.
+    Node* boxNode = scene_->GetChild("Box");
+    // Create a component that sets up UI rendering. It sets material to StaticModel of the node.
+    UIComponent* component = boxNode->CreateComponent<UIComponent>();
+    // Optionally modify material. Technique is changed so object is visible without any lights.
+    component->GetMaterial()->SetTechnique(0, cache->GetResource<Technique>("Techniques/DiffUnlit.xml"));
+    // Add UI element for rendering. All it's children will be rendered into texture which will be applied to boxNode.
+    component->SetElement(textureRoot_);
+}
+
+void HelloGUI::HandleUpdate(StringHash, VariantMap& eventData)
+{
+    using namespace Update;
+    float timeStep = eventData[P_TIMESTEP].GetFloat();
+    Input* input = GetSubsystem<Input>();
+    Node* node = scene_->GetChild("Box");
+
+    static UIElement* current = 0;
+    if (current)
+        GetSubsystem<UI>()->DebugDraw(current);
+
+    if (input->GetMouseButtonPress(MOUSEB_LEFT))
+    {
+        current = GetSubsystem<UI>()->GetElementAt(input->GetMousePosition());
+    }
+
+    if (input->GetKeyPress(KEY_TAB))
+    {
+        renderOnCube_ = !renderOnCube_;
+        // Toggle between rendering on screen or to texture.
+        if (renderOnCube_)
+        {
+            node->SetEnabled(true);
+            textureRoot_->AddChild(window_);
+        }
+        else
+        {
+            node->SetEnabled(false);
+            uiRoot_->AddChild(window_);
+        }
+    }
+
+    if (input->GetKeyPress(KEY_SPACE))
+        animateCube_ = !animateCube_;
+
+    if (animateCube_)
+    {
+        node->Yaw(6.0f * timeStep * 1.5f);
+        node->Roll(-6.0f * timeStep * 1.5f);
+        node->Pitch(-6.0f * timeStep * 1.5f);
+    }
 }

--- a/Source/Samples/02_HelloGUI/HelloGUI.h
+++ b/Source/Samples/02_HelloGUI/HelloGUI.h
@@ -101,6 +101,10 @@ private:
     bool animateCube_;
     /// Enable or disable rendering to texture.
     bool renderOnCube_;
+    /// Draw debug information of last clicked element.
+    bool drawDebug_;
+    /// Last clicked UI element.
+    WeakPtr<UIElement> current_;
 };
 
 

--- a/Source/Samples/02_HelloGUI/HelloGUI.h
+++ b/Source/Samples/02_HelloGUI/HelloGUI.h
@@ -62,6 +62,8 @@ protected:
     }
 
 private:
+    /// Create and initialize a Scene.
+    void InitScene();
     /// Create and initialize a Window control.
     void InitWindow();
     /// Create and add various common controls for demonstration purposes.
@@ -78,13 +80,27 @@ private:
     void HandleControlClicked(StringHash eventType, VariantMap& eventData);
     /// Handle close button pressed and released.
     void HandleClosePressed(StringHash eventType, VariantMap& eventData);
+    /// Animate cube.
+    void HandleUpdate(StringHash, VariantMap& eventData);
+    /// Create 3D UI.
+    void Init3DUI();
 
+    /// The Scene.
+    SharedPtr<Scene> scene_;
     /// The Window.
     SharedPtr<Window> window_;
     /// The UI's root UIElement.
     SharedPtr<UIElement> uiRoot_;
     /// Remembered drag begin position.
     IntVector2 dragBeginPosition_;
+    /// Root UI element of texture.
+    SharedPtr<UIElement> textureRoot_;
+    /// UI element with instructions.
+    SharedPtr<Text> instructions_;
+    /// Enable or disable cube rotation.
+    bool animateCube_;
+    /// Enable or disable rendering to texture.
+    bool renderOnCube_;
 };
 
 

--- a/Source/Urho3D/AngelScript/UIAPI.cpp
+++ b/Source/Urho3D/AngelScript/UIAPI.cpp
@@ -41,6 +41,7 @@
 #include "../UI/UI.h"
 #include "../UI/View3D.h"
 #include "../UI/UIComponent.h"
+#include "../Graphics/Texture2D.h"
 
 #include "../DebugNew.h"
 

--- a/Source/Urho3D/AngelScript/UIAPI.cpp
+++ b/Source/Urho3D/AngelScript/UIAPI.cpp
@@ -40,6 +40,7 @@
 #include "../UI/ToolTip.h"
 #include "../UI/UI.h"
 #include "../UI/View3D.h"
+#include "../UI/UIComponent.h"
 
 #include "../DebugNew.h"
 
@@ -800,6 +801,16 @@ static void RegisterUI(asIScriptEngine* engine)
     engine->RegisterGlobalFunction("UI@+ get_ui()", asFUNCTION(GetUI), asCALL_CDECL);
 }
 
+static void RegisterUIComponent(asIScriptEngine* engine)
+{
+    RegisterComponent<UIComponent>(engine, "UIComponent", true, false);
+    engine->RegisterObjectMethod("UIComponent", "void SetElement(UIElement@+)", asMETHOD(UIComponent, SetElement), asCALL_THISCALL);
+    engine->RegisterObjectMethod("UIComponent", "UIElement@+ GetElement()", asMETHOD(UIComponent, GetElement), asCALL_THISCALL);
+    engine->RegisterObjectMethod("UIComponent", "Material@+ GetMaterial()", asMETHOD(UIComponent, GetMaterial), asCALL_THISCALL);
+    engine->RegisterObjectMethod("UIComponent", "Texture2D@+ GetTexture()", asMETHOD(UIComponent, GetTexture), asCALL_THISCALL);
+    engine->RegisterObjectMethod("UIComponent", "bool IsEnabled() const", asMETHOD(UIComponent, IsEnabled), asCALL_THISCALL);
+}
+
 void RegisterUIAPI(asIScriptEngine* engine)
 {
     RegisterFont(engine);
@@ -825,6 +836,7 @@ void RegisterUIAPI(asIScriptEngine* engine)
     RegisterFileSelector(engine);
     RegisterToolTip(engine);
     RegisterUI(engine);
+    RegisterUIComponent(engine);
 }
 
 }

--- a/Source/Urho3D/AngelScript/UIAPI.cpp
+++ b/Source/Urho3D/AngelScript/UIAPI.cpp
@@ -804,11 +804,9 @@ static void RegisterUI(asIScriptEngine* engine)
 static void RegisterUIComponent(asIScriptEngine* engine)
 {
     RegisterComponent<UIComponent>(engine, "UIComponent", true, false);
-    engine->RegisterObjectMethod("UIComponent", "void SetElement(UIElement@+)", asMETHOD(UIComponent, SetElement), asCALL_THISCALL);
-    engine->RegisterObjectMethod("UIComponent", "UIElement@+ GetElement()", asMETHOD(UIComponent, GetElement), asCALL_THISCALL);
+    engine->RegisterObjectMethod("UIComponent", "UIElement@+ GetRoot()", asMETHOD(UIComponent, GetRoot), asCALL_THISCALL);
     engine->RegisterObjectMethod("UIComponent", "Material@+ GetMaterial()", asMETHOD(UIComponent, GetMaterial), asCALL_THISCALL);
     engine->RegisterObjectMethod("UIComponent", "Texture2D@+ GetTexture()", asMETHOD(UIComponent, GetTexture), asCALL_THISCALL);
-    engine->RegisterObjectMethod("UIComponent", "bool IsEnabled() const", asMETHOD(UIComponent, IsEnabled), asCALL_THISCALL);
 }
 
 void RegisterUIAPI(asIScriptEngine* engine)

--- a/Source/Urho3D/LuaScript/pkgs/UI/UIComponent.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/UI/UIComponent.pkg
@@ -1,0 +1,32 @@
+$#include "UI/UIComponent.h"
+$#include "UI/UIElement.h"
+$#include "Scene/Component.h"
+$#include "Graphics/Material.h"
+$#include "Graphics/Texture2D.h"
+$#include "Graphics/StaticModel.h"
+
+class UIComponent : public Component
+{
+    UIComponent();
+    virtual ~UIComponent();
+
+    void SetElement(UIElement* element);
+    UIElement* GetElement();
+    Material* GetMaterial();
+    Texture2D* GetTexture();
+    bool IsEnabled() const;
+};
+
+${
+#define TOLUA_DISABLE_tolua_UILuaAPI_UIComponent_new00
+static int tolua_UILuaAPI_UIComponent_new00(lua_State* tolua_S)
+{
+    return ToluaNewObject<UIComponent>(tolua_S);
+}
+
+#define TOLUA_DISABLE_tolua_UILuaAPI_UIComponent_new00_local
+static int tolua_UILuaAPI_UIComponent_new00_local(lua_State* tolua_S)
+{
+    return ToluaNewObjectGC<UIComponent>(tolua_S);
+}
+$}

--- a/Source/Urho3D/LuaScript/pkgs/UI/UIComponent.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/UI/UIComponent.pkg
@@ -8,13 +8,10 @@ $#include "Graphics/StaticModel.h"
 class UIComponent : public Component
 {
     UIComponent();
-    virtual ~UIComponent();
 
-    void SetElement(UIElement* element);
-    UIElement* GetElement();
+    UIElement* GetRoot();
     Material* GetMaterial();
     Texture2D* GetTexture();
-    bool IsEnabled() const;
 };
 
 ${

--- a/Source/Urho3D/LuaScript/pkgs/UILuaAPI.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/UILuaAPI.pkg
@@ -21,6 +21,7 @@ $pfile "UI/ToolTip.pkg"
 $pfile "UI/UI.pkg"
 $pfile "UI/Window.pkg"
 $pfile "UI/View3D.pkg"
+$pfile "UI/UIComponent.pkg"
 
 $using namespace Urho3D;
 $#pragma warning(disable:4800)

--- a/Source/Urho3D/Scene/Scene.cpp
+++ b/Source/Urho3D/Scene/Scene.cpp
@@ -42,6 +42,7 @@
 #include "../Scene/SplinePath.h"
 #include "../Scene/UnknownComponent.h"
 #include "../Scene/ValueAnimation.h"
+#include "../Graphics/Renderer.h"
 
 #include "../DebugNew.h"
 
@@ -1526,6 +1527,23 @@ void Scene::PreloadResourcesJSON(const JSONValue& value)
         PreloadResourcesJSON(childVal);
     }
 #endif
+}
+
+Viewport* Scene::GetViewport(int index)
+{
+    Renderer* renderer = GetSubsystem<Renderer>();
+    for (unsigned i = 0; i < renderer->GetNumViewports(); ++i)
+    {
+        Viewport* viewport = renderer->GetViewport(i);
+        if (viewport && viewport->GetScene() == GetScene())
+        {
+            if (index == 0)
+                return viewport;
+            else
+                --index;
+        }
+    }
+    return 0;
 }
 
 void RegisterSceneLibrary(Context* context)

--- a/Source/Urho3D/Scene/Scene.h
+++ b/Source/Urho3D/Scene/Scene.h
@@ -34,6 +34,7 @@ namespace Urho3D
 
 class File;
 class PackageFile;
+class Viewport;
 
 static const unsigned FIRST_REPLICATED_ID = 0x1;
 static const unsigned LAST_REPLICATED_ID = 0xffffff;
@@ -255,6 +256,8 @@ public:
     void MarkNetworkUpdate(Component* component);
     /// Mark a node dirty in scene replication states. The node does not need to have own replication state yet.
     void MarkReplicationDirty(Node* node);
+    /// Returns viewport assigned to this scene. By default returns first viewport assigned to a scene.
+    Viewport* GetViewport(int index=0);
 
 private:
     /// Handle the logic update event to update the scene, if active.

--- a/Source/Urho3D/UI/UI.cpp
+++ b/Source/Urho3D/UI/UI.cpp
@@ -450,7 +450,7 @@ void UI::RenderUpdate()
         {
             component->batches_.Clear();
             component->vertexData_.Clear();
-            UIElement* element = component->GetElement();
+            UIElement* element = component->GetRoot();
             const IntVector2& size = element->GetSize();
             const IntVector2& pos = element->GetPosition();
             // Note: the scissors operate on unscaled coordinates. Scissor scaling is only performed during render
@@ -502,7 +502,7 @@ void UI::Render(bool resetRenderTargets)
             SetVertexData(component->debugVertexBuffer_, component->debugVertexData_);
             Render(resetRenderTargets, component->vertexBuffer_, component->batches_, 0, component->batches_.Size(),
                    component->GetTexture()->GetRenderSurface());
-            Render(false, component->debugVertexBuffer_, component->debugDrawBatches_, 0,
+            Render(resetRenderTargets, component->debugVertexBuffer_, component->debugDrawBatches_, 0,
                    component->debugDrawBatches_.Size(), component->GetTexture()->GetRenderSurface());
             component->debugDrawBatches_.Clear();
             component->debugVertexData_.Clear();
@@ -533,7 +533,7 @@ void UI::DebugDraw(UIElement* element)
             for (Vector<WeakPtr<UIComponent> >::Iterator it = renderToTexture_.Begin(); it != renderToTexture_.End(); it++)
             {
                 WeakPtr<UIComponent> component = *it;
-                if (component.NotNull() && component->GetElement() == root && component->IsEnabled())
+                if (component.NotNull() && component->GetRoot() == root && component->IsEnabled())
                 {
                     element->GetDebugDrawBatches(component->debugDrawBatches_, component->debugVertexData_, scissor);
                     break;
@@ -761,7 +761,7 @@ UIElement* UI::GetElementAt(const IntVector2& position, bool enabledOnly, IntVec
             IntVector2 screenPosition;
             if (component->ScreenToUIPosition(position, screenPosition))
             {
-                result = GetElementAt(component->GetElement(), screenPosition, enabledOnly);
+                result = GetElementAt(component->GetRoot(), screenPosition, enabledOnly);
                 if (result)
                 {
                     if (elementScreenPosition)

--- a/Source/Urho3D/UI/UI.cpp
+++ b/Source/Urho3D/UI/UI.cpp
@@ -960,6 +960,7 @@ void UI::Render(bool resetRenderTargets, VertexBuffer* buffer, const PODVector<U
 
     bool scissorTest = true;
     unsigned alphaFormat = Graphics::GetAlphaFormat();
+    RenderSurface* previousSurface = graphics_->GetRenderTarget(0);
     IntVector2 viewSize;
     if (surface)
         viewSize = IntVector2(surface->GetWidth(), surface->GetHeight());
@@ -1068,6 +1069,9 @@ void UI::Render(bool resetRenderTargets, VertexBuffer* buffer, const PODVector<U
         graphics_->Draw(TRIANGLE_LIST, batch.vertexStart_ / UI_VERTEX_SIZE,
             (batch.vertexEnd_ - batch.vertexStart_) / UI_VERTEX_SIZE);
     }
+
+    if (surface && !resetRenderTargets)
+        graphics_->SetRenderTarget(0, previousSurface);
 }
 
 void UI::GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, UIElement* element, IntRect currentScissor)

--- a/Source/Urho3D/UI/UI.cpp
+++ b/Source/Urho3D/UI/UI.cpp
@@ -32,6 +32,10 @@
 #include "../Graphics/ShaderVariation.h"
 #include "../Graphics/Texture2D.h"
 #include "../Graphics/VertexBuffer.h"
+#include "../Graphics/Octree.h"
+#include "../Graphics/Viewport.h"
+#include "../Graphics/Camera.h"
+#include "../Scene/Scene.h"
 #include "../Input/Input.h"
 #include "../Input/InputEvents.h"
 #include "../IO/Log.h"
@@ -56,6 +60,7 @@
 #include "../UI/UIEvents.h"
 #include "../UI/Window.h"
 #include "../UI/View3D.h"
+#include "../UI/UIComponent.h"
 
 #include <assert.h>
 #include <SDL/SDL.h>
@@ -419,20 +424,49 @@ void UI::RenderUpdate()
     // Note: the scissors operate on unscaled coordinates. Scissor scaling is only performed during render
     IntRect currentScissor = IntRect(rootPos.x_, rootPos.y_, rootPos.x_ + rootSize.x_, rootPos.y_ + rootSize.y_);
     if (rootElement_->IsVisible())
-        GetBatches(rootElement_, currentScissor);
+        GetBatches(batches_, vertexData_, rootElement_, currentScissor);
 
     // Save the batch size of the non-modal batches for later use
     nonModalBatchSize_ = batches_.Size();
 
     // Get rendering batches from the modal UI elements
-    GetBatches(rootModalElement_, currentScissor);
+    GetBatches(batches_, vertexData_, rootModalElement_, currentScissor);
 
     // Get batches from the cursor (and its possible children) last to draw it on top of everything
     if (cursor_ && cursor_->IsVisible() && !osCursorVisible)
     {
         currentScissor = IntRect(0, 0, rootSize.x_, rootSize.y_);
         cursor_->GetBatches(batches_, vertexData_, currentScissor);
-        GetBatches(cursor_, currentScissor);
+        GetBatches(batches_, vertexData_, cursor_, currentScissor);
+    }
+
+    // Get batches for UI elements rendered into textures. Each element rendered into texture is treated as root element.
+    for (Vector<WeakPtr<UIComponent> >::Iterator it = renderToTexture_.Begin(); it != renderToTexture_.End();)
+    {
+        WeakPtr<UIComponent> component = *it;
+        if (component.Null() || !component->IsEnabled())
+            it = renderToTexture_.Erase(it);
+        else if (component->IsEnabled())
+        {
+            component->batches_.Clear();
+            component->vertexData_.Clear();
+            UIElement* element = component->GetElement();
+            const IntVector2& size = element->GetSize();
+            const IntVector2& pos = element->GetPosition();
+            // Note: the scissors operate on unscaled coordinates. Scissor scaling is only performed during render
+            IntRect scissor = IntRect(pos.x_, pos.y_, pos.x_ + size.x_, pos.y_ + size.y_);
+            GetBatches(component->batches_, component->vertexData_, element, scissor);
+
+            // UIElement does not have anything to show. Insert dummy batch that will clear the texture.
+            if (component->batches_.Empty())
+            {
+                UIBatch batch(element, BLEND_REPLACE, scissor, 0, &component->vertexData_);
+                batch.SetColor(Color::BLACK);
+                batch.AddQuad(scissor.left_, scissor.top_, scissor.right_, scissor.bottom_, 0, 0);
+                component->batches_.Push(batch);
+            }
+            ++it;
+        }
     }
 }
 
@@ -458,6 +492,22 @@ void UI::Render(bool resetRenderTargets)
     Render(resetRenderTargets, debugVertexBuffer_, debugDrawBatches_, 0, debugDrawBatches_.Size());
     // Render modal batches
     Render(resetRenderTargets, vertexBuffer_, batches_, nonModalBatchSize_, batches_.Size());
+    // Render to textures
+    for (Vector<WeakPtr<UIComponent> >::ConstIterator it = renderToTexture_.Begin(); it != renderToTexture_.End(); it++)
+    {
+        WeakPtr<UIComponent> component = *it;
+        if (component->IsEnabled())
+        {
+            SetVertexData(component->vertexBuffer_, component->vertexData_);
+            SetVertexData(component->debugVertexBuffer_, component->debugVertexData_);
+            Render(resetRenderTargets, component->vertexBuffer_, component->batches_, 0, component->batches_.Size(),
+                   component->GetTexture()->GetRenderSurface());
+            Render(false, component->debugVertexBuffer_, component->debugDrawBatches_, 0,
+                   component->debugDrawBatches_.Size(), component->GetTexture()->GetRenderSurface());
+            component->debugDrawBatches_.Clear();
+            component->debugVertexData_.Clear();
+        }
+    }
 
     // Clear the debug draw batches and data
     debugDrawBatches_.Clear();
@@ -470,11 +520,26 @@ void UI::DebugDraw(UIElement* element)
 {
     if (element)
     {
-        const IntVector2& rootSize = rootElement_->GetSize();
-        const IntVector2& rootPos = rootElement_->GetPosition();
-        element->GetDebugDrawBatches(debugDrawBatches_, debugVertexData_, IntRect(rootPos.x_, rootPos.y_,
-                                                                                  rootPos.x_ + rootSize.x_,
-                                                                                  rootPos.y_ + rootSize.y_));
+        UIElement* root = element->GetRoot();
+        if (!root)
+            root = element;
+        const IntVector2& rootSize = root->GetSize();
+        const IntVector2& rootPos = root->GetPosition();
+        IntRect scissor(rootPos.x_, rootPos.y_, rootPos.x_ + rootSize.x_, rootPos.y_ + rootSize.y_);
+        if (root == rootElement_ || root == rootModalElement_)
+            element->GetDebugDrawBatches(debugDrawBatches_, debugVertexData_, scissor);
+        else
+        {
+            for (Vector<WeakPtr<UIComponent> >::Iterator it = renderToTexture_.Begin(); it != renderToTexture_.End(); it++)
+            {
+                WeakPtr<UIComponent> component = *it;
+                if (component.NotNull() && component->GetElement() == root && component->IsEnabled())
+                {
+                    element->GetDebugDrawBatches(component->debugDrawBatches_, component->debugVertexData_, scissor);
+                    break;
+                }
+            }
+        }
     }
 }
 
@@ -674,11 +739,54 @@ IntVector2 UI::GetCursorPosition() const
     return cursor_ ? cursor_->GetPosition() : GetSubsystem<Input>()->GetMousePosition();
 }
 
+UIElement* UI::GetElementAt(const IntVector2& position, bool enabledOnly, IntVector2* elementScreenPosition)
+{
+    UIElement* result = 0;
+
+    if (HasModalElement())
+        result = GetElementAt(rootModalElement_, position, enabledOnly);
+
+    if (!result)
+        result = GetElementAt(rootElement_, position, enabledOnly);
+
+    // Mouse was not hovering UI element. Check elements rendered on 3D objects.
+    if (!result && renderToTexture_.Size())
+    {
+        for (Vector<WeakPtr<UIComponent> >::Iterator it = renderToTexture_.Begin(); it != renderToTexture_.End(); it++)
+        {
+            WeakPtr<UIComponent> component = *it;
+            if (component.Null() || !component->IsEnabled())
+                continue;
+
+            IntVector2 screenPosition;
+            if (component->ScreenToUIPosition(position, screenPosition))
+            {
+                result = GetElementAt(component->GetElement(), screenPosition, enabledOnly);
+                if (result)
+                {
+                    if (elementScreenPosition)
+                        *elementScreenPosition = screenPosition;
+                    break;
+                }
+            }
+        }
+    }
+    else if (elementScreenPosition)
+        *elementScreenPosition = position;
+
+    return result;
+}
+
 UIElement* UI::GetElementAt(const IntVector2& position, bool enabledOnly)
 {
+    return GetElementAt(position, enabledOnly, 0);
+}
+
+UIElement* UI::GetElementAt(UIElement* root, const IntVector2& position, bool enabledOnly)
+{
     IntVector2 positionCopy(position);
-    const IntVector2& rootSize = rootElement_->GetSize();
-    const IntVector2& rootPos = rootElement_->GetPosition();
+    const IntVector2& rootSize = root->GetSize();
+    const IntVector2& rootPos = root->GetPosition();
 
     // If position is out of bounds of root element return null.
     if (position.x_ < rootPos.x_ || position.x_ > rootPos.x_ + rootSize.x_)
@@ -697,7 +805,7 @@ UIElement* UI::GetElementAt(const IntVector2& position, bool enabledOnly)
     }
 
     UIElement* result = 0;
-    GetElementAt(result, HasModalElement() ? rootModalElement_ : rootElement_, positionCopy, enabledOnly);
+    GetElementAt(result, root, positionCopy, enabledOnly);
     return result;
 }
 
@@ -839,7 +947,7 @@ void UI::SetVertexData(VertexBuffer* dest, const PODVector<float>& vertexData)
 }
 
 void UI::Render(bool resetRenderTargets, VertexBuffer* buffer, const PODVector<UIBatch>& batches, unsigned batchStart,
-    unsigned batchEnd)
+                unsigned batchEnd, RenderSurface* surface)
 {
     // Engine does not render when window is closed or device is lost
     assert(graphics_ && graphics_->IsInitialized() && !graphics_->IsDeviceLost());
@@ -850,10 +958,32 @@ void UI::Render(bool resetRenderTargets, VertexBuffer* buffer, const PODVector<U
     if (resetRenderTargets)
         graphics_->ResetRenderTargets();
 
-    IntVector2 viewSize = graphics_->GetViewport().Size();
+    bool scissorTest = true;
+    unsigned alphaFormat = Graphics::GetAlphaFormat();
+    IntVector2 viewSize;
+    if (surface)
+        viewSize = IntVector2(surface->GetWidth(), surface->GetHeight());
+    else
+        viewSize = graphics_->GetViewport().Size();
     Vector2 invScreenSize(1.0f / (float)viewSize.x_, 1.0f / (float)viewSize.y_);
     Vector2 scale(2.0f * invScreenSize.x_, -2.0f * invScreenSize.y_);
     Vector2 offset(-1.0f, 1.0f);
+
+    if (surface)
+    {
+#ifdef URHO3D_OPENGL
+        // On OpenGL, flip the projection if rendering to a texture so that the texture can be addressed in the
+        // same way as a render texture produced on Direct3D. Requires disabling scissor as well. This needs a
+        // proper fix.
+        offset.y_ = -offset.y_;
+        scale.y_ = -scale.y_;
+        scissorTest = false;
+#endif
+        graphics_->SetRenderTarget(0, surface);
+        graphics_->SetViewport(IntRect(0, 0, viewSize.x_, viewSize.y_));
+        if (resetRenderTargets)
+            graphics_->Clear(Urho3D::CLEAR_COLOR);
+    }
 
     Matrix4 projection(Matrix4::IDENTITY);
     projection.m00_ = scale.x_ * uiScale_;
@@ -866,7 +996,13 @@ void UI::Render(bool resetRenderTargets, VertexBuffer* buffer, const PODVector<U
 
     graphics_->ClearParameterSources();
     graphics_->SetColorWrite(true);
-    graphics_->SetCullMode(CULL_CCW);
+#ifdef URHO3D_OPENGL
+    // Required due to OpenGL workaround above.
+    if (surface)
+        graphics_->SetCullMode(CULL_NONE);
+    else
+#endif
+        graphics_->SetCullMode(CULL_CCW);
     graphics_->SetDepthTest(CMP_ALWAYS);
     graphics_->SetDepthWrite(false);
     graphics_->SetFillMode(FILL_SOLID);
@@ -880,7 +1016,6 @@ void UI::Render(bool resetRenderTargets, VertexBuffer* buffer, const PODVector<U
     ShaderVariation* diffMaskTexturePS = graphics_->GetShader(PS, "Basic", "DIFFMAP ALPHAMASK VERTEXCOLOR");
     ShaderVariation* alphaTexturePS = graphics_->GetShader(PS, "Basic", "ALPHAMAP VERTEXCOLOR");
 
-    unsigned alphaFormat = Graphics::GetAlphaFormat();
 
     for (unsigned i = batchStart; i < batchEnd; ++i)
     {
@@ -928,14 +1063,14 @@ void UI::Render(bool resetRenderTargets, VertexBuffer* buffer, const PODVector<U
         scissor.bottom_ = (int)(scissor.bottom_ * uiScale_);
 
         graphics_->SetBlendMode(batch.blendMode_);
-        graphics_->SetScissorTest(true, scissor);
+        graphics_->SetScissorTest(scissorTest, scissor);
         graphics_->SetTexture(0, batch.texture_);
         graphics_->Draw(TRIANGLE_LIST, batch.vertexStart_ / UI_VERTEX_SIZE,
             (batch.vertexEnd_ - batch.vertexStart_) / UI_VERTEX_SIZE);
     }
 }
 
-void UI::GetBatches(UIElement* element, IntRect currentScissor)
+void UI::GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, UIElement* element, IntRect currentScissor)
 {
     // Set clipping scissor for child elements. No need to draw if zero size
     element->AdjustScissor(currentScissor);
@@ -959,14 +1094,14 @@ void UI::GetBatches(UIElement* element, IntRect currentScissor)
             while (j != children.End() && (*j)->GetPriority() == currentPriority)
             {
                 if ((*j)->IsWithinScissor(currentScissor) && (*j) != cursor_)
-                    (*j)->GetBatches(batches_, vertexData_, currentScissor);
+                    (*j)->GetBatches(batches, vertexData, currentScissor);
                 ++j;
             }
             // Now recurse into the children
             while (i != j)
             {
                 if ((*i)->IsVisible() && (*i) != cursor_)
-                    GetBatches(*i, currentScissor);
+                    GetBatches(batches, vertexData, *i, currentScissor);
                 ++i;
             }
         }
@@ -979,9 +1114,9 @@ void UI::GetBatches(UIElement* element, IntRect currentScissor)
             if ((*i) != cursor_)
             {
                 if ((*i)->IsWithinScissor(currentScissor))
-                    (*i)->GetBatches(batches_, vertexData_, currentScissor);
+                    (*i)->GetBatches(batches, vertexData, currentScissor);
                 if ((*i)->IsVisible())
-                    GetBatches(*i, currentScissor);
+                    GetBatches(batches, vertexData, *i, currentScissor);
             }
             ++i;
         }
@@ -1112,9 +1247,10 @@ void UI::ReleaseFontFaces()
         fonts[i]->ReleaseFaces();
 }
 
-void UI::ProcessHover(const IntVector2& cursorPos, int buttons, int qualifiers, Cursor* cursor)
+void UI::ProcessHover(const IntVector2& windowCursorPos, int buttons, int qualifiers, Cursor* cursor)
 {
-    WeakPtr<UIElement> element(GetElementAt(cursorPos));
+    IntVector2 cursorPos;
+    WeakPtr<UIElement> element(GetElementAt(windowCursorPos, true, &cursorPos));
 
     for (HashMap<WeakPtr<UIElement>, UI::DragData*>::Iterator i = dragElements_.Begin(); i != dragElements_.End();)
     {
@@ -1200,11 +1336,12 @@ void UI::ProcessHover(const IntVector2& cursorPos, int buttons, int qualifiers, 
     }
 }
 
-void UI::ProcessClickBegin(const IntVector2& cursorPos, int button, int buttons, int qualifiers, Cursor* cursor, bool cursorVisible)
+void UI::ProcessClickBegin(const IntVector2& windowCursorPos, int button, int buttons, int qualifiers, Cursor* cursor, bool cursorVisible)
 {
     if (cursorVisible)
     {
-        WeakPtr<UIElement> element(GetElementAt(cursorPos));
+        IntVector2 cursorPos;
+        WeakPtr<UIElement> element(GetElementAt(windowCursorPos, true, &cursorPos));
 
         bool newButton;
         if (usingTouchInput_)
@@ -1280,11 +1417,12 @@ void UI::ProcessClickBegin(const IntVector2& cursorPos, int button, int buttons,
     }
 }
 
-void UI::ProcessClickEnd(const IntVector2& cursorPos, int button, int buttons, int qualifiers, Cursor* cursor, bool cursorVisible)
+void UI::ProcessClickEnd(const IntVector2& windowCursorPos, int button, int buttons, int qualifiers, Cursor* cursor, bool cursorVisible)
 {
     WeakPtr<UIElement> element;
+    IntVector2 cursorPos = windowCursorPos;
     if (cursorVisible)
-        element = GetElementAt(cursorPos);
+        element = GetElementAt(cursorPos, true, &cursorPos);
 
     // Handle end of drag
     for (HashMap<WeakPtr<UIElement>, UI::DragData*>::Iterator i = dragElements_.Begin(); i != dragElements_.End();)
@@ -1345,11 +1483,14 @@ void UI::ProcessClickEnd(const IntVector2& cursorPos, int button, int buttons, i
     }
 }
 
-void UI::ProcessMove(const IntVector2& cursorPos, const IntVector2& cursorDeltaPos, int buttons, int qualifiers, Cursor* cursor,
+void UI::ProcessMove(const IntVector2& windowCursorPos, const IntVector2& cursorDeltaPos, int buttons, int qualifiers, Cursor* cursor,
     bool cursorVisible)
 {
     if (cursorVisible && dragElementsCount_ > 0 && buttons)
     {
+        IntVector2 cursorPos;
+        GetElementAt(windowCursorPos, true, &cursorPos);
+
         Input* input = GetSubsystem<Input>();
         bool mouseGrabbed = input->IsMouseGrabbed();
         for (HashMap<WeakPtr<UIElement>, UI::DragData*>::Iterator i = dragElements_.Begin(); i != dragElements_.End();)
@@ -1926,6 +2067,18 @@ IntVector2 UI::GetEffectiveRootElementSize(bool applyScale) const
     return size;
 }
 
+void UI::SetRenderToTexture(UIComponent* component, bool enable)
+{
+    WeakPtr<UIComponent> weak(component);
+    if (enable)
+    {
+        if (!renderToTexture_.Contains(weak))
+            renderToTexture_.Push(weak);
+    }
+    else
+        renderToTexture_.Remove(weak);
+}
+
 void RegisterUILibrary(Context* context)
 {
     Font::RegisterObject(context);
@@ -1951,6 +2104,7 @@ void RegisterUILibrary(Context* context)
     MessageBox::RegisterObject(context);
     ProgressBar::RegisterObject(context);
     ToolTip::RegisterObject(context);
+    UIComponent::RegisterObject(context);
 }
 
 }

--- a/Source/Urho3D/UI/UI.h
+++ b/Source/Urho3D/UI/UI.h
@@ -51,6 +51,8 @@ class UIElement;
 class VertexBuffer;
 class XMLElement;
 class XMLFile;
+class RenderSurface;
+class UIComponent;
 
 /// %UI subsystem. Manages the graphical user interface.
 class URHO3D_API UI : public Object
@@ -136,10 +138,12 @@ public:
 
     /// Return cursor position.
     IntVector2 GetCursorPosition() const;
-    /// Return UI element at screen coordinates. By default returns only input-enabled elements.
+    /// Return UI element at global screen coordinates. By default returns only input-enabled elements.
     UIElement* GetElementAt(const IntVector2& position, bool enabledOnly = true);
-    /// Return UI element at screen coordinates. By default returns only input-enabled elements.
+    /// Return UI element at global screen coordinates. By default returns only input-enabled elements.
     UIElement* GetElementAt(int x, int y, bool enabledOnly = true);
+    /// Get a child element at element's screen position relative to specified root element.
+    UIElement* GetElementAt(UIElement* root, const IntVector2& position, bool enabledOnly=true);
 
     /// Return focused element.
     UIElement* GetFocusElement() const { return focusElement_; }
@@ -208,6 +212,9 @@ public:
     /// Return root element custom size. Returns 0,0 when custom size is not being used and automatic resizing according to window size is in use instead (default.)
     const IntVector2& GetCustomSize() const { return customSize_; }
 
+    /// Register UIElement for being rendered into a texture.
+    void SetRenderToTexture(UIComponent* component, bool enable);
+
     /// Data structure used to represent the drag data associated to a UIElement.
     struct DragData
     {
@@ -233,10 +240,12 @@ private:
     /// Upload UI geometry into a vertex buffer.
     void SetVertexData(VertexBuffer* dest, const PODVector<float>& vertexData);
     /// Render UI batches. Geometry must have been uploaded first.
-    void Render
-        (bool resetRenderTargets, VertexBuffer* buffer, const PODVector<UIBatch>& batches, unsigned batchStart, unsigned batchEnd);
+    void Render(bool resetRenderTargets, VertexBuffer* buffer, const PODVector<UIBatch>& batches, unsigned batchStart,
+                unsigned batchEnd, RenderSurface* surface=0);
     /// Generate batches from an UI element recursively. Skip the cursor element.
-    void GetBatches(UIElement* element, IntRect currentScissor);
+    void GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, UIElement* element, IntRect currentScissor);
+    /// Return UI element at global screen coordinates. Return position converted to element's screen coordinates.
+    UIElement* GetElementAt(const IntVector2& position, bool enabledOnly, IntVector2* elementScreenPosition);
     /// Return UI element at screen position recursively.
     void GetElementAt(UIElement*& result, UIElement* current, const IntVector2& position, bool enabledOnly);
     /// Return the first element in hierarchy that can alter focus.
@@ -248,14 +257,14 @@ private:
     /// Force release of font faces when global font properties change.
     void ReleaseFontFaces();
     /// Handle button or touch hover.
-    void ProcessHover(const IntVector2& cursorPos, int buttons, int qualifiers, Cursor* cursor);
+    void ProcessHover(const IntVector2& windowCursorPos, int buttons, int qualifiers, Cursor* cursor);
     /// Handle button or touch begin.
     void
-        ProcessClickBegin(const IntVector2& cursorPos, int button, int buttons, int qualifiers, Cursor* cursor, bool cursorVisible);
+        ProcessClickBegin(const IntVector2& windowCursorPos, int button, int buttons, int qualifiers, Cursor* cursor, bool cursorVisible);
     /// Handle button or touch end.
-    void ProcessClickEnd(const IntVector2& cursorPos, int button, int buttons, int qualifiers, Cursor* cursor, bool cursorVisible);
+    void ProcessClickEnd(const IntVector2& windowCursorPos, int button, int buttons, int qualifiers, Cursor* cursor, bool cursorVisible);
     /// Handle mouse or touch move.
-    void ProcessMove(const IntVector2& cursorPos, const IntVector2& cursorDeltaPos, int buttons, int qualifiers, Cursor* cursor,
+    void ProcessMove(const IntVector2& windowCursorPos, const IntVector2& cursorDeltaPos, int buttons, int qualifiers, Cursor* cursor,
         bool cursorVisible);
     /// Send a UI element drag or hover begin event.
     void SendDragOrHoverEvent
@@ -389,6 +398,10 @@ private:
     float uiScale_;
     /// Root element custom size. 0,0 for automatic resizing (default.)
     IntVector2 customSize_;
+    /// Elements that should be rendered to textures.
+    Vector<WeakPtr<UIComponent> > renderToTexture_;
+
+    friend class UIComponent;
 };
 
 /// Register UI library objects.

--- a/Source/Urho3D/UI/UIComponent.cpp
+++ b/Source/Urho3D/UI/UIComponent.cpp
@@ -1,0 +1,218 @@
+//
+// Copyright (c) 2008-2017 the Urho3D project.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+#include "UIComponent.h"
+#include "../Core/Context.h"
+#include "../Graphics/BillboardSet.h"
+#include "../Graphics/Graphics.h"
+#include "../Graphics/Octree.h"
+#include "../Graphics/Technique.h"
+#include "../Graphics/Material.h"
+#include "../Graphics/Texture2D.h"
+#include "../Graphics/StaticModel.h"
+#include "../Graphics/Renderer.h"
+#include "../Graphics/Camera.h"
+#include "../Graphics/VertexBuffer.h"
+#include "../Scene/Scene.h"
+#include "../Resource/ResourceCache.h"
+#include "../IO/Log.h"
+#include "../UI/UI.h"
+#include "../UI/UIEvents.h"
+
+
+namespace Urho3D
+{
+
+static int const UICOMPONENT_DEFAULT_TEXTURE_SIZE = 512;
+static int const UICOMPONENT_MIN_TEXTURE_SIZE = 64;
+static int const UICOMPONENT_MAX_TEXTURE_SIZE = 4096;
+
+UIComponent::UIComponent(Context* context)
+    : Component(context)
+{
+    vertexBuffer_ = new VertexBuffer(context_);
+    debugVertexBuffer_ = new VertexBuffer(context_);
+}
+
+void UIComponent::RegisterObject(Context* context)
+{
+    context->RegisterFactory<UIComponent>();
+}
+
+void UIComponent::OnNodeSet(Node* node)
+{
+    if (node)
+    {
+        if (texture_.Null())
+            SetTextureSize(UICOMPONENT_DEFAULT_TEXTURE_SIZE, UICOMPONENT_DEFAULT_TEXTURE_SIZE);
+
+        if (material_.Null())
+        {
+            material_ = context_->CreateObject<Material>();
+            material_->SetTechnique(0, GetSubsystem<ResourceCache>()->GetResource<Technique>("Techniques/Diff.xml"));
+            material_->SetTexture(TU_DIFFUSE, texture_);
+        }
+
+        model_ = node->GetComponent<StaticModel>();
+        if (model_.Null())
+            model_ = node->CreateComponent<StaticModel>();
+    }
+    else
+    {
+        material_ = 0;
+        texture_ = 0;
+        model_ = 0;
+        SetElement(0);
+    }
+}
+
+void UIComponent::SetElement(UIElement* element)
+{
+    UI* ui = GetSubsystem<UI>();
+    if (element)
+    {
+        // Elements rendered to texture do not belong to normal UI tree. They are treated as top-level elements.
+        element->Remove();
+        element->SetTraversalMode(TM_DEPTH_FIRST);
+        SetTextureSize(element->GetSize());
+        SubscribeToEvent(element, E_RESIZED, URHO3D_HANDLER(UIComponent, OnElementResized));
+        ui->SetRenderToTexture(this, true);
+        if (model_.NotNull())
+            model_->SetMaterial(material_);
+    }
+    else
+    {
+        if (element_.NotNull())
+            element_->SetTraversalMode(TM_BREADTH_FIRST);
+        UnsubscribeFromEvent(E_RESIZED);
+        ui->SetRenderToTexture(this, false);
+        if (model_.NotNull())
+            model_->SetMaterial(0);
+    }
+    element_ = element;
+}
+
+void UIComponent::OnElementResized(StringHash eventType, VariantMap& args)
+{
+    SetTextureSize(args[Resized::P_WIDTH].GetInt(), args[Resized::P_HEIGHT].GetInt());
+}
+
+bool UIComponent::SetTextureSize(const IntVector2& size)
+{
+    return SetTextureSize(size.x_, size.y_);
+}
+
+bool UIComponent::SetTextureSize(int width, int height)
+{
+    if (width < UICOMPONENT_MIN_TEXTURE_SIZE || width > UICOMPONENT_MAX_TEXTURE_SIZE ||
+        height < UICOMPONENT_MIN_TEXTURE_SIZE || height > UICOMPONENT_MAX_TEXTURE_SIZE)
+    {
+        URHO3D_LOGERROR("UIComponent::SetTextureSize() - Attempting to set invalid size, failed");
+        return false;
+    }
+
+    if (texture_.Null())
+        texture_ = context_->CreateObject<Texture2D>();
+
+    if (texture_->SetSize(width, height, GetSubsystem<Graphics>()->GetRGBAFormat(), TEXTURE_RENDERTARGET))
+    {
+        texture_->SetFilterMode(FILTER_BILINEAR);
+        texture_->SetAddressMode(COORD_U, ADDRESS_CLAMP);
+        texture_->SetAddressMode(COORD_V, ADDRESS_CLAMP);
+        texture_->SetNumLevels(1);                                                // No mipmaps
+        texture_->GetRenderSurface()->SetUpdateMode(SURFACE_MANUALUPDATE);
+        return true;
+    }
+    return false;
+}
+
+Viewport* UIComponent::GetViewport() const
+{
+    if (!GetScene())
+        return 0;
+
+    Renderer* renderer = GetSubsystem<Renderer>();
+    for (unsigned i = 0; i < renderer->GetNumViewports(); ++i)
+    {
+        Viewport* viewport = renderer->GetViewport(i);
+        // Find viewport with same scene
+        // TODO: support multiple viewports
+        if (viewport && viewport->GetScene() == GetScene())
+            return viewport;
+    }
+    return 0;
+}
+
+bool UIComponent::ScreenToUIPosition(IntVector2 screenPos, IntVector2& result)
+{
+    Viewport* viewport = GetViewport();
+    if (!viewport)
+        return false;
+
+    Scene* scene = GetScene();
+    Camera* camera = viewport->GetCamera();
+    Octree* octree = scene->GetComponent<Octree>();
+
+    if (!camera || !octree)
+        return false;
+
+    IntRect rect = viewport->GetRect();
+    if (rect == IntRect::ZERO)
+    {
+        Graphics* graphics = GetSubsystem<Graphics>();
+        rect.right_ = graphics->GetWidth();
+        rect.bottom_ = graphics->GetHeight();
+    }
+
+    Ray ray(camera->GetScreenRay((float)screenPos.x_ / rect.Width(), (float)screenPos.y_ / rect.Height()));
+    PODVector<RayQueryResult> queryResultVector;
+    RayOctreeQuery query(queryResultVector, ray, RAY_TRIANGLE_UV, M_INFINITY, DRAWABLE_GEOMETRY, DEFAULT_VIEWMASK);
+
+    octree->Raycast(query);
+
+    if (queryResultVector.Empty())
+        return false;
+
+    for (unsigned i = 0; i < queryResultVector.Size(); i++)
+    {
+        RayQueryResult& queryResult = queryResultVector[i];
+        if (queryResult.drawable_ != model_)
+        {
+            // ignore billboard sets by default
+            if (queryResult.drawable_->GetTypeInfo()->IsTypeOf(BillboardSet::GetTypeStatic()))
+                continue;
+            return false;
+        }
+
+        Vector2& uv = queryResult.textureUV_;
+        result = IntVector2(static_cast<int>(uv.x_ * element_->GetWidth()),
+                            static_cast<int>(uv.y_ * element_->GetHeight()));
+        return true;
+    }
+    return false;
+}
+
+bool UIComponent::IsEnabled() const
+{
+    return Component::IsEnabled() && model_.NotNull() && texture_.NotNull() && material_.NotNull();;
+}
+
+}

--- a/Source/Urho3D/UI/UIComponent.h
+++ b/Source/Urho3D/UI/UIComponent.h
@@ -1,0 +1,96 @@
+//
+// Copyright (c) 2008-2017 the Urho3D project.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+#pragma once
+
+
+#include "../Scene/Component.h"
+
+
+namespace Urho3D
+{
+
+class Material;
+class Texture2D;
+class StaticModel;
+class Viewport;
+class UIElement;
+class UIBatch;
+class VertexBuffer;
+
+class URHO3D_API UIComponent : public Component
+{
+    URHO3D_OBJECT(UIComponent, Component);
+public:
+    /// Construct.
+    UIComponent(Context* context);
+    /// Register object factory.
+    static void RegisterObject(Context* context);
+
+    /// Set UIElement. Element will be removed from it's parent.
+    void SetElement(UIElement* element);
+    /// Get UIElement.
+    UIElement* GetElement() { return element_; }
+    /// Get material which will be used for rendering UI texture.
+    Material* GetMaterial() { return material_; }
+    /// Get texture which will be used for rendering UI to.
+    Texture2D* GetTexture() { return texture_; }
+    /// Return `true` if component is in a state ready for rendering.
+    bool IsEnabled() const;
+
+protected:
+    /// Material that is set to the model.
+    SharedPtr<Material> material_;
+    /// Texture that UIElement will be rendered into.
+    SharedPtr<Texture2D> texture_;
+    /// Model that texture will be applied to.
+    SharedPtr<StaticModel> model_;
+    /// UIElement to be rendered into texture.
+    SharedPtr<UIElement> element_;
+    /// UI rendering batches.
+    PODVector<UIBatch> batches_;
+    /// UI rendering vertex data.
+    PODVector<float> vertexData_;
+    /// UI vertex buffer.
+    SharedPtr<VertexBuffer> vertexBuffer_;
+    /// UI rendering batches for debug draw.
+    PODVector<UIBatch> debugDrawBatches_;
+    /// UI rendering vertex data for debug draw.
+    PODVector<float> debugVertexData_;
+    /// UI debug geometry vertex buffer.
+    SharedPtr<VertexBuffer> debugVertexBuffer_;
+
+    virtual void OnNodeSet(Node* node);
+    /// Handle resizing of element. Setting size of element will automatically resize texture. UIElement size matches size of texture.
+    void OnElementResized(StringHash eventType, VariantMap& args);
+    /// Set size of texture.
+    bool SetTextureSize(const IntVector2& size);
+    /// Set size of texture.
+    bool SetTextureSize(int width, int height);
+    /// Get viewport that this component belongs to.
+    Viewport* GetViewport() const;
+    /// Convert screen position to position on UIElement.
+    bool ScreenToUIPosition(IntVector2 screenPos, IntVector2& result);
+
+    friend class UI;
+};
+
+}

--- a/Source/Urho3D/UI/UIComponent.h
+++ b/Source/Urho3D/UI/UIComponent.h
@@ -45,16 +45,12 @@ public:
     /// Register object factory.
     static void RegisterObject(Context* context);
 
-    /// Set UIElement. Element will be removed from it's parent.
-    void SetElement(UIElement* element);
     /// Get UIElement.
-    UIElement* GetElement() { return element_; }
+    UIElement* GetRoot() { return rootElement_; }
     /// Get material which will be used for rendering UI texture.
     Material* GetMaterial() { return material_; }
     /// Get texture which will be used for rendering UI to.
     Texture2D* GetTexture() { return texture_; }
-    /// Return `true` if component is in a state ready for rendering.
-    bool IsEnabled() const;
 
 protected:
     /// Material that is set to the model.
@@ -64,7 +60,7 @@ protected:
     /// Model that texture will be applied to.
     SharedPtr<StaticModel> model_;
     /// UIElement to be rendered into texture.
-    SharedPtr<UIElement> element_;
+    SharedPtr<UIElement> rootElement_;
     /// UI rendering batches.
     PODVector<UIBatch> batches_;
     /// UI rendering vertex data.
@@ -77,16 +73,12 @@ protected:
     PODVector<float> debugVertexData_;
     /// UI debug geometry vertex buffer.
     SharedPtr<VertexBuffer> debugVertexBuffer_;
+    /// Is StaticModel component created by this component.
+    bool isStaticModelOwned_;
 
     virtual void OnNodeSet(Node* node);
     /// Handle resizing of element. Setting size of element will automatically resize texture. UIElement size matches size of texture.
     void OnElementResized(StringHash eventType, VariantMap& args);
-    /// Set size of texture.
-    bool SetTextureSize(const IntVector2& size);
-    /// Set size of texture.
-    bool SetTextureSize(int width, int height);
-    /// Get viewport that this component belongs to.
-    Viewport* GetViewport() const;
     /// Convert screen position to position on UIElement.
     bool ScreenToUIPosition(IntVector2 screenPos, IntVector2& result);
 


### PR DESCRIPTION
This change adds support for rendering GUI into a texture. This is achieved by adding `UIComponent` component to `Node`. `UIComponent` overrides material of `Node`'s `StaticModel`. UI subsystem is changed so that batches belonging to UI elements owned by `UIComponent` are rendered into a texture that is also contained in `UIComponent`. Input is handled by UI subsystem, so anything that worked on normal UI will work on UI rendered on to 3D object. This required a minor change for input handling. Previously "screen" was considered surface of entire window. Now screen is considered area of `root_element_position` + `root_element_size`. This is fully backwards-compatible.

There is one issue i am unable to solve: since on OpenGL texture coordinates start from bottom-left corner a workaround is needed. Texture is flipped by projection matrix, however it breaks scissor test. I do not know how to properly fix it therefore scissor test is disabled when rendering into texture on OpenGL. Issue is clearly visible when scrolling a `ListView` in `HelloGUI` sample when UI is rendered on to a cube. Any help regarding OpenGL issue would be greatly appreciated.

Other changes: lua and angelscript bindings, HelloGUI sample can toggle between rendering on screen or rendering on cube, added a ListView to HelloGUI sample window.

![screen](https://user-images.githubusercontent.com/19151258/29453889-c245ce12-83fa-11e7-93be-3f29c34b5f25.png)
