### PR TITLE
ScriptInstance Enum Attributes

### DIFF
--- a/Source/Urho3D/AngelScript/Script.cpp
+++ b/Source/Urho3D/AngelScript/Script.cpp
@@ -321,34 +321,32 @@ const char **Script::GetEnumValues(int asTypeID)
     if (!type)
         return nullptr;
 
-    if (type->GetFlags() & asOBJ_ENUM)
-    {
-        unsigned count = type->GetEnumValueCount();
-        enumValues_[asTypeID].Resize(count + 1);
-        int val;
-        for (unsigned i = 0; i < count; ++i)
-        {
-            const char* name = type->GetEnumValueByIndex(i,&val);
-            if ((unsigned)val >= count)// use unsigned for val so negative values will be flagged as invalid
-            {
-                URHO3D_LOGDEBUGF("Could not register enum attribute names for type %d."
-                          "%s has value of %d, which is outside of the range [0,%d) for a 0-based enum.",
-                          asTypeID,name,val,count);
-
-                //fill with empty buffer
-                enumValues_[asTypeID] = PODVector<const char*>();
-                return nullptr;
-            }
-            else
-            {
-                enumValues_[asTypeID][i] = name;
-            }
-        }
-        enumValues_[asTypeID][count] = 0;
-        return enumValues_[asTypeID].Buffer();
-    }
-    else
+    if (!(type->GetFlags() & asOBJ_ENUM))
         return nullptr;
+
+    unsigned count = type->GetEnumValueCount();
+    enumValues_[asTypeID].Resize(count + 1);
+    for (unsigned i = 0; i < count; ++i)
+    {
+        int val = -1;
+        const char* name = type->GetEnumValueByIndex(i,&val);
+        if ((unsigned)val >= count)// use unsigned for val so negative values will be flagged as invalid
+        {
+            URHO3D_LOGDEBUGF("Could not register enum attribute names for type %d."
+                      "%s has value of %d, which is outside of the range [0,%d) for a 0-based enum.",
+                      asTypeID,name,val,count);
+
+            //fill with empty buffer
+            enumValues_[asTypeID] = PODVector<const char*>();
+            return nullptr;
+        }
+        else
+        {
+            enumValues_[asTypeID][i] = name;
+        }
+    }
+    enumValues_[asTypeID][count] = 0;
+    return enumValues_[asTypeID].Buffer();
 }
 
 asIScriptContext* Script::GetScriptFileContext()

--- a/Source/Urho3D/AngelScript/Script.cpp
+++ b/Source/Urho3D/AngelScript/Script.cpp
@@ -311,6 +311,46 @@ asITypeInfo* Script::GetObjectType(const char* declaration)
     return type;
 }
 
