### PR TITLE
Skyplane technique fixed. 

### DIFF
--- a/bin/CoreData/Shaders/GLSL/Skyplane.glsl
+++ b/bin/CoreData/Shaders/GLSL/Skyplane.glsl
@@ -1,0 +1,16 @@
+#include "Uniforms.glsl"
+#include "Samplers.glsl"
+#include "Transform.glsl"
+
+varying vec2 vTexCoord;
+
+void VS()
+{
+    gl_Position = vec4(iPos.x*2.0, iPos.z*2.0, 1.0 ,1.0);
+    vTexCoord = iTexCoord.xy;
+}
+
+void PS()
+{
+    gl_FragColor = texture2D(sDiffMap, vTexCoord);
+}

--- a/bin/CoreData/Shaders/HLSL/Skyplane.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Skyplane.hlsl
@@ -1,0 +1,18 @@
+#include "Uniforms.hlsl"
+#include "Samplers.hlsl"
+#include "Transform.hlsl"
+
+void VS(float4 iPos : POSITION, 
+    float2 iTexCoord: TEXCOORD0,
+    out float2 oTexCoord : TEXCOORD0, 
+    out float4 oPos : OUTPOSITION)
+{
+    oPos = float4(iPos.x*2.0, iPos.z*2.0, 1.0, 1.0);
+    oTexCoord = iTexCoord;
+}
+
+void PS(float2 iTexCoord : TEXCOORD0, 
+        out float4 oColor : OUTCOLOR0)
+{
+    oColor = cMatDiffColor * Sample2D(DiffMap, iTexCoord);
+}

--- a/bin/CoreData/Techniques/DiffSkyplane.xml
+++ b/bin/CoreData/Techniques/DiffSkyplane.xml
@@ -1,3 +1,3 @@
-<technique vs="Unlit" ps="Unlit" psdefines="DIFFMAP">
+<technique vs="Skyplane" ps="Skyplane" psdefines="DIFFMAP">
     <pass name="postopaque" depthwrite="false" />
 </technique>


### PR DESCRIPTION
Now it is rendering a fullscreeen backgroud image as (i guess) it was intended.

It looks like "skyplane" previously wasn't implemented the same way as other "sky*" techniques which seemed as a mistake. This one could be useful for a background images like camera feed, etc.