### PR TITLE
Make Variant able to store any type.

### DIFF
--- a/Source/Urho3D/Core/Context.cpp
+++ b/Source/Urho3D/Core/Context.cpp
@@ -196,7 +196,8 @@ void Context::RemoveSubsystem(StringHash objectType)
 void Context::RegisterAttribute(StringHash objectType, const AttributeInfo& attr)
 {
     // None or pointer types can not be supported
-    if (attr.type_ == VAR_NONE || attr.type_ == VAR_VOIDPTR || attr.type_ == VAR_PTR)
+    if (attr.type_ == VAR_NONE || attr.type_ == VAR_VOIDPTR || attr.type_ == VAR_PTR
+        || attr.type_ == VAR_CUSTOM_HEAP || attr.type_ == VAR_CUSTOM_STACK)
     {
         URHO3D_LOGWARNING("Attempt to register unsupported attribute type " + Variant::GetTypeName(attr.type_) + " to class " +
             GetTypeName(objectType));

--- a/Source/Urho3D/IO/Deserializer.cpp
+++ b/Source/Urho3D/IO/Deserializer.cpp
@@ -386,8 +386,14 @@ Variant Deserializer::ReadVariant(VariantType type)
     case VAR_DOUBLE:
         return Variant(ReadDouble());
 
+        // Deserializing custom values is not supported. Return empty
+    case VAR_CUSTOM_HEAP:
+    case VAR_CUSTOM_STACK:
+        ReadUInt();
+        return Variant::EMPTY;
+
     default:
-        return Variant();
+        return Variant::EMPTY;
     }
 }
 

--- a/Source/Urho3D/IO/Serializer.cpp
+++ b/Source/Urho3D/IO/Serializer.cpp
@@ -286,9 +286,11 @@ bool Serializer::WriteVariantData(const Variant& value)
     case VAR_BUFFER:
         return WriteBuffer(value.GetBuffer());
 
-        // Serializing pointers is not supported. Write null
+        // Serializing pointers and custom values is not supported. Write null
     case VAR_VOIDPTR:
     case VAR_PTR:
+    case VAR_CUSTOM_HEAP:
+    case VAR_CUSTOM_STACK:
         return WriteUInt(0);
 
     case VAR_RESOURCEREF:


### PR DESCRIPTION
1. Varaint is able to store any custom type
2. Types are stored without memory allocation if `sizeof(Type) <= sizeof(void*)*2`
3. It is guaranteed that there is no internal allocations if assign the same type again (either directly or inside another Variant)
4. It is guaranteed that assignment operator is called in this case
5. ~~Custom types cannot be compared to either custom type or zero~~
6. Custom types cannot serialized
7. Custom types can be converted to string, compared to zero or each other if traits are specialized

The main purpose was to type-safely store pointers in the Variant.