### PR TITLE
Fix crash on android

### DIFF
--- a/Android/src/org/libsdl/app/SDLActivity.java
+++ b/Android/src/org/libsdl/app/SDLActivity.java
@@ -64,6 +64,8 @@ public class SDLActivity extends Activity {
 
     // Urho3D: flag to load the .so and a new method load them
     private static boolean mIsSharedLibraryLoaded = false;
+    // Urho3D: Hash of activity object that owns state, kept around in order to prevent dying activity overwriting state it no longer owns.
+    private static int mStateOwner = 0;
 
     protected boolean onLoadLibrary(ArrayList<String> libraryNames) {
         for (final String name : libraryNames) {
@@ -98,6 +100,7 @@ public class SDLActivity extends Activity {
         mIsPaused = false;
         mIsSurfaceReady = false;
         mHasFocus = true;
+        mStateOwner = 0;
     }
 
     // Setup
@@ -109,6 +112,7 @@ public class SDLActivity extends Activity {
         super.onCreate(savedInstanceState);
 
         SDLActivity.initialize();
+        mStateOwner = hashCode();
         // So we can call stuff from static callbacks
         mSingleton = this;
 
@@ -255,7 +259,8 @@ public class SDLActivity extends Activity {
         if (!SDLActivity.mIsSharedLibraryLoaded) {  // Urho3D
            super.onDestroy();
            // Reset everything in case the user re opens the app
-           SDLActivity.initialize();
+           if (mStateOwner == hashCode())
+               SDLActivity.initialize();
            return;
         }
 
@@ -277,7 +282,8 @@ public class SDLActivity extends Activity {
 
         super.onDestroy();
         // Reset everything in case the user re opens the app
-        SDLActivity.initialize();
+        if (mStateOwner == hashCode())
+            SDLActivity.initialize();
     }
 
     @Override


### PR DESCRIPTION
In some cases old activity may be destroyed after new activity is created. `onCreate()` of new activity gets called and initializes new activity as well as static variables, then `onDestroy()` is called on old activity and cleans up static variables that were just initialized by new activity. This change prevents calling `SDLActivity.initialize()` in `onDestroy()` if new activity has already reinitialized static variables.