### PR TITLE
Fix programmatic point constraint creation after RigidBody component

### DIFF
--- a/Source/Urho3D/Physics/Constraint.cpp
+++ b/Source/Urho3D/Physics/Constraint.cpp
@@ -173,7 +173,7 @@ void Constraint::DrawDebugGeometry(DebugRenderer* debug, bool depthTest)
 
 void Constraint::SetConstraintType(ConstraintType type)
 {
-    if (type != constraintType_)
+    if (type != constraintType_ || !constraint_)
     {
         constraintType_ = type;
         CreateConstraint();


### PR DESCRIPTION
Bypasses the check for same type if no constraint created yet. Fixes #2116.

Arguably it could be cleaner to have a "none" constraint type initially, this way either deserialization or programmatic creation could set the correct type, without having to worry of creating a default type constraint uselessly first.