+const char **Script::GetEnumValues(int asTypeID)
+{
+    // If we've already found it, do not try to update the values, as that may invalidate the buffer
+    if (enumValues_.Contains(asTypeID))
+        return enumValues_[asTypeID].Buffer();
+
+    asITypeInfo* type = scriptEngine_->GetTypeInfoById(asTypeID);
+    if (!type)
+        return nullptr;
+
+    if (type->GetFlags() & asOBJ_ENUM)
+    {
+        unsigned count = type->GetEnumValueCount();
+        enumValues_[asTypeID].Resize(count + 1);
+        int val;
+        for (unsigned i = 0; i < count; ++i)
+        {
+            const char* name = type->GetEnumValueByIndex(i,&val);
+            if ((unsigned)val >= count)// use unsigned for val so negative values will be flagged as invalid
+            {
+                URHO3D_LOGDEBUGF("Could not register enum attribute names for type %d."
+                          "%s has value of %d, which is outside of the range [0,%d) for a 0-based enum.",
+                          asTypeID,name,val,count);
+
+                //fill with empty buffer
+                enumValues_[asTypeID] = PODVector<const char*>();
+                return nullptr;
+            }
+            else
+            {
+                enumValues_[asTypeID][i] = name;
+            }
+        }
+        enumValues_[asTypeID][count] = 0;
+        return enumValues_[asTypeID].Buffer();
+    }
+    else
+        return nullptr;
+}
+
 asIScriptContext* Script::GetScriptFileContext()
 {
     while (scriptNestingLevel_ >= scriptFileContexts_.Size())

--- a/Source/Urho3D/AngelScript/Script.h
+++ b/Source/Urho3D/AngelScript/Script.h
@@ -102,6 +102,9 @@ public:
     /// Return the script module create/delete mutex.
     Mutex& GetModuleMutex() { return moduleMutex_; }
 
+    /// Returns an array of strings of enum value names for Enum Attributes
+    const char** GetEnumValues(int asTypeID);
+
 
 private:
     /// Increase script nesting level.
@@ -132,6 +135,8 @@ private:
     Vector<asIScriptContext*> scriptFileContexts_;
     /// Search cache for inbuilt object types.
     HashMap<const char*, asITypeInfo*> objectTypes_;
+    /// Cache of typeIds to array of enum value strings for attributes. Once found, the
+    HashMap<int, PODVector<const char*>> enumValues_;
     /// AngelScript resource router.
     SharedPtr<ResourceRouter> router_;
     /// Script module create/delete mutex.

--- a/Source/Urho3D/AngelScript/Script.h
+++ b/Source/Urho3D/AngelScript/Script.h
@@ -102,7 +102,7 @@ public:
     /// Return the script module create/delete mutex.
     Mutex& GetModuleMutex() { return moduleMutex_; }
 
-    /// Returns an array of strings of enum value names for Enum Attributes
+    /// Returns an array of strings of enum value names for Enum Attributes.
     const char** GetEnumValues(int asTypeID);
 
 
@@ -135,7 +135,7 @@ private:
     Vector<asIScriptContext*> scriptFileContexts_;
     /// Search cache for inbuilt object types.
     HashMap<const char*, asITypeInfo*> objectTypes_;
-    /// Cache of typeIds to array of enum value strings for attributes. Once found, the
+    /// Cache of typeIds to array of enum value strings for attributes.
     HashMap<int, PODVector<const char*>> enumValues_;
     /// AngelScript resource router.
     SharedPtr<ResourceRouter> router_;

--- a/Source/Urho3D/AngelScript/ScriptInstance.cpp
+++ b/Source/Urho3D/AngelScript/ScriptInstance.cpp
@@ -643,7 +643,7 @@ void ScriptInstance::GetScriptAttributes()
     {
         const char* name;
         int typeId;
-        bool isPrivate, isProtected, isHandle;
+        bool isPrivate, isProtected, isHandle, isEnum;
 
         scriptObject_->GetObjectType()->GetProperty(i, &name, &typeId, &isPrivate, &isProtected);
 
@@ -656,12 +656,20 @@ void ScriptInstance::GetScriptAttributes()
         if (isHandle)
             typeName = typeName.Substring(0, typeName.Length() - 1);
 
+        if (engine->GetTypeInfoById(typeId))
+            isEnum = engine->GetTypeInfoById(typeId)->GetFlags() & asOBJ_ENUM;
+
         AttributeInfo info;
         info.mode_ = AM_FILE;
         info.name_ = name;
         info.ptr_ = scriptObject_->GetAddressOfProperty(i);
 
-        if (!isHandle)
+        if (isEnum)
+        {
+            info.type_ = VAR_INT;
+            info.enumNames_ = GetSubsystem<Script>()->GetEnumValues(typeId);
+        }
+        else if (!isHandle)
         {
             switch (typeId)
             {

--- a/Source/Urho3D/AngelScript/ScriptInstance.cpp
+++ b/Source/Urho3D/AngelScript/ScriptInstance.cpp
@@ -641,9 +641,9 @@ void ScriptInstance::GetScriptAttributes()
     unsigned numProperties = scriptObject_->GetPropertyCount();
     for (unsigned i = 0; i < numProperties; ++i)
     {
-        const char* name;
-        int typeId;
-        bool isPrivate, isProtected, isHandle, isEnum;
+        const char* name = nullptr;
+        int typeId = 0; // AngelScript void typeid
+        bool isPrivate=false, isProtected=false, isHandle=false, isEnum=false;
 
         scriptObject_->GetObjectType()->GetProperty(i, &name, &typeId, &isPrivate, &isProtected);
 


### PR DESCRIPTION
Based on https://discourse.urho3d.io/t/enum-value-editing-via-editor/3804, I tried implementing the feature. As I personally don't use the editor for much, I can't say if this actually works (or that it won't eventually cause crashes potentially from the HashMap moving things around or the like), but I can say that enum attributes do show up in the editor now for ScriptInstances, and that they seem to be serialized to the scene when it is saved and then loaded when the scene is loaded.

So, its only the last commit (58ee22c) that I meant to have with this pull request, the rest are from my personal branch -- what is the best way to go about fixing this?