### PR TITLE
Combine GetOSVersion() into GetPlatform()

### DIFF
--- a/Source/Urho3D/AngelScript/CoreAPI.cpp
+++ b/Source/Urho3D/AngelScript/CoreAPI.cpp
@@ -832,7 +832,6 @@ static void RegisterProcessUtils(asIScriptEngine* engine)
     engine->RegisterGlobalFunction("uint64 GetTotalMemory()", asFUNCTION(GetTotalMemory), asCALL_CDECL);
     engine->RegisterGlobalFunction("String GetLoginName()", asFUNCTION(GetLoginName), asCALL_CDECL);
     engine->RegisterGlobalFunction("String GetHostName()", asFUNCTION(GetHostName), asCALL_CDECL);
-    engine->RegisterGlobalFunction("String GetOSVersion()", asFUNCTION(GetOSVersion), asCALL_CDECL);
 }
 
 static void ConstructAttributeInfo(AttributeInfo* ptr)

--- a/Source/Urho3D/Core/ProcessUtils.h
+++ b/Source/Urho3D/Core/ProcessUtils.h
@@ -75,6 +75,4 @@ URHO3D_API unsigned long long GetTotalMemory();
 URHO3D_API String GetLoginName(); 
 /// Return the name of the running machine. 
 URHO3D_API String GetHostName();
-/// Return the version of the currently running OS, or (?) if not identified.
-URHO3D_API String GetOSVersion(); 
 }

--- a/Source/Urho3D/LuaScript/pkgs/Core/ProcessUtils.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Core/ProcessUtils.pkg
@@ -19,4 +19,3 @@ String GetMiniDumpDir();
 unsigned long long GetTotalMemory(); 
 String GetLoginName(); 
 String GetHostName();
-String GetOSVersion(); 


### PR DESCRIPTION
I noticed there's functionality duplication of `GetPlatform()` and `GetOSVersion()`. While the former simply returns the platform name, `GetOSVersion()` returns platform name plus version information. Did a PR to combine both into one, from now on `GetPlatform()` returns platform + also version (if version checking is implemented for that platform). No need for `GetOSVersion()`.