### PR TITLE
Add ability to specify an image offset in Button, to enable graying-out buttons that are disabled.

### DIFF
--- a/Source/Urho3D/AngelScript/APITemplates.h
+++ b/Source/Urho3D/AngelScript/APITemplates.h
@@ -1338,10 +1338,13 @@ template <class T> void RegisterButton(asIScriptEngine* engine, const char* clas
 {
     RegisterBorderImage<T>(engine, className);
     engine->RegisterObjectMethod(className, "void SetPressedOffset(int, int)", asMETHODPR(T, SetPressedOffset, (int, int), void), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "void SetDisabledOffset(int, int)", asMETHODPR(T, SetDisabledOffset, (int, int), void), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "void SetPressedChildOffset(int, int)", asMETHODPR(T, SetPressedChildOffset, (int, int), void), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "void SetRepeat(float, float)", asMETHOD(T, SetRepeat), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "void set_pressedOffset(const IntVector2&in)", asMETHODPR(T, SetPressedOffset, (const IntVector2&), void), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "const IntVector2& get_pressedOffset() const", asMETHOD(T, GetPressedOffset), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "void set_disabledOffset(const IntVector2&in)", asMETHODPR(T, SetDisabledOffset, (const IntVector2&), void), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "const IntVector2& get_disabledOffset() const", asMETHOD(T, GetDisabledOffset), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "void set_pressedChildOffset(const IntVector2&in)", asMETHODPR(T, SetPressedChildOffset, (const IntVector2&), void), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "const IntVector2& get_pressedChildOffset() const", asMETHOD(T, GetPressedChildOffset), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "void set_repeatDelay(float)", asMETHOD(T, SetRepeatDelay), asCALL_THISCALL);

--- a/Source/Urho3D/LuaScript/pkgs/UI/Button.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/UI/Button.pkg
@@ -16,7 +16,7 @@ class Button : public BorderImage
     void SetRepeatRate(float rate);
     
     const IntVector2& GetPressedOffset() const;
-	const IntVector2& GetDisabledOffset() const;
+    const IntVector2& GetDisabledOffset() const;
     const IntVector2& GetPressedChildOffset() const;
     float GetRepeatDelay() const;
     float GetRepeatRate() const;

--- a/Source/Urho3D/LuaScript/pkgs/UI/Button.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/UI/Button.pkg
@@ -7,6 +7,8 @@ class Button : public BorderImage
     
     void SetPressedOffset(const IntVector2& offset);
     void SetPressedOffset(int x, int y);
+	void SetDisabledOffset(const IntVector2& offset);
+	void SetDisabledOffset(int x, int y);
     void SetPressedChildOffset(const IntVector2& offset);
     void SetPressedChildOffset(int x, int y);
     void SetRepeat(float delay, float rate);
@@ -14,12 +16,14 @@ class Button : public BorderImage
     void SetRepeatRate(float rate);
     
     const IntVector2& GetPressedOffset() const;
+	const IntVector2& GetDisabledOffset() const;
     const IntVector2& GetPressedChildOffset() const;
     float GetRepeatDelay() const;
     float GetRepeatRate() const;
     bool IsPressed() const;
     
     tolua_property__get_set IntVector2& pressedOffset;
+	tolua_property__get_set IntVector2& disabledOffset;
     tolua_property__get_set IntVector2& pressedChildOffset;
     tolua_property__get_set float repeatDelay;
     tolua_property__get_set float repeatRate;

--- a/Source/Urho3D/LuaScript/pkgs/UI/Button.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/UI/Button.pkg
@@ -7,8 +7,8 @@ class Button : public BorderImage
     
     void SetPressedOffset(const IntVector2& offset);
     void SetPressedOffset(int x, int y);
-	void SetDisabledOffset(const IntVector2& offset);
-	void SetDisabledOffset(int x, int y);
+    void SetDisabledOffset(const IntVector2& offset);
+    void SetDisabledOffset(int x, int y);
     void SetPressedChildOffset(const IntVector2& offset);
     void SetPressedChildOffset(int x, int y);
     void SetRepeat(float delay, float rate);
@@ -23,7 +23,7 @@ class Button : public BorderImage
     bool IsPressed() const;
     
     tolua_property__get_set IntVector2& pressedOffset;
-	tolua_property__get_set IntVector2& disabledOffset;
+    tolua_property__get_set IntVector2& disabledOffset;
     tolua_property__get_set IntVector2& pressedChildOffset;
     tolua_property__get_set float repeatDelay;
     tolua_property__get_set float repeatRate;

--- a/Source/Urho3D/UI/Button.cpp
+++ b/Source/Urho3D/UI/Button.cpp
@@ -38,7 +38,7 @@ extern const char* UI_CATEGORY;
 Button::Button(Context* context) :
     BorderImage(context),
     pressedOffset_(IntVector2::ZERO),
-	disabledOffset_(IntVector2::ZERO),
+    disabledOffset_(IntVector2::ZERO),
     pressedChildOffset_(IntVector2::ZERO),
     repeatDelay_(1.0f),
     repeatRate_(0.0f),
@@ -61,7 +61,7 @@ void Button::RegisterObject(Context* context)
     URHO3D_UPDATE_ATTRIBUTE_DEFAULT_VALUE("Is Enabled", true);
     URHO3D_UPDATE_ATTRIBUTE_DEFAULT_VALUE("Focus Mode", FM_FOCUSABLE);
     URHO3D_ACCESSOR_ATTRIBUTE("Pressed Image Offset", GetPressedOffset, SetPressedOffset, IntVector2, IntVector2::ZERO, AM_FILE);
-	URHO3D_ACCESSOR_ATTRIBUTE("Disabled Image Offset", GetDisabledOffset, SetDisabledOffset, IntVector2, IntVector2::ZERO, AM_FILE);
+    URHO3D_ACCESSOR_ATTRIBUTE("Disabled Image Offset", GetDisabledOffset, SetDisabledOffset, IntVector2, IntVector2::ZERO, AM_FILE);
     URHO3D_ACCESSOR_ATTRIBUTE("Pressed Child Offset", GetPressedChildOffset, SetPressedChildOffset, IntVector2, IntVector2::ZERO, AM_FILE);
     URHO3D_ACCESSOR_ATTRIBUTE("Repeat Delay", GetRepeatDelay, SetRepeatDelay, float, 1.0f, AM_FILE);
     URHO3D_ACCESSOR_ATTRIBUTE("Repeat Rate", GetRepeatRate, SetRepeatRate, float, 0.0f, AM_FILE);
@@ -92,18 +92,18 @@ void Button::Update(float timeStep)
 void Button::GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect& currentScissor)
 {
     IntVector2 offset(IntVector2::ZERO);
-	if (enabled_)
-	{
-		if (hovering_ || HasFocus())
-			offset += hoverOffset_;
-		if (pressed_ || selected_)
-			offset += pressedOffset_;
-	}
-	else
-	{
-		offset += disabledOffset_;
-	}
-
+    if (enabled_)
+    {
+        if (hovering_ || HasFocus())
+            offset += hoverOffset_;
+        if (pressed_ || selected_)
+            offset += pressedOffset_;
+    }
+    else
+    {
+        offset += disabledOffset_;
+    }
+    
     BorderImage::GetBatches(batches, vertexData, currentScissor, offset);
 }
 

--- a/Source/Urho3D/UI/Button.cpp
+++ b/Source/Urho3D/UI/Button.cpp
@@ -38,6 +38,7 @@ extern const char* UI_CATEGORY;
 Button::Button(Context* context) :
     BorderImage(context),
     pressedOffset_(IntVector2::ZERO),
+	disabledOffset_(IntVector2::ZERO),
     pressedChildOffset_(IntVector2::ZERO),
     repeatDelay_(1.0f),
     repeatRate_(0.0f),
@@ -60,6 +61,7 @@ void Button::RegisterObject(Context* context)
     URHO3D_UPDATE_ATTRIBUTE_DEFAULT_VALUE("Is Enabled", true);
     URHO3D_UPDATE_ATTRIBUTE_DEFAULT_VALUE("Focus Mode", FM_FOCUSABLE);
     URHO3D_ACCESSOR_ATTRIBUTE("Pressed Image Offset", GetPressedOffset, SetPressedOffset, IntVector2, IntVector2::ZERO, AM_FILE);
+	URHO3D_ACCESSOR_ATTRIBUTE("Disabled Image Offset", GetDisabledOffset, SetDisabledOffset, IntVector2, IntVector2::ZERO, AM_FILE);
     URHO3D_ACCESSOR_ATTRIBUTE("Pressed Child Offset", GetPressedChildOffset, SetPressedChildOffset, IntVector2, IntVector2::ZERO, AM_FILE);
     URHO3D_ACCESSOR_ATTRIBUTE("Repeat Delay", GetRepeatDelay, SetRepeatDelay, float, 1.0f, AM_FILE);
     URHO3D_ACCESSOR_ATTRIBUTE("Repeat Rate", GetRepeatRate, SetRepeatRate, float, 0.0f, AM_FILE);
@@ -90,10 +92,17 @@ void Button::Update(float timeStep)
 void Button::GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect& currentScissor)
 {
     IntVector2 offset(IntVector2::ZERO);
-    if (hovering_ || HasFocus())
-        offset += hoverOffset_;
-    if (pressed_ || selected_)
-        offset += pressedOffset_;
+	if (enabled_)
+	{
+		if (hovering_ || HasFocus())
+			offset += hoverOffset_;
+		if (pressed_ || selected_)
+			offset += pressedOffset_;
+	}
+	else
+	{
+		offset += disabledOffset_;
+	}
 
     BorderImage::GetBatches(batches, vertexData, currentScissor, offset);
 }
