### PR TITLE
Allow abstracting resource I/O

### DIFF
--- a/Source/Urho3D/AngelScript/ScriptFile.cpp
+++ b/Source/Urho3D/AngelScript/ScriptFile.cpp
@@ -691,7 +691,7 @@ bool ScriptFile::AddScriptSection(asIScriptEngine* engine, Deserializer& source)
     for (unsigned i = 0; i < includeFiles.Size(); ++i)
     {
         cache->StoreResourceDependency(this, includeFiles[i]);
-        SharedPtr<File> file = cache->GetFile(includeFiles[i]);
+        SharedPtr<AbstractFile> file = cache->GetAbstractFile(includeFiles[i]);
         if (file)
         {
             if (!AddScriptSection(engine, *file))

--- a/Source/Urho3D/Core/Context.h
+++ b/Source/Urho3D/Core/Context.h
@@ -264,7 +264,7 @@ template <class T> T* Context::RegisterSubsystem()
 
 template <class T> void Context::RegisterDerivedSubsystem(T* subsystem)
 {
-    if(!subsystem)
+    if (!subsystem)
         return;
     subsystems_[T::GetTypeStatic()] = subsystem;
 }

--- a/Source/Urho3D/Core/Context.h
+++ b/Source/Urho3D/Core/Context.h
@@ -117,6 +117,8 @@ public:
     template <class T> void RegisterFactory(const char* category);
     /// Template version of registering subsystem.
     template <class T> T* RegisterSubsystem();
+    /// Template version of registering subsystem that allows the subsystem object to be a subclass of the template type.
+    template<class T> void RegisterDerivedSubsystem(T* subsystem);
     /// Template version of removing a subsystem.
     template <class T> void RemoveSubsystem();
     /// Template version of registering an object attribute.
@@ -258,6 +260,13 @@ template <class T> T* Context::RegisterSubsystem()
     T* subsystem = new T(this);
     RegisterSubsystem(subsystem);
     return subsystem;
+}
+
+template <class T> void Context::RegisterDerivedSubsystem(T* subsystem)
+{
+    if(!subsystem)
+        return;
+    subsystems_[T::GetTypeStatic()] = subsystem;
 }
 
 template <class T> void Context::RemoveSubsystem() { RemoveSubsystem(T::GetTypeStatic()); }

--- a/Source/Urho3D/Graphics/Material.cpp
+++ b/Source/Urho3D/Graphics/Material.cpp
@@ -145,7 +145,7 @@ StringHash ParseTextureTypeXml(ResourceCache* cache, String filename)
     if (!cache)
         return type;
 
-    SharedPtr<File> texXmlFile = cache->GetFile(filename, false);
+    SharedPtr<AbstractFile> texXmlFile = cache->GetAbstractFile(filename, false);
     if (texXmlFile.NotNull())
     {
         SharedPtr<XMLFile> texXml(new XMLFile(cache->GetContext()));

--- a/Source/Urho3D/Graphics/Shader.cpp
+++ b/Source/Urho3D/Graphics/Shader.cpp
@@ -184,7 +184,7 @@ bool Shader::ProcessSource(String& code, Deserializer& source)
         {
             String includeFileName = GetPath(source.GetName()) + line.Substring(9).Replaced("\"", "").Trimmed();
 
-            SharedPtr<File> includeFile = cache->GetFile(includeFileName);
+            SharedPtr<AbstractFile> includeFile = cache->GetAbstractFile(includeFileName);
             if (!includeFile)
                 return false;
 

--- a/Source/Urho3D/Graphics/StaticModel.cpp
+++ b/Source/Urho3D/Graphics/StaticModel.cpp
@@ -308,7 +308,7 @@ void StaticModel::ApplyMaterialList(const String& fileName)
         useFileName = ReplaceExtension(model_->GetName(), ".txt");
 
     ResourceCache* cache = GetSubsystem<ResourceCache>();
-    SharedPtr<File> file = cache->GetFile(useFileName, false);
+    SharedPtr<AbstractFile> file = cache->GetAbstractFile(useFileName, false);
     if (!file)
         return;
 

--- a/Source/Urho3D/Graphics/Texture3D.cpp
+++ b/Source/Urho3D/Graphics/Texture3D.cpp
@@ -120,7 +120,7 @@ bool Texture3D::BeginLoad(Deserializer& source)
         if (colorlutTexPath.Empty())
             name = texPath + name;
 
-        SharedPtr<File> file = GetSubsystem<ResourceCache>()->GetFile(name);
+        SharedPtr<AbstractFile> file = GetSubsystem<ResourceCache>()->GetAbstractFile(name);
         loadImage_ = new Image(context_);
         if (!loadImage_->LoadColorLUT(*(file.Get())))
         {

--- a/Source/Urho3D/IO/File.cpp
+++ b/Source/Urho3D/IO/File.cpp
@@ -66,7 +66,7 @@ static const unsigned READ_BUFFER_SIZE = 32768;
 static const unsigned SKIP_BUFFER_SIZE = 1024;
 
 File::File(Context* context) :
-    Object(context),
+    AbstractFile(context),
     mode_(FILE_READ),
     handle_(nullptr),
 #ifdef __ANDROID__
@@ -83,7 +83,7 @@ File::File(Context* context) :
 }
 
 File::File(Context* context, const String& fileName, FileMode mode) :
-    Object(context),
+    AbstractFile(context),
     mode_(FILE_READ),
     handle_(nullptr),
 #ifdef __ANDROID__
@@ -101,7 +101,7 @@ File::File(Context* context, const String& fileName, FileMode mode) :
 }
 
 File::File(Context* context, PackageFile* package, const String& fileName) :
-    Object(context),
+    AbstractFile(context),
     mode_(FILE_READ),
     handle_(nullptr),
 #ifdef __ANDROID__

--- a/Source/Urho3D/IO/File.h
+++ b/Source/Urho3D/IO/File.h
@@ -23,7 +23,6 @@
 #pragma once
 
 #include "../Container/ArrayPtr.h"
-#include "../Core/Object.h"
 #include "../IO/AbstractFile.h"
 
 #ifdef __ANDROID__
@@ -57,9 +56,9 @@ enum FileMode
 class PackageFile;
 
 /// %File opened either through the filesystem or from within a package file.
-class URHO3D_API File : public Object, public AbstractFile
+class URHO3D_API File : public AbstractFile
 {
-    URHO3D_OBJECT(File, Object);
+    URHO3D_OBJECT(File, AbstractFile);
 
 public:
     /// Construct.

--- a/Source/Urho3D/IO/IOStream.h
+++ b/Source/Urho3D/IO/IOStream.h
@@ -22,24 +22,22 @@
 
 #pragma once
 
-#include "../Core/Object.h"
-#include "../IO/IOStream.h"
+#include "../IO/Serializer.h"
+#include "../IO/Deserializer.h"
 
 namespace Urho3D
 {
 
-/// A common root class for file-like objects that are associated with a context.
-class URHO3D_API AbstractFile : public Object, public IOStream
+/// A common root class for objects that implement both Serializer and Deserializer.
+class URHO3D_API IOStream : public Deserializer, public Serializer
 {
-    URHO3D_OBJECT(AbstractFile, Object);
-
 public:
     /// Construct.
-    AbstractFile(Context* ctx) : Object(ctx), IOStream() { }
+    IOStream() : Deserializer() { }
     /// Construct.
-    AbstractFile(Context* ctx, unsigned int size) : Object(ctx), IOStream(size) { }
+    IOStream(unsigned int size) : Deserializer(size) { }
     /// Destruct.
-    virtual ~AbstractFile() override { }
+    virtual ~IOStream() override { }
 };
 
 };

--- a/Source/Urho3D/IO/MemoryBuffer.cpp
+++ b/Source/Urho3D/IO/MemoryBuffer.cpp
@@ -28,7 +28,7 @@ namespace Urho3D
 {
 
 MemoryBuffer::MemoryBuffer(void* data, unsigned size) :
-    AbstractFile(size),
+    IOStream(size),
     buffer_((unsigned char*)data),
     readOnly_(false)
 {
@@ -37,7 +37,7 @@ MemoryBuffer::MemoryBuffer(void* data, unsigned size) :
 }
 
 MemoryBuffer::MemoryBuffer(const void* data, unsigned size) :
-    AbstractFile(size),
+    IOStream(size),
     buffer_((unsigned char*)data),
     readOnly_(true)
 {
@@ -46,14 +46,14 @@ MemoryBuffer::MemoryBuffer(const void* data, unsigned size) :
 }
 
 MemoryBuffer::MemoryBuffer(PODVector<unsigned char>& data) :
-    AbstractFile(data.Size()),
+    IOStream(data.Size()),
     buffer_(data.Begin().ptr_),
     readOnly_(false)
 {
 }
 
 MemoryBuffer::MemoryBuffer(const PODVector<unsigned char>& data) :
-    AbstractFile(data.Size()),
+    IOStream(data.Size()),
     buffer_(data.Begin().ptr_),
     readOnly_(true)
 {

--- a/Source/Urho3D/IO/MemoryBuffer.h
+++ b/Source/Urho3D/IO/MemoryBuffer.h
@@ -22,13 +22,13 @@
 
 #pragma once
 
-#include "../IO/AbstractFile.h"
+#include "../IO/IOStream.h"
 
 namespace Urho3D
 {
 
 /// Memory area that can be read and written to as a stream.
-class URHO3D_API MemoryBuffer : public AbstractFile
+class URHO3D_API MemoryBuffer : public IOStream
 {
 public:
     /// Construct with a pointer and size.

--- a/Source/Urho3D/IO/NamedPipe.cpp
+++ b/Source/Urho3D/IO/NamedPipe.cpp
@@ -43,7 +43,7 @@ namespace Urho3D
 static const unsigned PIPE_BUFFER_SIZE = 65536;
 
 NamedPipe::NamedPipe(Context* context) :
-    Object(context),
+    AbstractFile(context),
     isServer_(false),
 #ifdef _WIN32
     handle_(INVALID_HANDLE_VALUE)
@@ -55,7 +55,7 @@ NamedPipe::NamedPipe(Context* context) :
 }
 
 NamedPipe::NamedPipe(Context* context, const String& pipeName, bool isServer) :
-    Object(context),
+    AbstractFile(context),
     isServer_(false),
 #ifdef _WIN32
     handle_(INVALID_HANDLE_VALUE)

--- a/Source/Urho3D/IO/NamedPipe.h
+++ b/Source/Urho3D/IO/NamedPipe.h
@@ -34,9 +34,9 @@ namespace Urho3D
 {
 
 /// Named pipe for interprocess communication.
-class URHO3D_API NamedPipe : public Object, public AbstractFile
+class URHO3D_API NamedPipe : public AbstractFile
 {
-    URHO3D_OBJECT(NamedPipe, Object);
+    URHO3D_OBJECT(NamedPipe, AbstractFile);
 
 public:
     /// Construct.

--- a/Source/Urho3D/IO/VectorBuffer.h
+++ b/Source/Urho3D/IO/VectorBuffer.h
@@ -22,13 +22,13 @@
 
 #pragma once
 
-#include "../IO/AbstractFile.h"
+#include "../IO/IOStream.h"
 
 namespace Urho3D
 {
 
 /// Dynamically sized buffer that can be read and written to as a stream.
-class URHO3D_API VectorBuffer : public AbstractFile
+class URHO3D_API VectorBuffer : public IOStream
 {
 public:
     /// Construct an empty buffer.

--- a/Source/Urho3D/Network/Connection.cpp
+++ b/Source/Urho3D/Network/Connection.cpp
@@ -1519,7 +1519,7 @@ void Connection::OnPackagesReady()
     {
         // Otherwise start the async loading process
         String extension = GetExtension(sceneFileName_);
-        SharedPtr<File> file = GetSubsystem<ResourceCache>()->GetFile(sceneFileName_);
+        SharedPtr<AbstractFile> file = GetSubsystem<ResourceCache>()->GetAbstractFile(sceneFileName_);
         bool success;
 
         if (extension == ".xml")

--- a/Source/Urho3D/Resource/BackgroundLoader.cpp
+++ b/Source/Urho3D/Resource/BackgroundLoader.cpp
@@ -79,7 +79,7 @@ void BackgroundLoader::ThreadFunction()
             backgroundLoadMutex_.Release();
 
             bool success = false;
-            SharedPtr<File> file = owner_->GetFile(resource->GetName(), item.sendEventOnFailure_);
+            SharedPtr<AbstractFile> file = owner_->GetAbstractFile(resource->GetName(), item.sendEventOnFailure_);
             if (file)
             {
                 resource->SetAsyncLoadState(ASYNC_LOADING);

--- a/Source/Urho3D/Resource/ResourceCache.cpp
+++ b/Source/Urho3D/Resource/ResourceCache.cpp
@@ -570,7 +570,7 @@ SharedPtr<AbstractFile> ResourceCache::GetAbstractFile(const String& name, bool 
 {
     for (unsigned i = 0; i < resourceAbstractSources_.Size(); ++i)
     {
-        SharedPtr<AbstractFile> file(resourceAbstractSources_[i]->GetAbstractFile(name));
+        SharedPtr<AbstractFile> file(resourceAbstractSources_[i]->ProduceAbstractFile(name));
         if (file.NotNull())
             return file;
     }
@@ -839,6 +839,11 @@ String ResourceCache::GetResourceFileName(const String& name) const
 ResourceRouter* ResourceCache::GetResourceRouter(unsigned index) const
 {
     return index < resourceRouters_.Size() ? resourceRouters_[index] : nullptr;
+}
+
+ResourceAbstractSource* ResourceCache::GetResourceAbstractSource(unsigned index) const
+{
+    return index < resourceAbstractSources_.Size() ? resourceAbstractSources_[index] : nullptr;
 }
 
 String ResourceCache::GetPreferredResourceDir(const String& path) const

--- a/Source/Urho3D/Resource/ResourceCache.h
+++ b/Source/Urho3D/Resource/ResourceCache.h
@@ -81,7 +81,7 @@ public:
     virtual void Route(String& name, ResourceRequest requestType) = 0;
 };
 
-/// Optional resource abstract data source. Can produce AbstractFile objects for resource requests before the default filesystem access is used.
+/// Optional resource abstract data source. Can produce AbstractFile objects for resource loading before the default filesystem is used.
 class URHO3D_API ResourceAbstractSource : public Object
 {
     URHO3D_OBJECT(ResourceAbstractSource, Object);
@@ -96,7 +96,7 @@ public:
     virtual ~ResourceAbstractSource() {}
 
     /// Produce an AbstractFile object for deserializing data for a resource request. Return null to forward request to next abstract source or filesystem.
-    virtual SharedPtr<AbstractFile> GetAbstractFile(const String& name) = 0;
+    virtual SharedPtr<AbstractFile> ProduceAbstractFile(const String& name) = 0;
 };
 
 /// %Resource cache subsystem. Loads resources on demand and stores them for later access.
@@ -156,9 +156,9 @@ public:
     /// Remove a resource router object.
     void RemoveResourceRouter(ResourceRouter* router);
 
-    /// Add a resource abstract source object. By default there is none, so the routing process is skipped.
+    /// Add a resource abstract source object. By default there is none, so the the default filesystem is exclusively used for loading resources.
     void AddResourceAbstractSource(ResourceAbstractSource* abstractSource, bool addAsFirst = false);
-    /// Remove a resource router object.
+    /// Remove a resource abstract source object.
     void RemoveResourceAbstractSource(ResourceAbstractSource* abstractSource);
 
     /// Open and return a file from the resource load paths or from inside a package file. If not found, use a fallback search with absolute path. Return null if fails. Can be called from outside the main thread.
@@ -224,6 +224,8 @@ public:
 
     /// Return a resource router by index.
     ResourceRouter* GetResourceRouter(unsigned index) const;
+    /// Return a resource abstract source by index.
+    ResourceAbstractSource* GetResourceAbstractSource(unsigned index) const;
 
     /// Return either the path itself or its parent, based on which of them has recognized resource subdirectories.
     String GetPreferredResourceDir(const String& path) const;

--- a/Source/Urho3D/Resource/ResourceCache.h
+++ b/Source/Urho3D/Resource/ResourceCache.h
@@ -135,7 +135,7 @@ public:
     void RemoveResourceRouter(ResourceRouter* router);
 
     /// Open and return a file from the resource load paths or from inside a package file. If not found, use a fallback search with absolute path. Return null if fails. Can be called from outside the main thread.
-    SharedPtr<File> GetFile(const String& name, bool sendEventOnFailure = true);
+    virtual SharedPtr<File> GetFile(const String& name, bool sendEventOnFailure = true);
     /// Return a resource by type and name. Load if not loaded yet. Return null if not found or if fails, unless SetReturnFailedResources(true) has been called. Can be called only from the main thread.
     Resource* GetResource(StringHash type, const String& name, bool sendEventOnFailure = true);
     /// Load a resource without storing it in the resource cache. Return null if not found or if fails. Can be called from outside the main thread if the resource itself is safe to load completely (it does not possess for example GPU data.)

--- a/Source/Urho3D/Scene/Scene.cpp
+++ b/Source/Urho3D/Scene/Scene.cpp
@@ -306,7 +306,7 @@ bool Scene::SaveJSON(Serializer& dest, const String& indentation) const
         return false;
 }
 
-bool Scene::LoadAsync(File* file, LoadMode mode)
+bool Scene::LoadAsync(AbstractFile* file, LoadMode mode)
 {
     if (!file)
     {
@@ -379,7 +379,7 @@ bool Scene::LoadAsync(File* file, LoadMode mode)
     return true;
 }
 
-bool Scene::LoadAsyncXML(File* file, LoadMode mode)
+bool Scene::LoadAsyncXML(AbstractFile* file, LoadMode mode)
 {
     if (!file)
     {
@@ -448,7 +448,7 @@ bool Scene::LoadAsyncXML(File* file, LoadMode mode)
     return true;
 }
 
-bool Scene::LoadAsyncJSON(File* file, LoadMode mode)
+bool Scene::LoadAsyncJSON(AbstractFile* file, LoadMode mode)
 {
     if (!file)
     {
@@ -1289,7 +1289,7 @@ void Scene::FinishSaving(Serializer* dest) const
     }
 }
 
-void Scene::PreloadResources(File* file, bool isSceneFile)
+void Scene::PreloadResources(AbstractFile* file, bool isSceneFile)
 {
     // If not threaded, can not background load resources, so rather load synchronously later when needed
 #ifdef URHO3D_THREADING

--- a/Source/Urho3D/Scene/Scene.h
+++ b/Source/Urho3D/Scene/Scene.h
@@ -32,7 +32,7 @@
 namespace Urho3D
 {
 
-class File;
+class AbstractFile;
 class PackageFile;
 
 static const unsigned FIRST_REPLICATED_ID = 0x1;
@@ -55,7 +55,7 @@ enum LoadMode
 struct AsyncProgress
 {
     /// File for binary mode.
-    SharedPtr<File> file_;
+    SharedPtr<AbstractFile> file_;
     /// XML file for XML mode.
     SharedPtr<XMLFile> xmlFile_;
     /// JSON file for JSON mode
@@ -120,11 +120,11 @@ public:
     /// Save to a JSON file. Return true if successful.
     bool SaveJSON(Serializer& dest, const String& indentation = "\t") const;
     /// Load from a binary file asynchronously. Return true if started successfully. The LOAD_RESOURCES_ONLY mode can also be used to preload resources from object prefab files.
-    bool LoadAsync(File* file, LoadMode mode = LOAD_SCENE_AND_RESOURCES);
+    bool LoadAsync(AbstractFile* file, LoadMode mode = LOAD_SCENE_AND_RESOURCES);
     /// Load from an XML file asynchronously. Return true if started successfully. The LOAD_RESOURCES_ONLY mode can also be used to preload resources from object prefab files.
-    bool LoadAsyncXML(File* file, LoadMode mode = LOAD_SCENE_AND_RESOURCES);
+    bool LoadAsyncXML(AbstractFile* file, LoadMode mode = LOAD_SCENE_AND_RESOURCES);
     /// Load from a JSON file asynchronously. Return true if started successfully. The LOAD_RESOURCES_ONLY mode can also be used to preload resources from object prefab files.
-    bool LoadAsyncJSON(File* file, LoadMode mode = LOAD_SCENE_AND_RESOURCES);
+    bool LoadAsyncJSON(AbstractFile* file, LoadMode mode = LOAD_SCENE_AND_RESOURCES);
     /// Stop asynchronous loading.
     void StopAsyncLoading();
     /// Instantiate scene content from binary data. Return root node if successful.
@@ -270,7 +270,7 @@ private:
     /// Finish saving. Sets the scene filename and checksum.
     void FinishSaving(Serializer* dest) const;
     /// Preload resources from a binary scene or object prefab file.
-    void PreloadResources(File* file, bool isSceneFile);
+    void PreloadResources(AbstractFile* file, bool isSceneFile);
     /// Preload resources from an XML scene or object prefab file.
     void PreloadResourcesXML(const XMLElement& element);
     /// Preload resources from a JSON scene or object prefab file.

--- a/Source/Urho3D/UI/FontFaceBitmap.cpp
+++ b/Source/Urho3D/UI/FontFaceBitmap.cpp
@@ -100,7 +100,7 @@ bool FontFaceBitmap::Load(const unsigned char* fontData, unsigned fontDataSize, 
         String textureFile = fontPath + pageElem.GetAttribute("file");
 
         // Load texture manually to allow controlling the alpha channel mode
-        SharedPtr<File> fontFile = resourceCache->GetFile(textureFile);
+        SharedPtr<AbstractFile> fontFile = resourceCache->GetAbstractFile(textureFile);
         SharedPtr<Image> fontImage(new Image(context));
         if (!fontFile || !fontImage->Load(*fontFile))
         {

--- a/Source/Urho3D/Urho2D/AnimationSet2D.cpp
+++ b/Source/Urho3D/Urho2D/AnimationSet2D.cpp
@@ -84,7 +84,7 @@ char* _spUtil_readFile(const char* path, int* length)
         return 0;
 
     ResourceCache* cache = currentAnimationSet->GetSubsystem<ResourceCache>();
-    SharedPtr<File> file = cache->GetFile(path);
+    SharedPtr<AbstractFile> file = cache->GetAbstractFile(path);
     if (!file)
         return 0;
 

--- a/Source/Urho3D/Urho2D/TmxFile2D.cpp
+++ b/Source/Urho3D/Urho2D/TmxFile2D.cpp
@@ -593,7 +593,7 @@ const TmxLayer2D* TmxFile2D::GetLayer(unsigned index) const
 SharedPtr<XMLFile> TmxFile2D::LoadTSXFile(const String& source)
 {
     String tsxFilePath = GetParentPath(GetName()) + source;
-    SharedPtr<File> tsxFile = GetSubsystem<ResourceCache>()->GetFile(tsxFilePath);
+    SharedPtr<AbstractFile> tsxFile = GetSubsystem<ResourceCache>()->GetAbstractFile(tsxFilePath);
     SharedPtr<XMLFile> tsxXMLFile(new XMLFile(context_));
     if (!tsxFile || !tsxXMLFile->Load(*tsxFile))
     {


### PR DESCRIPTION
This is the first time I've ever tried to make a pull request on anything... please let me know if I did it wrong.

For a while I've wished that I could abstract the I/O part of resource loading, so I could potentially load resources from a memory buffer, a network request, etc... These are some minimal, non-API-breaking changes that allow someone to do this by subclassing both File and ResourceCache.