### PR TITLE
Disregard Menu accelerator keys when a LineEdit is focused

### DIFF
--- a/Source/Urho3D/UI/Menu.cpp
+++ b/Source/Urho3D/UI/Menu.cpp
@@ -25,6 +25,7 @@
 #include "../Core/Context.h"
 #include "../Input/InputEvents.h"
 #include "../IO/Log.h"
+#include "../UI/LineEdit.h"
 #include "../UI/Menu.h"
 #include "../UI/UI.h"
 #include "../UI/UIEvents.h"
@@ -430,8 +431,10 @@ void Menu::HandleKeyDown(StringHash eventType, VariantMap& eventData)
         (acceleratorQualifiers_ == QUAL_ANY || eventData[P_QUALIFIERS].GetInt() == acceleratorQualifiers_) &&
         eventData[P_REPEAT].GetBool() == false)
     {
-        // Ignore if UI has modal element
-        if (GetSubsystem<UI>()->HasModalElement())
+        // Ignore if UI has modal element or focused LineEdit
+        UI* ui = GetSubsystem<UI>();
+        UIElement* focusElement = ui->GetFocusElement();
+        if (ui->HasModalElement() || (focusElement && focusElement->GetType() == LineEdit::GetTypeStatic()))
             return;
 
         HandlePressedReleased(eventType, eventData);


### PR DESCRIPTION
Typing keys that are an accelerator key would fire up Menu actions. In the case of issue #2100, U or Ctrl-U would be one way to cause the Editor quick action window to be closed, due to logic code in the Editor that causes each menu selection to close it.

Not sure if this is wanted in each case, but would seem to make sense, particularly if there are accelerators bound without qualifier.