@@ -157,6 +166,16 @@ void Button::SetPressedOffset(const IntVector2& offset)
 void Button::SetPressedOffset(int x, int y)
 {
     pressedOffset_ = IntVector2(x, y);
+}
+
+void Button::SetDisabledOffset(const IntVector2& offset)
+{
+    disabledOffset_ = offset;
+}
+
+void Button::SetDisabledOffset(int x, int y)
+{
+    disabledOffset_ = IntVector2(x, y);
 }
 
 void Button::SetPressedChildOffset(const IntVector2& offset)

--- a/Source/Urho3D/UI/Button.h
+++ b/Source/Urho3D/UI/Button.h
@@ -62,6 +62,10 @@ public:
     void SetPressedOffset(const IntVector2& offset);
     /// Set offset to image rectangle used when pressed.
     void SetPressedOffset(int x, int y);
+    /// Set offset to image rectangle used when disabled.
+    void SetDisabledOffset(const IntVector2& offset);
+    /// Set offset to image rectangle used when disabled.
+    void SetDisabledOffset(int x, int y);
     /// Set offset of child elements when pressed.
     void SetPressedChildOffset(const IntVector2& offset);
     /// Set offset of child elements when pressed.
@@ -75,6 +79,9 @@ public:
 
     /// Return pressed image offset.
     const IntVector2& GetPressedOffset() const { return pressedOffset_; }
+    
+    /// Return disabled image offset.
+    const IntVector2& GetDisabledOffset() const { return disabledOffset_; }
 
     /// Return offset of child elements when pressed.
     const IntVector2& GetPressedChildOffset() const { return pressedChildOffset_; }
@@ -94,6 +101,8 @@ protected:
 
     /// Pressed image offset.
     IntVector2 pressedOffset_;
+    /// Disabled image offset.
+    IntVector2 disabledOffset_;
     /// Pressed label offset.
     IntVector2 pressedChildOffset_;
     /// Repeat delay.


### PR DESCRIPTION
Possibly, it might be more appropriate to add this offset to the BorderImage class instead, although I can't think of a personal use-case for doing so. If others disagree, I can withdraw this PR and add the functionality to BorderImage instead.