### PR TITLE
Fix too strict assert in kNet.

### DIFF
--- a/Source/ThirdParty/kNet/src/MessageConnection.cpp
+++ b/Source/ThirdParty/kNet/src/MessageConnection.cpp
@@ -12,6 +12,8 @@
    See the License for the specific language governing permissions and
    limitations under the License. */
 
+// Modified by Henrik Heino for Urho3D
+
 /** @file MessageConnection.cpp
 	@brief */
 
@@ -738,7 +740,8 @@ void MessageConnection::SendMessage(unsigned long id, bool reliable, bool inOrde
 	msg->inOrder = inOrder;
 	msg->priority = priority;
 	msg->contentID = contentID;
-	assert(msg->data);
+	// Urho3D: Allow NULL data if there is zero bytes.
+	assert(msg->data || !numBytes);
 	assert(msg->Size() == numBytes);
 	memcpy(msg->data, data, numBytes);
 	EndAndQueueMessage(msg);


### PR DESCRIPTION
I don't know if I should make pull request to Urho or kNet, so I'll first try this place :)

If you call `kNet::MessageConnection::sendMessage()` with zero length data, one of the assertions will fail. The reason for this is that `kNet::NetworkMessage::Resize()` does not allocate memory for `data` if length is zero, which is perfectly logical. However the assertion in `kNet::MessageConnection::sendMessage()` does not take this into account. This PR fixes the assertion, so it does not care about NULL if length is also zero.