### PR TITLE
Fixing shared pointer release bug

### DIFF
--- a/Source/Urho3D/Container/Ptr.h
+++ b/Source/Urho3D/Container/Ptr.h
@@ -80,9 +80,10 @@ public:
         if (ptr_ == rhs.ptr_)
             return *this;
 
-        ReleaseRef();
+        T* tmp = ptr_;
         ptr_ = rhs.ptr_;
         AddRef();
+        if (tmp) tmp->ReleaseRef();
 
         return *this;
     }
@@ -93,9 +94,10 @@ public:
         if (ptr_ == rhs.ptr_)
             return *this;
 
-        ReleaseRef();
+        T* tmp = ptr_;
         ptr_ = rhs.ptr_;
         AddRef();
+        if (tmp) tmp->ReleaseRef();
 
         return *this;
     }
@@ -106,9 +108,10 @@ public:
         if (ptr_ == ptr)
             return *this;
 
-        ReleaseRef();
+        T* tmp = ptr_;
         ptr_ = ptr;
         AddRef();
+        if (tmp) tmp->ReleaseRef();
 
         return *this;
     }
@@ -166,17 +169,19 @@ public:
     /// Perform a static cast from a shared pointer of another type.
     template <class U> void StaticCast(const SharedPtr<U>& rhs)
     {
-        ReleaseRef();
+        T* tmp = ptr_;
         ptr_ = static_cast<T*>(rhs.Get());
         AddRef();
+        if (tmp) tmp->ReleaseRef();
     }
 
     /// Perform a dynamic cast from a shared pointer of another type.
     template <class U> void DynamicCast(const SharedPtr<U>& rhs)
     {
-        ReleaseRef();
-        ptr_ = dynamic_cast<T*>(rhs.Get());
+        T* tmp = ptr_;
+        ptr_ = static_cast<T*>(rhs.Get());
         AddRef();
+        if (tmp) tmp->ReleaseRef();
     }
 
     /// Check if the pointer is null.


### PR DESCRIPTION
Granted, this is an extremely rare bug, but even so: The following code will not behave as expected:
```cpp
struct Foo : public RefCounted {
    SharedPtr<Foo> child_;
};

// --- elsewhere ---

SharedPtr<Foo> foo = new Foo;  // #1
foo->child_ = new Foo;  // #2
foo->child_->child_ = new Foo;  // #3

foo = foo->child_->child_;  // Deletes all 3 Foo instances
```

The expected behaviour is for Foo #3 to now be assigned to "foo" with a refcount of 1. In reality, all three Foo objects are released and "foo" is NULL. The reason why this happens can be seen in the assignment operator of SharedPtr:

```cpp
    SharedPtr<T>& operator =(const SharedPtr<T>& rhs)
    {
        if (ptr_ == rhs.ptr_)
            return *this;

        ReleaseRef();  // BUG!
        ptr_ = rhs.ptr_;
        AddRef();

        return *this;
    }
```

Releasing the refcount of this->ptr_ potentially executes destruct code, which can in very rare cases cause rhs.ptr_ to be deleted (this is such a case) before acquiring rhs.ptr_ and incrementing its refcount.

The correct implementation is:

```cpp
    SharedPtr<T>& operator =(const SharedPtr<T>& rhs)
    {
        if (ptr_ == rhs.ptr_)
            return *this;

        T* tmp = ptr_;
        ptr_ = rhs.ptr_;
        AddRef();
        if (tmp) tmp->ReleaseRef();

        return *this;
    }
```