### PR TITLE
fix fixtureless 2D shape scaling; fixes #2111

### DIFF
--- a/Source/Urho3D/Urho2D/CollisionShape2D.cpp
+++ b/Source/Urho3D/Urho2D/CollisionShape2D.cpp
@@ -320,8 +320,7 @@ void CollisionShape2D::OnMarkedDirty(Node* node)
 
     cachedWorldScale_ = newWorldScale;
 
-    if (fixture_)
-        ApplyNodeWorldScale();
+    ApplyNodeWorldScale();
 }
 
 }


### PR DESCRIPTION
`ApplyNodeWorldScale` works well in the fixtureless case: it calls `RecreateFixture` which scales the shape, as expected, but ignores the fixture and the body when they are not there to start with: https://github.com/urho3d/Urho3D/blob/14bdd868e8db33c2e9193ed26ac57dbca510142d/Source/Urho3D/Urho2D/CollisionShape2D.cpp#L237 and https://github.com/urho3d/Urho3D/blob/14bdd868e8db33c2e9193ed26ac57dbca510142d/Source/Urho3D/Urho2D/CollisionShape2D.cpp#L215.