### PR TITLE
remove verbose logging of window position and size.

### DIFF
--- a/Source/Urho3D/Graphics/Direct3D11/D3D11Graphics.cpp
+++ b/Source/Urho3D/Graphics/Direct3D11/D3D11Graphics.cpp
@@ -1862,8 +1862,6 @@ void Graphics::OnWindowResized()
     // Reset rendertargets and viewport for the new screen size
     ResetRenderTargets();
 
-    URHO3D_LOGDEBUGF("Window was resized to %dx%d", width_, height_);
-
     using namespace ScreenMode;
 
     VariantMap& eventData = GetEventDataMap();
@@ -1889,8 +1887,6 @@ void Graphics::OnWindowMoved()
 
     position_.x_ = newX;
     position_.y_ = newY;
-
-    URHO3D_LOGDEBUGF("Window was moved to %d,%d", position_.x_, position_.y_);
 
     using namespace WindowPos;
 

--- a/Source/Urho3D/Graphics/Direct3D9/D3D9Graphics.cpp
+++ b/Source/Urho3D/Graphics/Direct3D9/D3D9Graphics.cpp
@@ -2112,8 +2112,6 @@ void Graphics::OnWindowResized()
     // Reset rendertargets and viewport for the new screen size
     ResetRenderTargets();
 
-    URHO3D_LOGDEBUGF("Window was resized to %dx%d", width_, height_);
-
     using namespace ScreenMode;
 
     VariantMap& eventData = GetEventDataMap();
@@ -2139,8 +2137,6 @@ void Graphics::OnWindowMoved()
 
     position_.x_ = newX;
     position_.y_ = newY;
-
-    URHO3D_LOGDEBUGF("Window was moved to %d,%d", position_.x_, position_.y_);
 
     using namespace WindowPos;
 

--- a/Source/Urho3D/Graphics/OpenGL/OGLGraphics.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLGraphics.cpp
@@ -2273,8 +2273,6 @@ void Graphics::OnWindowResized()
     CleanupFramebuffers();
     ResetRenderTargets();
 
-    URHO3D_LOGDEBUGF("Window was resized to %dx%d", width_, height_);
-
     using namespace ScreenMode;
 
     VariantMap& eventData = GetEventDataMap();
@@ -2300,8 +2298,6 @@ void Graphics::OnWindowMoved()
 
     position_.x_ = newX;
     position_.y_ = newY;
-
-    URHO3D_LOGDEBUGF("Window was moved to %d,%d", position_.x_, position_.y_);
 
     using namespace WindowPos;
 


### PR DESCRIPTION
every time the window is moved or resized, the new position or size is logged. in my opinion this logging is too verbose, even for debug logging.