### PR TITLE
Add internal layout functions for ListView.

### DIFF
--- a/Source/Urho3D/AngelScript/UIAPI.cpp
+++ b/Source/Urho3D/AngelScript/UIAPI.cpp
@@ -309,6 +309,9 @@ static void RegisterListView(asIScriptEngine* engine)
     engine->RegisterEnumValue("HighlightMode", "HM_ALWAYS", HM_ALWAYS);
 
     RegisterUIElement<ListView>(engine, "ListView");
+    engine->RegisterObjectMethod("ListView", "void UpdateInternalLayout()", asMETHOD(ListView, UpdateInternalLayout), asCALL_THISCALL);
+    engine->RegisterObjectMethod("ListView", "void DisableInternalLayoutUpdate()", asMETHOD(ListView, DisableInternalLayoutUpdate), asCALL_THISCALL);
+    engine->RegisterObjectMethod("ListView", "void EnableInternalLayoutUpdate()", asMETHOD(ListView, EnableInternalLayoutUpdate), asCALL_THISCALL);
     engine->RegisterObjectMethod("ListView", "void SetViewPosition(int, int)", asMETHODPR(ListView, SetViewPosition, (int, int), void), asCALL_THISCALL);
     engine->RegisterObjectMethod("ListView", "void SetScrollBarsVisible(bool, bool)", asMETHOD(ListView, SetScrollBarsVisible), asCALL_THISCALL);
     engine->RegisterObjectMethod("ListView", "void AddItem(UIElement@+)", asMETHOD(ListView, AddItem), asCALL_THISCALL);

--- a/Source/Urho3D/LuaScript/pkgs/UI/ListView.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/UI/ListView.pkg
@@ -15,12 +15,16 @@ class ListView : public ScrollView
 {
     ListView();
     virtual ~ListView();
-    
+
+    void UpdateInternalLayout();
+    void DisableInternalLayoutUpdate();
+    void EnableInternalLayoutUpdate();
+
     void AddItem(UIElement* item);
-    
+
     void InsertItem(unsigned index, UIElement* item, UIElement* parentItem = 0);
     void RemoveItem(UIElement* item, unsigned index = 0);
-    
+
     void RemoveItem(unsigned index);
     void RemoveAllItems();
     void SetSelection(unsigned index);
@@ -28,7 +32,7 @@ class ListView : public ScrollView
     void AddSelection(unsigned index);
     void RemoveSelection(unsigned index);
     void ToggleSelection(unsigned index);
-    
+
     void ChangeSelection(int delta, bool additive = false);
     void ClearSelection();
     void SetHighlightMode(HighlightMode mode);

--- a/Source/Urho3D/UI/ListView.cpp
+++ b/Source/Urho3D/UI/ListView.cpp
@@ -323,6 +323,27 @@ void ListView::OnResize(const IntVector2& newSize, const IntVector2& delta)
         overlayContainer_->SetSize(scrollPanel_->GetSize());
 }
 
+void ListView::UpdateInternalLayout()
+{
+    if (overlayContainer_)
+        overlayContainer_->UpdateLayout();
+    contentElement_->UpdateLayout();
+}
+
+void ListView::DisableInternalLayoutUpdate()
+{
+    if (overlayContainer_)
+        overlayContainer_->DisableLayoutUpdate();
+    contentElement_->DisableLayoutUpdate();
+}
+
+void ListView::EnableInternalLayoutUpdate()
+{
+    if (overlayContainer_)
+        overlayContainer_->EnableLayoutUpdate();
+    contentElement_->EnableLayoutUpdate();
+}
+
 void ListView::AddItem(UIElement* item)
 {
     InsertItem(M_MAX_UNSIGNED, item);

--- a/Source/Urho3D/UI/ListView.h
+++ b/Source/Urho3D/UI/ListView.h
@@ -56,6 +56,13 @@ public:
     /// React to resize.
     virtual void OnResize(const IntVector2& newSize, const IntVector2& delta) override;
 
+    /// Manually update layout on internal elements.
+    void UpdateInternalLayout();
+    /// Disable automatic layout update for internal elements.
+    void DisableInternalLayoutUpdate();
+    /// Enable automatic layout update for internal elements.
+    void EnableInternalLayoutUpdate();
+
     /// Add item to the end of the list.
     void AddItem(UIElement* item);
     /// \brief Insert item at a specific index. In hierarchy mode, the optional parameter will be used to determine the child's indent level in respect to its parent.


### PR DESCRIPTION
Some helpers that make massive ListView item instertion 10 times faster
```
    Text* rootItem = new Text(context_);
    rootItem->SetText("Root");
    rootItem->SetStyleAuto();
    listView->DisableInternalLayoutUpdate();
    listView->InsertItem(M_MAX_UNSIGNED, rootItem, nullptr);
    for (int j = 0; j < 15; ++j)
    {
        auto tp1 = std::chrono::high_resolution_clock::now();
        for (int i = 0; i < 1000; ++i)
        {
            Text* childItem = new Text(context_);
            childItem->SetStyleAuto();
            childItem->SetText("Level" + String(j) + "Item" + String(i));
            listView->InsertItem(1000 * j / 2, childItem, rootItem);
        }
        auto tp2 = std::chrono::high_resolution_clock::now();
        unsigned dur = std::chrono::duration_cast<std::chrono::milliseconds>(tp2 - tp1).count();
        URHO3D_LOGINFOF("j=%d t=%u", j, dur);
    }
    listView->EnableInternalLayoutUpdate();
    listView->UpdateInternalLayout();
```