### PR TITLE
Inherit transform mode

### DIFF
--- a/Source/Urho3D/AngelScript/SceneAPI.cpp
+++ b/Source/Urho3D/AngelScript/SceneAPI.cpp
@@ -161,6 +161,15 @@ static void RegisterNode(asIScriptEngine* engine)
     RegisterComponent<DebugRenderer>(engine, "DebugRenderer", true, false);
     engine->RegisterObjectMethod("Component", "void DrawDebugGeometry(DebugRenderer@+, bool)", asMETHOD(Component, DrawDebugGeometry), asCALL_THISCALL);
     engine->RegisterObjectMethod("DebugRenderer", "void DrawDebugGeometry(DebugRenderer@+, bool)", asMETHOD(DebugRenderer, DrawDebugGeometry), asCALL_THISCALL);
+
+    engine->RegisterGlobalProperty("const uint INHERIT_NONE", (void*)&INHERIT_NONE);
+    engine->RegisterGlobalProperty("const uint INHERIT_POSITION", (void*)&INHERIT_POSITION);
+    engine->RegisterGlobalProperty("const uint INHERIT_ROTATION", (void*)&INHERIT_ROTATION);
+    engine->RegisterGlobalProperty("const uint INHERIT_SCALE", (void*)&INHERIT_SCALE);
+    engine->RegisterGlobalProperty("const uint INHERIT_ALL", (void*)&INHERIT_ALL);
+
+    engine->RegisterObjectMethod("Node", "void set_inheritMode(uint)", asMETHOD(Node, SetInheritMode), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Node", "uint get_inheritMode() const", asMETHOD(Node, GetInheritMode), asCALL_THISCALL);
 }
 
 static bool SceneLoadXML(File* file, Scene* ptr)

--- a/Source/Urho3D/LuaScript/pkgs/Scene/Node.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Scene/Node.pkg
@@ -17,6 +17,12 @@ enum TransformSpace
     TS_WORLD
 };
 
+static const unsigned INHERIT_NONE;
+static const unsigned INHERIT_POSITION;
+static const unsigned INHERIT_ROTATION;
+static const unsigned INHERIT_SCALE;
+static const unsigned INHERIT_ALL;
+
 class Node : public Animatable
 {
     Node();
@@ -66,6 +72,9 @@ class Node : public Animatable
     void SetWorldTransform2D(const Vector2& position, float rotation);
     void SetWorldTransform2D(const Vector2& position, float rotation, const Vector2& scale);
     void SetWorldTransform2D(const Vector2& position, float rotation, float scale);
+    
+    void SetInheritMode(unsigned inheritMode);
+    unsigned GetInheritMode() const;
 
     void Translate(const Vector3& delta, TransformSpace space = TS_LOCAL);
     void Translate2D(const Vector2& delta, TransformSpace space = TS_LOCAL);
@@ -220,6 +229,7 @@ class Node : public Animatable
     tolua_property__get_set Vector3& position;
     tolua_property__get_set Vector2 position2D;
     tolua_property__get_set Quaternion& rotation;
+    tolua_property__get_set unsigned inheritMode;
     tolua_property__get_set float rotation2D;
     tolua_property__get_set Vector3 direction;
     tolua_readonly tolua_property__get_set Vector3 up;

--- a/Source/Urho3D/Physics/RaycastVehicle.cpp
+++ b/Source/Urho3D/Physics/RaycastVehicle.cpp
@@ -330,7 +330,7 @@ void RaycastVehicle::FixedPostUpdate(float timeStep)
             }
             if (skidInfoCumulative_[i] > 0.05f)
             {
-                skidInfoCumulative_[i] -= 0.002;
+                skidInfoCumulative_[i] -= 0.002f;
             }
         }
         else

--- a/Source/Urho3D/Scene/Node.h
+++ b/Source/Urho3D/Scene/Node.h
@@ -52,6 +52,13 @@ enum TransformSpace
     TS_WORLD
 };
 
+// Transformations that will be inherited from parent
+static const unsigned INHERIT_NONE = 0x0;
+static const unsigned INHERIT_POSITION = 0x1;
+static const unsigned INHERIT_ROTATION = 0x2;
+static const unsigned INHERIT_SCALE = 0x4;
+static const unsigned INHERIT_ALL = INHERIT_POSITION | INHERIT_ROTATION | INHERIT_SCALE;
+
 /// Internal implementation structure for less performance-critical Node variables.
 struct URHO3D_API NodeImpl
 {
@@ -253,6 +260,9 @@ public:
         RotateAround(Vector3(point), Quaternion(delta), space);
     }
 
+    /// Set inherit transform mode.
+    void SetInheritMode(unsigned inheritMode);
+
     /// Rotate around the X axis.
     void Pitch(float angle, TransformSpace space = TS_LOCAL);
     /// Rotate around the Y axis.
@@ -396,6 +406,9 @@ public:
 
     /// Return parent space transform matrix.
     Matrix3x4 GetTransform() const { return Matrix3x4(position_, rotation_, scale_); }
+
+    /// Get inherit transform mode.
+    unsigned GetInheritMode() const { return inheritMode_; }
 
     /// Return position in world space.
     Vector3 GetWorldPosition() const
@@ -695,6 +708,8 @@ private:
     Vector<WeakPtr<Component> > listeners_;
     /// Pointer to implementation.
     UniquePtr<NodeImpl> impl_;
+    /// Inherit transform mode.
+    unsigned inheritMode_;
 
 protected:
     /// User variables.


### PR DESCRIPTION
In some situations child node should inherit parent position but ingnore scaling of parent node.

p.s. I could not test this for LUA. Bite operations added in LUA 5.3 but urho used lua 5.1,
so
```
childNode.inheritMode = INHERIT_ROTATION | INHERIT_POSITION
```
just not works