### PR TITLE
File Abstraction

### DIFF
--- a/Source/Samples/11_Physics/Physics.cpp
+++ b/Source/Samples/11_Physics/Physics.cpp
@@ -33,7 +33,7 @@
 #include <Urho3D/Graphics/Skybox.h>
 #include <Urho3D/Graphics/Zone.h>
 #include <Urho3D/Input/Input.h>
-#include <Urho3D/IO/File.h>
+#include <Urho3D/IO/SystemFile.h>
 #include <Urho3D/IO/FileSystem.h>
 #include <Urho3D/Physics/CollisionShape.h>
 #include <Urho3D/Physics/PhysicsWorld.h>
@@ -255,12 +255,12 @@ void Physics::MoveCamera(float timeStep)
     // directory
     if (input->GetKeyPress(KEY_F5))
     {
-        File saveFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/Physics.xml", FILE_WRITE);
+        SystemFile saveFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/Physics.xml", FILE_WRITE);
         scene_->SaveXML(saveFile);
     }
     if (input->GetKeyPress(KEY_F7))
     {
-        File loadFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/Physics.xml", FILE_READ);
+        SystemFile loadFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/Physics.xml", FILE_READ);
         scene_->LoadXML(loadFile);
     }
 

--- a/Source/Samples/12_PhysicsStressTest/PhysicsStressTest.cpp
+++ b/Source/Samples/12_PhysicsStressTest/PhysicsStressTest.cpp
@@ -33,7 +33,7 @@
 #include <Urho3D/Graphics/StaticModel.h>
 #include <Urho3D/Graphics/Zone.h>
 #include <Urho3D/Input/Input.h>
-#include <Urho3D/IO/File.h>
+#include <Urho3D/IO/SystemFile.h>
 #include <Urho3D/IO/FileSystem.h>
 #include <Urho3D/Physics/CollisionShape.h>
 #include <Urho3D/Physics/PhysicsWorld.h>
@@ -260,12 +260,12 @@ void PhysicsStressTest::MoveCamera(float timeStep)
     // Check for loading / saving the scene
     if (input->GetKeyPress(KEY_F5))
     {
-        File saveFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/PhysicsStressTest.xml", FILE_WRITE);
+        SystemFile saveFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/PhysicsStressTest.xml", FILE_WRITE);
         scene_->SaveXML(saveFile);
     }
     if (input->GetKeyPress(KEY_F7))
     {
-        File loadFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/PhysicsStressTest.xml", FILE_READ);
+        SystemFile loadFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/PhysicsStressTest.xml", FILE_READ);
         scene_->LoadXML(loadFile);
     }
 

--- a/Source/Samples/13_Ragdolls/Ragdolls.cpp
+++ b/Source/Samples/13_Ragdolls/Ragdolls.cpp
@@ -32,7 +32,7 @@
 #include <Urho3D/Graphics/Renderer.h>
 #include <Urho3D/Graphics/Zone.h>
 #include <Urho3D/Input/Input.h>
-#include <Urho3D/IO/File.h>
+#include <Urho3D/IO/SystemFile.h>
 #include <Urho3D/IO/FileSystem.h>
 #include <Urho3D/Physics/CollisionShape.h>
 #include <Urho3D/Physics/PhysicsWorld.h>
@@ -245,12 +245,12 @@ void Ragdolls::MoveCamera(float timeStep)
     // Check for loading / saving the scene
     if (input->GetKeyPress(KEY_F5))
     {
-        File saveFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/Ragdolls.xml", FILE_WRITE);
+        SystemFile saveFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/Ragdolls.xml", FILE_WRITE);
         scene_->SaveXML(saveFile);
     }
     if (input->GetKeyPress(KEY_F7))
     {
-        File loadFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/Ragdolls.xml", FILE_READ);
+        SystemFile loadFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/Ragdolls.xml", FILE_READ);
         scene_->LoadXML(loadFile);
     }
 

--- a/Source/Samples/18_CharacterDemo/CharacterDemo.cpp
+++ b/Source/Samples/18_CharacterDemo/CharacterDemo.cpp
@@ -33,6 +33,7 @@
 #include <Urho3D/Graphics/Zone.h>
 #include <Urho3D/Input/Controls.h>
 #include <Urho3D/Input/Input.h>
+#include <Urho3D/IO/SystemFile.h>
 #include <Urho3D/IO/FileSystem.h>
 #include <Urho3D/Physics/CollisionShape.h>
 #include <Urho3D/Physics/PhysicsWorld.h>
@@ -324,12 +325,12 @@ void CharacterDemo::HandleUpdate(StringHash eventType, VariantMap& eventData)
             // Check for loading / saving the scene
             if (input->GetKeyPress(KEY_F5))
             {
-                File saveFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/CharacterDemo.xml", FILE_WRITE);
+                SystemFile saveFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/CharacterDemo.xml", FILE_WRITE);
                 scene_->SaveXML(saveFile);
             }
             if (input->GetKeyPress(KEY_F7))
             {
-                File loadFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/CharacterDemo.xml", FILE_READ);
+                SystemFile loadFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/CharacterDemo.xml", FILE_READ);
                 scene_->LoadXML(loadFile);
                 // After loading we have to reacquire the weak pointer to the Character component, as it has been recreated
                 // Simply find the character's scene node by name as there's only one of them

--- a/Source/Samples/19_VehicleDemo/VehicleDemo.cpp
+++ b/Source/Samples/19_VehicleDemo/VehicleDemo.cpp
@@ -249,13 +249,13 @@ void VehicleDemo::HandleUpdate(StringHash eventType, VariantMap& eventData)
             // Check for loading / saving the scene
             if (input->GetKeyPress(KEY_F5))
             {
-                File saveFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/VehicleDemo.xml",
+                SystemFile saveFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/VehicleDemo.xml",
                     FILE_WRITE);
                 scene_->SaveXML(saveFile);
             }
             if (input->GetKeyPress(KEY_F7))
             {
-                File loadFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/VehicleDemo.xml", FILE_READ);
+                SystemFile loadFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/VehicleDemo.xml", FILE_READ);
                 scene_->LoadXML(loadFile);
                 // After loading we have to reacquire the weak pointer to the Vehicle component, as it has been recreated
                 // Simply find the vehicle's scene node by name as there's only one of them

--- a/Source/Samples/21_AngelScriptIntegration/AngelScriptIntegration.cpp
+++ b/Source/Samples/21_AngelScriptIntegration/AngelScriptIntegration.cpp
@@ -21,7 +21,7 @@
 //
 
 #include <Urho3D/AngelScript/Script.h>
-#include <Urho3D/AngelScript/ScriptSystemFile.h>
+#include <Urho3D/AngelScript/ScriptFile.h>
 #include <Urho3D/AngelScript/ScriptInstance.h>
 #include <Urho3D/Core/CoreEvents.h>
 #include <Urho3D/Engine/Engine.h>

--- a/Source/Samples/21_AngelScriptIntegration/AngelScriptIntegration.cpp
+++ b/Source/Samples/21_AngelScriptIntegration/AngelScriptIntegration.cpp
@@ -21,7 +21,7 @@
 //
 
 #include <Urho3D/AngelScript/Script.h>
-#include <Urho3D/AngelScript/ScriptFile.h>
+#include <Urho3D/AngelScript/ScriptSystemFile.h>
 #include <Urho3D/AngelScript/ScriptInstance.h>
 #include <Urho3D/Core/CoreEvents.h>
 #include <Urho3D/Engine/Engine.h>

--- a/Source/Samples/22_LuaIntegration/LuaIntegration.cpp
+++ b/Source/Samples/22_LuaIntegration/LuaIntegration.cpp
@@ -31,7 +31,7 @@
 #include <Urho3D/Graphics/StaticModel.h>
 #include <Urho3D/Graphics/Zone.h>
 #include <Urho3D/Input/Input.h>
-#include <Urho3D/LuaScript/LuaFile.h>
+#include <Urho3D/LuaScript/LuaSystemFile.h>
 #include <Urho3D/LuaScript/LuaFunction.h>
 #include <Urho3D/LuaScript/LuaScript.h>
 #include <Urho3D/LuaScript/LuaScriptInstance.h>

--- a/Source/Samples/23_Water/Water.cpp
+++ b/Source/Samples/23_Water/Water.cpp
@@ -35,7 +35,7 @@
 #include <Urho3D/Graphics/Texture2D.h>
 #include <Urho3D/Graphics/Zone.h>
 #include <Urho3D/Input/Input.h>
-#include <Urho3D/IO/File.h>
+#include <Urho3D/IO/SystemFile.h>
 #include <Urho3D/IO/FileSystem.h>
 #include <Urho3D/Resource/ResourceCache.h>
 #include <Urho3D/Scene/Scene.h>

--- a/Source/Samples/32_Urho2DConstraints/Urho2DConstraints.cpp
+++ b/Source/Samples/32_Urho2DConstraints/Urho2DConstraints.cpp
@@ -495,7 +495,7 @@ void Urho2DConstraints::HandleUpdate(StringHash eventType, VariantMap& eventData
     // Save scene
     if (input->GetKeyPress(KEY_F5))
     {
-        File saveFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/Constraints.xml", FILE_WRITE);
+        SystemFile saveFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/Constraints.xml", FILE_WRITE);
         scene_->SaveXML(saveFile);
     }
 }

--- a/Source/Samples/39_CrowdNavigation/CrowdNavigation.cpp
+++ b/Source/Samples/39_CrowdNavigation/CrowdNavigation.cpp
@@ -456,12 +456,12 @@ void CrowdNavigation::MoveCamera(float timeStep)
     // Check for loading/saving the scene from/to the file Data/Scenes/CrowdNavigation.xml relative to the executable directory
     if (input->GetKeyPress(KEY_F5))
     {
-        File saveFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/CrowdNavigation.xml", FILE_WRITE);
+        SystemFile saveFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/CrowdNavigation.xml", FILE_WRITE);
         scene_->SaveXML(saveFile);
     }
     else if (input->GetKeyPress(KEY_F7))
     {
-        File loadFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/CrowdNavigation.xml", FILE_READ);
+        SystemFile loadFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/CrowdNavigation.xml", FILE_READ);
         scene_->LoadXML(loadFile);
     }
 

--- a/Source/Samples/46_RaycastVehicle/RaycastVehicleDemo.cpp
+++ b/Source/Samples/46_RaycastVehicle/RaycastVehicleDemo.cpp
@@ -232,13 +232,13 @@ void RaycastVehicleDemo::HandleUpdate(StringHash eventType,
             // Check for loading / saving the scene
             if (input->GetKeyPress(KEY_F5))
             {
-                File saveFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/RaycastVehicleDemo.xml", 
+                SystemFile saveFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/RaycastVehicleDemo.xml", 
                               FILE_WRITE);
                 scene_->SaveXML(saveFile);
             }
             if (input->GetKeyPress(KEY_F7))
             {
-                File loadFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/RaycastVehicleDemo.xml",
+                SystemFile loadFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/RaycastVehicleDemo.xml",
                               FILE_READ);
                 scene_->LoadXML(loadFile);
                 // After loading we have to reacquire the weak pointer to the Vehicle component, as it has been recreated

--- a/Source/Samples/49_Urho2DIsometricDemo/Urho2DIsometricDemo.cpp
+++ b/Source/Samples/49_Urho2DIsometricDemo/Urho2DIsometricDemo.cpp
@@ -297,7 +297,7 @@ void Urho2DIsometricDemo::ReloadScene(bool reInit)
     if (!reInit)
         filename += "InGame";
 
-    File loadFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/" + filename + ".xml", FILE_READ);
+    SystemFile loadFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/" + filename + ".xml", FILE_READ);
     scene_->LoadXML(loadFile);
     // After loading we have to reacquire the weak pointer to the Character2D component, as it has been recreated
     // Simply find the character's scene node by name as there's only one of them

--- a/Source/Samples/50_Urho2DPlatformer/Urho2DPlatformer.cpp
+++ b/Source/Samples/50_Urho2DPlatformer/Urho2DPlatformer.cpp
@@ -393,7 +393,7 @@ void Urho2DPlatformer::ReloadScene(bool reInit)
     if (!reInit)
         filename += "InGame";
 
-    File loadFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/" + filename + ".xml", FILE_READ);
+    SystemFile loadFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/" + filename + ".xml", FILE_READ);
     scene_->LoadXML(loadFile);
     // After loading we have to reacquire the weak pointer to the Character2D component, as it has been recreated
     // Simply find the character's scene node by name as there's only one of them

--- a/Source/Samples/Utilities2D/Sample2D.cpp
+++ b/Source/Samples/Utilities2D/Sample2D.cpp
@@ -34,7 +34,7 @@
 #include <Urho3D/Core/Context.h>
 #include <Urho3D/Core/CoreEvents.h>
 #include <Urho3D/Engine/Engine.h>
-#include <Urho3D/IO/File.h>
+#include <Urho3D/IO/SystemFile.h>
 #include <Urho3D/IO/FileSystem.h>
 #include <Urho3D/UI/Font.h>
 #include <Urho3D/Input/Input.h>
@@ -497,7 +497,7 @@ void Sample2D::SaveScene(bool initial)
     String filename = demoFilename_;
     if (!initial)
         filename += "InGame";
-    File saveFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/" + filename + ".xml", FILE_WRITE);
+    SystemFile saveFile(context_, GetSubsystem<FileSystem>()->GetProgramDir() + "Data/Scenes/" + filename + ".xml", FILE_WRITE);
     scene_->SaveXML(saveFile);
 }
 

--- a/Source/Samples/Utilities2D/Sample2D.h
+++ b/Source/Samples/Utilities2D/Sample2D.h
@@ -107,7 +107,7 @@ public:
     /// Play a non-looping sound effect.
     void PlaySoundEffect(String soundName);
 
-    /// Filename used in load/save functions.
+    /// SystemFilename used in load/save functions.
     String demoFilename_;
     /// The scene.
     Scene* scene_;

--- a/Source/Tools/AssetImporter/AssetImporter.cpp
+++ b/Source/Tools/AssetImporter/AssetImporter.cpp
@@ -1225,7 +1225,7 @@ void BuildAndSaveModel(OutModel& model)
             outModel->SetGeometryBoneMappings(allBoneMappings);
     }
 
-    File outFile(context_);
+    SystemFile outFile(context_);
     if (!outFile.Open(model.outName_, FILE_WRITE))
         ErrorExit("Could not open output file " + model.outName_);
     outModel->Save(outFile);
@@ -1234,7 +1234,7 @@ void BuildAndSaveModel(OutModel& model)
     if (!noMaterials_ && saveMaterialList_)
     {
         String materialListName = ReplaceExtension(model.outName_, ".txt");
-        File listFile(context_);
+        SystemFile listFile(context_);
         if (listFile.Open(materialListName, FILE_WRITE))
         {
             for (unsigned i = 0; i < model.meshes_.Size(); ++i)
@@ -1486,7 +1486,7 @@ void BuildAndSaveAnimations(OutModel* model)
             }
         }
 
-        File outFile(context_);
+        SystemFile outFile(context_);
         if (!outFile.Open(animOutName, FILE_WRITE))
             ErrorExit("Could not open output file " + animOutName);
         outAnim->Save(outFile);
@@ -1782,7 +1782,7 @@ void BuildAndSaveScene(OutScene& scene, bool asPrefab)
         }
     }
 
-    File file(context_);
+    SystemFile file(context_);
     if (!file.Open(scene.outName_, FILE_WRITE))
         ErrorExit("Could not open output file " + scene.outName_);
     if (!asPrefab)
@@ -1966,7 +1966,7 @@ void BuildAndSaveMaterial(aiMaterial* material, HashSet<String>& usedTextures)
 
     PrintLine("Writing material " + matName);
 
-    File outFile(context_);
+    SystemFile outFile(context_);
     if (!outFile.Open(outFileName, FILE_WRITE))
         ErrorExit("Could not open output file " + outFileName);
     outMaterial.Save(outFile);
@@ -2001,7 +2001,7 @@ void CopyTextures(const HashSet<String>& usedTextures, const String& sourcePath)
                 if (!tex->mHeight)
                 {
                     PrintLine("Saving embedded texture " + GetFileNameAndExtension(fullDestName));
-                    File dest(context_, fullDestName, FILE_WRITE);
+                    SystemFile dest(context_, fullDestName, FILE_WRITE);
                     dest.Write((const void*)tex->pcData, tex->mWidth);
                 }
                 // RGBA8 texture
@@ -2026,7 +2026,7 @@ void CopyTextures(const HashSet<String>& usedTextures, const String& sourcePath)
                 continue;
             }
             {
-                File test(context_, fullSourceName);
+                SystemFile test(context_, fullSourceName);
                 if (!test.GetSize())
                 {
                     PrintLine("Skipping copy of zero-size material texture " + *i);
@@ -2060,7 +2060,7 @@ void CombineLods(const PODVector<float>& lodDistances, const Vector<String>& mod
     for (unsigned i = 0; i < modelNames.Size(); ++i)
     {
         PrintLine("Reading LOD level " + String(i) + ": model " + modelNames[i] + " distance " + String(lodDistances[i]));
-        File srcFile(context_);
+        SystemFile srcFile(context_);
         srcFile.Open(modelNames[i]);
         SharedPtr<Model> srcModel(new Model(context_));
         if (!srcModel->Load(srcFile))
@@ -2137,7 +2137,7 @@ void CombineLods(const PODVector<float>& lodDistances, const Vector<String>& mod
 
     // Save the final model
     PrintLine("Writing output model");
-    File outFile(context_);
+    SystemFile outFile(context_);
     if (!outFile.Open(outName, FILE_WRITE))
         ErrorExit("Could not open output file " + outName);
     outModel->Save(outFile);

--- a/Source/Tools/OgreImporter/OgreImporter.cpp
+++ b/Source/Tools/OgreImporter/OgreImporter.cpp
@@ -24,7 +24,7 @@
 #include <Urho3D/Core/ProcessUtils.h>
 #include <Urho3D/Core/StringUtils.h>
 #include <Urho3D/Graphics/Tangent.h>
-#include <Urho3D/IO/File.h>
+#include <Urho3D/IO/SystemFile.h>
 #include <Urho3D/IO/FileSystem.h>
 #include <Urho3D/Resource/XMLFile.h>
 
@@ -150,7 +150,7 @@ void LoadSkeleton(const String& skeletonFileName)
 {
     // Process skeleton first (if found)
     XMLElement skeletonRoot;
-    File skeletonFileSource(context_);
+    SystemFile skeletonFileSource(context_);
     skeletonFileSource.Open(skeletonFileName);
     if (!skelFile_->Load(skeletonFileSource))
         PrintLine("Failed to load skeleton " + skeletonFileName);
@@ -247,7 +247,7 @@ void LoadSkeleton(const String& skeletonFileName)
 
 void LoadMesh(const String& inputFileName, bool generateTangents, bool splitSubMeshes, bool exportMorphs)
 {
-    File meshFileSource(context_);
+    SystemFile meshFileSource(context_);
     meshFileSource.Open(inputFileName);
     if (!meshFile_->Load(meshFileSource))
         ErrorExit("Could not load input file " + inputFileName);
@@ -851,7 +851,7 @@ void WriteOutput(const String& outputFileName, bool exportAnimations, bool rotat
 
     // Begin serialization
     {
-        File dest(context_);
+        SystemFile dest(context_);
         if (!dest.Open(outputFileName, FILE_WRITE))
             ErrorExit("Could not open output file " + outputFileName);
 
@@ -927,7 +927,7 @@ void WriteOutput(const String& outputFileName, bool exportAnimations, bool rotat
     if (saveMaterialList)
     {
         String materialListName = ReplaceExtension(outputFileName, ".txt");
-        File listFile(context_);
+        SystemFile listFile(context_);
         if (listFile.Open(materialListName, FILE_WRITE))
         {
             for (unsigned i = 0; i < materialNames_.Size(); ++i)
@@ -1026,7 +1026,7 @@ void WriteOutput(const String& outputFileName, bool exportAnimations, bool rotat
                 String animationFileName = outputFileName.Replaced(".mdl", "");
                 animationFileName += "_" + newAnimation.name_ + ".ani";
 
-                File dest(context_);
+                SystemFile dest(context_);
                 if (!dest.Open(animationFileName, FILE_WRITE))
                     ErrorExit("Could not open output file " + animationFileName);
 

--- a/Source/Tools/PackageTool/PackageTool.cpp
+++ b/Source/Tools/PackageTool/PackageTool.cpp
@@ -23,7 +23,7 @@
 #include <Urho3D/Core/Context.h>
 #include <Urho3D/Container/ArrayPtr.h>
 #include <Urho3D/Core/ProcessUtils.h>
-#include <Urho3D/IO/File.h>
+#include <Urho3D/IO/SystemFile.h>
 #include <Urho3D/IO/FileSystem.h>
 #include <Urho3D/IO/PackageFile.h>
 
@@ -67,7 +67,7 @@ int main(int argc, char** argv);
 void Run(const Vector<String>& arguments);
 void ProcessFile(const String& fileName, const String& rootDir);
 void WritePackageFile(const String& fileName, const String& rootDir);
-void WriteHeader(File& dest);
+void WriteHeader(SystemFile& dest);
 
 int main(int argc, char** argv)
 {
@@ -206,7 +206,7 @@ void Run(const Vector<String>& arguments)
 void ProcessFile(const String& fileName, const String& rootDir)
 {
     String fullPath = rootDir + "/" + fileName;
-    File file(context_);
+    SystemFile file(context_);
     if (!file.Open(fullPath))
         ErrorExit("Could not open file " + fileName);
     if (!file.GetSize())
@@ -225,7 +225,7 @@ void WritePackageFile(const String& fileName, const String& rootDir)
     if (!quiet_)
         PrintLine("Writing package");
 
-    File dest(context_);
+    SystemFile dest(context_);
     if (!dest.Open(fileName, FILE_WRITE))
         ErrorExit("Could not open output file " + fileName);
 
@@ -250,7 +250,7 @@ void WritePackageFile(const String& fileName, const String& rootDir)
         lastOffset = entries_[i].offset_ = dest.GetSize();
         String fileFullPath = rootDir + "/" + entries_[i].name_;
 
-        File srcFile(context_, fileFullPath);
+        SystemFile srcFile(context_, fileFullPath);
         if (!srcFile.IsOpen())
             ErrorExit("Could not open file " + fileFullPath);
 
@@ -334,7 +334,7 @@ void WritePackageFile(const String& fileName, const String& rootDir)
     }
 }
 
-void WriteHeader(File& dest)
+void WriteHeader(SystemFile& dest)
 {
     if (!compress_)
         dest.WriteFileID("UPAK");

--- a/Source/Tools/RampGenerator/RampGenerator.cpp
+++ b/Source/Tools/RampGenerator/RampGenerator.cpp
@@ -22,7 +22,7 @@
 
 #include <Urho3D/Container/ArrayPtr.h>
 #include <Urho3D/Core/Context.h>
-#include <Urho3D/IO/File.h>
+#include <Urho3D/IO/SystemFile.h>
 #include <Urho3D/IO/FileSystem.h>
 #include <Urho3D/Core/ProcessUtils.h>
 #include <Urho3D/Core/StringUtils.h>
@@ -92,7 +92,7 @@ void Run(const Vector<String>& arguments)
         const int height = dim == 2 ? width : 1;
 
         Context context;
-        File file(&context);
+        SystemFile file(&context);
         file.Open(inputFile);
 
         PODVector<float> horizontal;

--- a/Source/Tools/ScriptCompiler/ScriptCompiler.cpp
+++ b/Source/Tools/ScriptCompiler/ScriptCompiler.cpp
@@ -26,7 +26,7 @@
 #include <Urho3D/Core/ProcessUtils.h>
 #include <Urho3D/Engine/Engine.h>
 #include <Urho3D/Engine/EngineDefs.h>
-#include <Urho3D/IO/File.h>
+#include <Urho3D/IO/SystemFile.h>
 #include <Urho3D/IO/FileSystem.h>
 #include <Urho3D/IO/Log.h>
 #include <Urho3D/Resource/ResourceCache.h>
@@ -157,7 +157,7 @@ void CompileScript(Context* context, const String& fileName)
 {
     PrintLine("Compiling script file " + fileName);
 
-    File inFile(context, fileName, FILE_READ);
+    SystemFile inFile(context, fileName, FILE_READ);
     if (!inFile.IsOpen())
         ErrorExit("Failed to open script file " + fileName);
 
@@ -166,7 +166,7 @@ void CompileScript(Context* context, const String& fileName)
         ErrorExit();
 
     String outFileName = ReplaceExtension(fileName, ".asc");
-    File outFile(context, outFileName, FILE_WRITE);
+    SystemFile outFile(context, outFileName, FILE_WRITE);
     if (!outFile.IsOpen())
         ErrorExit("Failed to open output file " + fileName);
 

--- a/Source/Tools/SpritePacker/SpritePacker.cpp
+++ b/Source/Tools/SpritePacker/SpritePacker.cpp
@@ -23,7 +23,7 @@
 #include <Urho3D/Core/Context.h>
 #include <Urho3D/Core/ProcessUtils.h>
 #include <Urho3D/Core/StringUtils.h>
-#include <Urho3D/IO/File.h>
+#include <Urho3D/IO/SystemFile.h>
 #include <Urho3D/IO/FileSystem.h>
 #include <Urho3D/IO/Log.h>
 #include <Urho3D/Resource/Image.h>
@@ -203,7 +203,7 @@ void Run(Vector<String>& arguments)
     {
         String path = inputFiles[i];
         String name = ReplaceExtension(GetFileName(path), "");
-        File file(context, path);
+        SystemFile file(context, path);
         Image image(context);
 
         if (!image.Load(file))
@@ -364,7 +364,7 @@ void Run(Vector<String>& arguments)
 
         URHO3D_LOGINFO("Transferring " + packerInfo->path + " to sprite sheet.");
 
-        File file(context, packerInfo->path);
+        SystemFile file(context, packerInfo->path);
         Image image(context);
         if (!image.Load(file))
             ErrorExit("Could not load image " + packerInfo->path + ".");
@@ -421,7 +421,7 @@ void Run(Vector<String>& arguments)
     spriteSheetImage.SavePNG(outputFile);
 
     URHO3D_LOGINFO("Saving SpriteSheet xml file.");
-    File spriteSheetFile(context);
+    SystemFile spriteSheetFile(context);
     spriteSheetFile.Open(spriteSheetFileName, FILE_WRITE);
     xml.Save(spriteSheetFile);
 }

--- a/Source/Tools/Urho3DPlayer/Urho3DPlayer.cpp
+++ b/Source/Tools/Urho3DPlayer/Urho3DPlayer.cpp
@@ -27,6 +27,7 @@
 #include <Urho3D/Core/Main.h>
 #include <Urho3D/Engine/Engine.h>
 #include <Urho3D/Engine/EngineDefs.h>
+#include <Urho3D/IO/SystemFile.h>
 #include <Urho3D/IO/FileSystem.h>
 #include <Urho3D/IO/Log.h>
 #ifdef URHO3D_LUA
@@ -59,7 +60,7 @@ void Urho3DPlayer::Setup()
     const String commandFileName = filesystem->GetProgramDir() + "Data/CommandLine.txt";
     if (GetArguments().Empty() && filesystem->FileExists(commandFileName))
     {
-        SharedPtr<File> commandFile(new File(context_, commandFileName));
+        SharedPtr<File> commandFile(new SystemFile(context_, commandFileName));
         if (commandFile->IsOpen())
         {
             commandLineRead_ = true;

--- a/Source/Urho3D/AngelScript/APITemplates.h
+++ b/Source/Urho3D/AngelScript/APITemplates.h
@@ -823,28 +823,20 @@ template <class T> void RegisterFileConstructors(asIScriptEngine* engine, const 
 template <class T> void RegisterFile(asIScriptEngine* engine, const char* className)
 {
     RegisterObject<T>(engine, className);
-    // Do not register factory for the base class. Done with template specialization.
-//    if (strcmp("File", className))
-//    {
-        RegisterSubclass<File, T>(engine, "File", className);
-        RegisterObjectConstructor<T>(engine, className);
-        RegisterFileConstructors<T>(engine, className);
-//    }
-//    RegisterObject<File>(engine, "File");
-//    engine->RegisterObjectBehaviour("File", asBEHAVE_FACTORY, "File@+ f()", asFUNCTION(ConstructFile), asCALL_CDECL);
-//    engine->RegisterObjectBehaviour("File", asBEHAVE_FACTORY, "File@+ f(const String&in, FileMode mode = FILE_READ)", asFUNCTION(ConstructFileAndOpen), asCALL_CDECL);
+    RegisterSubclass<File, T>(engine, "File", className);
+    RegisterObjectConstructor<T>(engine, className);
+    RegisterFileConstructors<T>(engine, className);
     engine->RegisterObjectMethod(className, "bool Open(const String&in, FileMode mode = FILE_READ)", asMETHODPR(File, Open, (const String&, FileMode), bool), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "bool Open(FileSource@+, const String&in, FileMode mode = FILE_READ)", asMETHODPR(T, Open, (FileSource*, const String&, FileMode), bool), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "void Close()", asMETHOD(T, Close), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "void Flush()", asMETHOD(T, Flush), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "FileMode get_mode() const", asMETHOD(T, GetMode), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "bool get_open()", asMETHOD(T, IsOpen), asCALL_THISCALL);
-//    engine->RegisterObjectMethod(className, "bool get_packaged()", asMETHOD(T, IsPackaged), asCALL_THISCALL); Removed
     RegisterSerializer<T>(engine, className);
     RegisterDeserializer<T>(engine, className);
 }
 
-/// Template function for registering a class derived from File.
+/// Template specialization for registering the File class (because it cannot be constructed).
 template <> void RegisterFile<File>(asIScriptEngine* engine, const char* className);
 
 
@@ -869,17 +861,10 @@ static const CScriptArray* FileSourceGetEntryNames(FileSource* fileSource)
 template <class T> void RegisterFileSource(asIScriptEngine* engine, const char* className)
 {
     RegisterObject<T>(engine, className);
-    // Do not register factory for the base class
-//    if (strcmp("FileSource", className))
-//    {
-        RegisterSubclass<File, T>(engine, "FileSource", className);
-        RegisterObjectConstructor<T>(engine, className);
-        //Cannot use RegisterNamedObjectConstructor as SetName is not public
-        RegisterFileSourceConstructor<T>(engine, className);
-//    }
-//    RegisterObject<FileSource>(engine, className);
-//    engine->RegisterObjectBehaviour(className, asBEHAVE_FACTORY, "PackageFile@+ f()", asFUNCTION(ConstructPackageFile), asCALL_CDECL);
-// NOT GENERAL    engine->RegisterObjectBehaviour(className, asBEHAVE_FACTORY, "PackageFile@+ f(const String&in, uint startOffset = 0)", asFUNCTION(ConstructAndOpenPackageFile), asCALL_CDECL);
+    RegisterSubclass<File, T>(engine, "FileSource", className);
+    RegisterObjectConstructor<T>(engine, className);
+    //Cannot use RegisterNamedObjectConstructor as SetName is not public
+    RegisterFileSourceConstructor<T>(engine, className);
     engine->RegisterObjectMethod(className, "bool Open(const String&in) const", asMETHODPR(T, Open, (const String&), bool), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "bool Exists(const String&in) const", asMETHOD(T, Exists), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "File@+ GetFile(const String&in, FileMode mode)", asMETHOD(T, GetFile), asCALL_THISCALL);

--- a/Source/Urho3D/AngelScript/APITemplates.h
+++ b/Source/Urho3D/AngelScript/APITemplates.h
@@ -33,6 +33,7 @@
 #include "../Graphics/StaticModel.h"
 #include "../Graphics/Texture.h"
 #include "../IO/File.h"
+#include "../IO/FileSource.h"
 #include "../IO/Log.h"
 #include "../IO/VectorBuffer.h"
 #include "../Resource/Resource.h"
@@ -796,6 +797,104 @@ template <class T> void RegisterNode(asIScriptEngine* engine, const char* classN
     engine->RegisterObjectMethod(className, "Node@+ get_parent() const", asMETHOD(T, GetParent), asCALL_THISCALL);
     engine->RegisterObjectMethod(className, "VariantMap& get_vars()", asFUNCTION(NodeGetVars), asCALL_CDECL_OBJLAST);
 }
+
+template <class T> T* ConstructFileAndOpen(const String& fileName, FileMode mode)
+{
+    return new T(GetScriptContext(), fileName, mode);
+}
+
+template <class T> T* ConstructSourcedFileAndOpen(FileSource* source, const String& fileName, FileMode mode)
+{
+    return new T(GetScriptContext(), source, fileName, mode);
+}
+
+/// Template function for registering a named constructor for a class derived from Object.
+template <class T> void RegisterFileConstructors(asIScriptEngine* engine, const char* className)
+{
+    String declFactoryWithSource(String(className) + "@+ f(FileSource@+, const String&in, FileMode, FileMode mode = FILE_READ)");
+    engine->RegisterObjectBehaviour(className, asBEHAVE_FACTORY, declFactoryWithSource.CString(), asFUNCTION(ConstructSourcedFileAndOpen<T>), asCALL_CDECL);
+
+    String declFactoryWithName(String(className) + "@+ f(const String&in, FileMode, FileMode mode = FILE_READ)");
+    engine->RegisterObjectBehaviour(className, asBEHAVE_FACTORY, declFactoryWithName.CString(), asFUNCTION(ConstructFileAndOpen<T>), asCALL_CDECL);
+}
+
+
+/// Template function for registering a class derived from File.
+template <class T> void RegisterFile(asIScriptEngine* engine, const char* className)
+{
+    RegisterObject<T>(engine, className);
+    // Do not register factory for the base class. Done with template specialization.
+//    if (strcmp("File", className))
+//    {
+        RegisterSubclass<File, T>(engine, "File", className);
+        RegisterObjectConstructor<T>(engine, className);
+        RegisterFileConstructors<T>(engine, className);
+//    }
+//    RegisterObject<File>(engine, "File");
+//    engine->RegisterObjectBehaviour("File", asBEHAVE_FACTORY, "File@+ f()", asFUNCTION(ConstructFile), asCALL_CDECL);
+//    engine->RegisterObjectBehaviour("File", asBEHAVE_FACTORY, "File@+ f(const String&in, FileMode mode = FILE_READ)", asFUNCTION(ConstructFileAndOpen), asCALL_CDECL);
+    engine->RegisterObjectMethod(className, "bool Open(const String&in, FileMode mode = FILE_READ)", asMETHODPR(File, Open, (const String&, FileMode), bool), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "bool Open(FileSource@+, const String&in, FileMode mode = FILE_READ)", asMETHODPR(T, Open, (FileSource*, const String&, FileMode), bool), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "void Close()", asMETHOD(T, Close), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "void Flush()", asMETHOD(T, Flush), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "FileMode get_mode() const", asMETHOD(T, GetMode), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "bool get_open()", asMETHOD(T, IsOpen), asCALL_THISCALL);
+//    engine->RegisterObjectMethod(className, "bool get_packaged()", asMETHOD(T, IsPackaged), asCALL_THISCALL); Removed
+    RegisterSerializer<T>(engine, className);
+    RegisterDeserializer<T>(engine, className);
+}
+
+/// Template function for registering a class derived from File.
+template <> void RegisterFile<File>(asIScriptEngine* engine, const char* className);
+
+
+template <class T> T* ConstructAndOpenFileSource(const String& fileName)
+{
+    return new T(GetScriptContext(), fileName);
+}
+
+/// Template function for registering a named constructor for a class derived from Object.
+template <class T> void RegisterFileSourceConstructor(asIScriptEngine* engine, const char* className)
+{
+    String declFactoryWithName(String(className) + "@+ f(FileSource@+, const String&in, FileMode, FileMode mode = FILE_READ)");
+    engine->RegisterObjectBehaviour(className, asBEHAVE_FACTORY, declFactoryWithName.CString(), asFUNCTION(ConstructAndOpenFileSource<T>), asCALL_CDECL);
+}
+
+static const CScriptArray* FileSourceGetEntryNames(FileSource* fileSource)
+{
+    return VectorToArray<String>(fileSource->GetEntryNames(), "Array<String>");
+}
+
+/// Template function for registering a class derived from FileSource.
+template <class T> void RegisterFileSource(asIScriptEngine* engine, const char* className)
+{
+    RegisterObject<T>(engine, className);
+    // Do not register factory for the base class
+//    if (strcmp("FileSource", className))
+//    {
+        RegisterSubclass<File, T>(engine, "FileSource", className);
+        RegisterObjectConstructor<T>(engine, className);
+        //Cannot use RegisterNamedObjectConstructor as SetName is not public
+        RegisterFileSourceConstructor<T>(engine, className);
+//    }
+//    RegisterObject<FileSource>(engine, className);
+//    engine->RegisterObjectBehaviour(className, asBEHAVE_FACTORY, "PackageFile@+ f()", asFUNCTION(ConstructPackageFile), asCALL_CDECL);
+// NOT GENERAL    engine->RegisterObjectBehaviour(className, asBEHAVE_FACTORY, "PackageFile@+ f(const String&in, uint startOffset = 0)", asFUNCTION(ConstructAndOpenPackageFile), asCALL_CDECL);
+    engine->RegisterObjectMethod(className, "bool Open(const String&in) const", asMETHODPR(T, Open, (const String&), bool), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "bool Exists(const String&in) const", asMETHOD(T, Exists), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "File@+ GetFile(const String&in, FileMode mode)", asMETHOD(T, GetFile), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "const String& get_name() const", asMETHOD(T, GetName), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "uint get_numFiles() const", asMETHOD(T, GetNumFiles), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "uint get_totalSize() const", asMETHOD(T, GetTotalSize), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "uint get_totalDataSize() const", asMETHOD(T, GetTotalDataSize), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "uint get_checksum() const", asMETHOD(T, GetChecksum), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "bool compressed() const", asMETHOD(T, IsCompressed), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "Array<String>@ GetEntryNames() const", asFUNCTION(FileSourceGetEntryNames), asCALL_CDECL_OBJLAST);
+}
+
+
+/// Template specialization for registering the FileSource class (because it cannot be constructed).
+template <> void RegisterFileSource<FileSource>(asIScriptEngine* engine, const char* className);
 
 static bool ResourceLoad(File* file, Resource* ptr)
 {

--- a/Source/Urho3D/AngelScript/IOAPI.cpp
+++ b/Source/Urho3D/AngelScript/IOAPI.cpp
@@ -27,7 +27,7 @@
 #include "../IO/FileSystem.h"
 #include "../IO/NamedPipe.h"
 #include "../IO/PackageFile.h"
-#include "../IO/PhysicalFile.h"
+#include "../IO/SystemFile.h"
 
 namespace Urho3D
 {
@@ -186,13 +186,13 @@ static void RegisterLog(asIScriptEngine* engine)
 static File* ConstructFile()
 {
     // TODO: NEL: Fix File Script API
-    return new PhysicalFile(GetScriptContext());
+    return new SystemFile(GetScriptContext());
 }
 
 static File* ConstructFileAndOpen(const String& fileName, FileMode mode)
 {
     // TODO: NEL: Fix File Script API
-    return new PhysicalFile(GetScriptContext(), fileName, mode);
+    return new SystemFile(GetScriptContext(), fileName, mode);
 }
 
 static NamedPipe* ConstructNamedPipe()

--- a/Source/Urho3D/AngelScript/IOAPI.cpp
+++ b/Source/Urho3D/AngelScript/IOAPI.cpp
@@ -27,6 +27,7 @@
 #include "../IO/FileSystem.h"
 #include "../IO/NamedPipe.h"
 #include "../IO/PackageFile.h"
+#include "../IO/PhysicalFile.h"
 
 namespace Urho3D
 {
@@ -184,12 +185,14 @@ static void RegisterLog(asIScriptEngine* engine)
 
 static File* ConstructFile()
 {
-    return new File(GetScriptContext());
+    // TODO: NEL: Fix File Script API
+    return new PhysicalFile(GetScriptContext());
 }
 
 static File* ConstructFileAndOpen(const String& fileName, FileMode mode)
 {
-    return new File(GetScriptContext(), fileName, mode);
+    // TODO: NEL: Fix File Script API
+    return new PhysicalFile(GetScriptContext(), fileName, mode);
 }
 
 static NamedPipe* ConstructNamedPipe()

--- a/Source/Urho3D/AngelScript/IOAPI.cpp
+++ b/Source/Urho3D/AngelScript/IOAPI.cpp
@@ -294,6 +294,25 @@ static unsigned FileSystemSystemRunAsync(const String& fileName, CScriptArray* s
     return ptr->SystemRunAsync(fileName, destArguments);
 }
 
+/// Template function for registering a class derived from File.
+template <> void RegisterFile<File>(asIScriptEngine* engine, const char* className)
+{
+    RegisterObject<File>(engine, className);
+    // Do not register factory for the base class
+//    RegisterObject<File>(engine, "File");
+//    engine->RegisterObjectBehaviour("File", asBEHAVE_FACTORY, "File@+ f()", asFUNCTION(ConstructFile), asCALL_CDECL);
+//    engine->RegisterObjectBehaviour("File", asBEHAVE_FACTORY, "File@+ f(const String&in, FileMode mode = FILE_READ)", asFUNCTION(ConstructFileAndOpen), asCALL_CDECL);
+    engine->RegisterObjectMethod(className, "bool Open(const String&in, FileMode mode = FILE_READ)", asMETHODPR(File, Open, (const String&, FileMode), bool), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "bool Open(FileSource@+, const String&in, FileMode mode = FILE_READ)", asMETHODPR(File, Open, (FileSource*, const String&, FileMode), bool), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "void Close()", asMETHOD(File, Close), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "void Flush()", asMETHOD(File, Flush), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "FileMode get_mode() const", asMETHOD(File, GetMode), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "bool get_open()", asMETHOD(File, IsOpen), asCALL_THISCALL);
+//    engine->RegisterObjectMethod(className, "bool get_packaged()", asMETHOD(T, IsPackaged), asCALL_THISCALL); Removed
+    RegisterSerializer<File>(engine, className);
+    RegisterDeserializer<File>(engine, className);
+}
+
 static void RegisterSerialization(asIScriptEngine* engine)
 {
     engine->RegisterEnum("FileMode");
@@ -316,16 +335,22 @@ static void RegisterSerialization(asIScriptEngine* engine)
     engine->RegisterObjectBehaviour("Deserializer", asBEHAVE_RELEASE, "void f()", asFUNCTION(FakeReleaseRef), asCALL_CDECL_OBJLAST);
     RegisterDeserializer<Deserializer>(engine, "Deserializer");
 
-    RegisterObject<File>(engine, "File");
-    engine->RegisterObjectBehaviour("File", asBEHAVE_FACTORY, "File@+ f()", asFUNCTION(ConstructFile), asCALL_CDECL);
-    engine->RegisterObjectBehaviour("File", asBEHAVE_FACTORY, "File@+ f(const String&in, FileMode mode = FILE_READ)", asFUNCTION(ConstructFileAndOpen), asCALL_CDECL);
-    engine->RegisterObjectMethod("File", "bool Open(const String&in, FileMode mode = FILE_READ)", asMETHODPR(File, Open, (const String&, FileMode), bool), asCALL_THISCALL);
-    engine->RegisterObjectMethod("File", "void Close()", asMETHOD(File, Close), asCALL_THISCALL);
-    engine->RegisterObjectMethod("File", "FileMode get_mode() const", asMETHOD(File, GetMode), asCALL_THISCALL);
-    engine->RegisterObjectMethod("File", "bool get_open()", asMETHOD(File, IsOpen), asCALL_THISCALL);
-    engine->RegisterObjectMethod("File", "bool get_packaged()", asMETHOD(File, IsPackaged), asCALL_THISCALL);
-    RegisterSerializer<File>(engine, "File");
-    RegisterDeserializer<File>(engine, "File");
+    //Pre-register FileSource object as it is needed for File's Open
+    RegisterObject<FileSource>(engine, "FileSource");
+
+    RegisterFile<File>(engine, "File");
+    RegisterFile<SystemFile>(engine, "SystemFile");
+    RegisterFile<PackedFile>(engine, "PackedFile");
+//    RegisterObject<File>(engine, "File");
+//    engine->RegisterObjectBehaviour("File", asBEHAVE_FACTORY, "File@+ f()", asFUNCTION(ConstructFile), asCALL_CDECL);
+//    engine->RegisterObjectBehaviour("File", asBEHAVE_FACTORY, "File@+ f(const String&in, FileMode mode = FILE_READ)", asFUNCTION(ConstructFileAndOpen), asCALL_CDECL);
+//    engine->RegisterObjectMethod("File", "bool Open(const String&in, FileMode mode = FILE_READ)", asMETHODPR(File, Open, (const String&, FileMode), bool), asCALL_THISCALL);
+//    engine->RegisterObjectMethod("File", "void Close()", asMETHOD(File, Close), asCALL_THISCALL);
+//    engine->RegisterObjectMethod("File", "FileMode get_mode() const", asMETHOD(File, GetMode), asCALL_THISCALL);
+//    engine->RegisterObjectMethod("File", "bool get_open()", asMETHOD(File, IsOpen), asCALL_THISCALL);
+//    engine->RegisterObjectMethod("File", "bool get_packaged()", asMETHOD(File, IsPackaged), asCALL_THISCALL);
+//    RegisterSerializer<File>(engine, "File");
+//    RegisterDeserializer<File>(engine, "File");
 
     RegisterObject<NamedPipe>(engine, "NamedPipe");
     engine->RegisterObjectBehaviour("NamedPipe", asBEHAVE_FACTORY, "NamedPipe@+ f()", asFUNCTION(ConstructNamedPipe), asCALL_CDECL);
@@ -400,35 +425,60 @@ void RegisterFileSystem(asIScriptEngine* engine)
     engine->RegisterGlobalFunction("bool IsAbsolutePath(const String&in)", asFUNCTION(IsAbsolutePath), asCALL_CDECL);
 }
 
-static PackageFile* ConstructPackageFile()
-{
-    return new PackageFile(GetScriptContext());
-}
+//static PackageFile* ConstructPackageFile()
+//{
+//    return new PackageFile(GetScriptContext());
+//}
 
 static PackageFile* ConstructAndOpenPackageFile(const String& fileName, unsigned startOffset)
 {
     return new PackageFile(GetScriptContext(), fileName, startOffset);
 }
 
-static const CScriptArray* PackageFileGetEntryNames(PackageFile* packageFile)
+//static const CScriptArray* PackageFileGetEntryNames(PackageFile* packageFile)
+//{
+//    return VectorToArray<String>(packageFile->GetEntryNames(), "Array<String>");
+//}
+
+/// Template specialization for registering the FileSource class (because it cannot be constructed).
+template <> void RegisterFileSource<FileSource>(asIScriptEngine* engine, const char* className)
 {
-    return VectorToArray<String>(packageFile->GetEntryNames(), "Array<String>");
+    //FileSource was registered as an object already, before File.
+    //RegisterObject<FileSource>(engine, className);
+    // Do not register factory for the base class
+//    RegisterObject<FileSource>(engine, className);
+//    engine->RegisterObjectBehaviour(className, asBEHAVE_FACTORY, "PackageFile@+ f()", asFUNCTION(ConstructPackageFile), asCALL_CDECL);
+// NOT GENERAL    engine->RegisterObjectBehaviour(className, asBEHAVE_FACTORY, "PackageFile@+ f(const String&in, uint startOffset = 0)", asFUNCTION(ConstructAndOpenPackageFile), asCALL_CDECL);
+    engine->RegisterObjectMethod(className, "bool Open(const String&in) const", asMETHODPR(FileSource, Open, (const String&), bool), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "bool Exists(const String&in) const", asMETHOD(FileSource, Exists), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "File@+ GetFile(const String&in, FileMode mode)", asMETHOD(FileSource, GetFile), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "const String& get_name() const", asMETHOD(FileSource, GetName), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "uint get_numFiles() const", asMETHOD(FileSource, GetNumFiles), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "uint get_totalSize() const", asMETHOD(FileSource, GetTotalSize), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "uint get_totalDataSize() const", asMETHOD(FileSource, GetTotalDataSize), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "uint get_checksum() const", asMETHOD(FileSource, GetChecksum), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "bool compressed() const", asMETHOD(FileSource, IsCompressed), asCALL_THISCALL);
+    engine->RegisterObjectMethod(className, "Array<String>@ GetEntryNames() const", asFUNCTION(FileSourceGetEntryNames), asCALL_CDECL_OBJLAST);
 }
 
-static void RegisterPackageFile(asIScriptEngine* engine)
+static void RegisterFileSources(asIScriptEngine* engine)
 {
-    RegisterObject<PackageFile>(engine, "PackageFile");
-    engine->RegisterObjectBehaviour("PackageFile", asBEHAVE_FACTORY, "PackageFile@+ f()", asFUNCTION(ConstructPackageFile), asCALL_CDECL);
-    engine->RegisterObjectBehaviour("PackageFile", asBEHAVE_FACTORY, "PackageFile@+ f(const String&in, uint startOffset = 0)", asFUNCTION(ConstructAndOpenPackageFile), asCALL_CDECL);
-    engine->RegisterObjectMethod("PackageFile", "bool Open(const String&in, uint startOffset = 0) const", asMETHOD(PackageFile, Open), asCALL_THISCALL);
-    engine->RegisterObjectMethod("PackageFile", "bool Exists(const String&in) const", asMETHOD(PackageFile, Exists), asCALL_THISCALL);
-    engine->RegisterObjectMethod("PackageFile", "const String& get_name() const", asMETHOD(PackageFile, GetName), asCALL_THISCALL);
-    engine->RegisterObjectMethod("PackageFile", "uint get_numFiles() const", asMETHOD(PackageFile, GetNumFiles), asCALL_THISCALL);
-    engine->RegisterObjectMethod("PackageFile", "uint get_totalSize() const", asMETHOD(PackageFile, GetTotalSize), asCALL_THISCALL);
-    engine->RegisterObjectMethod("PackageFile", "uint get_totalDataSize() const", asMETHOD(PackageFile, GetTotalDataSize), asCALL_THISCALL);
-    engine->RegisterObjectMethod("PackageFile", "uint get_checksum() const", asMETHOD(PackageFile, GetChecksum), asCALL_THISCALL);
-    engine->RegisterObjectMethod("PackageFile", "bool compressed() const", asMETHOD(PackageFile, IsCompressed), asCALL_THISCALL);
-    engine->RegisterObjectMethod("PackageFile", "Array<String>@ GetEntryNames() const", asFUNCTION(PackageFileGetEntryNames), asCALL_CDECL_OBJLAST);
+//    RegisterObject<PackageFile>(engine, "PackageFile");
+//    engine->RegisterObjectBehaviour("PackageFile", asBEHAVE_FACTORY, "PackageFile@+ f()", asFUNCTION(ConstructPackageFile), asCALL_CDECL);
+//    engine->RegisterObjectBehaviour("PackageFile", asBEHAVE_FACTORY, "PackageFile@+ f(const String&in, uint startOffset = 0)", asFUNCTION(ConstructAndOpenPackageFile), asCALL_CDECL);
+//    engine->RegisterObjectMethod("PackageFile", "bool Open(const String&in, uint startOffset = 0) const", asMETHOD(PackageFile, Open), asCALL_THISCALL);
+//    engine->RegisterObjectMethod("PackageFile", "bool Exists(const String&in) const", asMETHOD(PackageFile, Exists), asCALL_THISCALL);
+//    engine->RegisterObjectMethod("PackageFile", "const String& get_name() const", asMETHOD(PackageFile, GetName), asCALL_THISCALL);
+//    engine->RegisterObjectMethod("PackageFile", "uint get_numFiles() const", asMETHOD(PackageFile, GetNumFiles), asCALL_THISCALL);
+//    engine->RegisterObjectMethod("PackageFile", "uint get_totalSize() const", asMETHOD(PackageFile, GetTotalSize), asCALL_THISCALL);
+//    engine->RegisterObjectMethod("PackageFile", "uint get_totalDataSize() const", asMETHOD(PackageFile, GetTotalDataSize), asCALL_THISCALL);
+//    engine->RegisterObjectMethod("PackageFile", "uint get_checksum() const", asMETHOD(PackageFile, GetChecksum), asCALL_THISCALL);
+//    engine->RegisterObjectMethod("PackageFile", "bool compressed() const", asMETHOD(PackageFile, IsCompressed), asCALL_THISCALL);
+//    engine->RegisterObjectMethod("PackageFile", "Array<String>@ GetEntryNames() const", asFUNCTION(PackageFileGetEntryNames), asCALL_CDECL_OBJLAST);
+    RegisterFileSource<FileSource>(engine, "FileSource");
+    RegisterFileSource<PackageFile>(engine, "PackageFile");
+    engine->RegisterObjectBehaviour("PackageFile", asBEHAVE_FACTORY, "PackageFile@+ f(const String&in, uint startOffset)", asFUNCTION(ConstructAndOpenPackageFile), asCALL_CDECL);
+    engine->RegisterObjectMethod("PackageFile", "bool Open(const String&in, uint startOffset) const", asMETHODPR(PackageFile, Open, (const String&, unsigned), bool), asCALL_THISCALL);
 }
 
 void RegisterIOAPI(asIScriptEngine* engine)
@@ -436,7 +486,7 @@ void RegisterIOAPI(asIScriptEngine* engine)
     RegisterLog(engine);
     RegisterSerialization(engine);
     RegisterFileSystem(engine);
-    RegisterPackageFile(engine);
+    RegisterFileSources(engine);
 }
 
 }

--- a/Source/Urho3D/AngelScript/ResourceAPI.cpp
+++ b/Source/Urho3D/AngelScript/ResourceAPI.cpp
@@ -108,12 +108,22 @@ static CScriptArray* ResourceCacheGetResourceDirs(ResourceCache* ptr)
 
 static CScriptArray* ResourceCacheGetPackageFiles(ResourceCache* ptr)
 {
-    return VectorToHandleArray<PackageFile>(ptr->GetPackageFiles(), "Array<PackageFile@>");
+    return VectorToHandleArray<FileSource>(ptr->GetPackageFiles(), "Array<FileSource@>");
+}
+
+static CScriptArray* ResourceCacheGetFileSources(ResourceCache* ptr)
+{
+    return VectorToHandleArray<FileSource>(ptr->GetFileSources(), "Array<FileSource@>");
 }
 
 static bool ResourceCacheBackgroundLoadResource(const String& type, const String& name, bool sendEventOnFailure, ResourceCache* ptr)
 {
     return ptr->BackgroundLoadResource(type, name, sendEventOnFailure);
+}
+
+static bool ResourceCacheAddFileSource(const String& type, const String& fileName, unsigned priority, ResourceCache* ptr)
+{
+    return ptr->AddFileSource(type, fileName, priority);
 }
 
 static Localization* GetLocalization()
@@ -144,10 +154,14 @@ static void RegisterResourceCache(asIScriptEngine* engine)
     engine->RegisterObjectMethod("ResourceCache", "bool AddResourceDir(const String&in, uint priority = M_MAX_UNSIGNED)", asMETHOD(ResourceCache, AddResourceDir), asCALL_THISCALL);
     engine->RegisterObjectMethod("ResourceCache", "bool AddPackageFile(PackageFile@+, uint priority = M_MAX_UNSIGNED)", asMETHODPR(ResourceCache, AddPackageFile, (PackageFile*, unsigned), bool), asCALL_THISCALL);
     engine->RegisterObjectMethod("ResourceCache", "bool AddPackageFile(const String&in, uint priority = M_MAX_UNSIGNED)", asMETHODPR(ResourceCache, AddPackageFile, (const String&, unsigned), bool), asCALL_THISCALL);
+    engine->RegisterObjectMethod("ResourceCache", "bool AddFileSource(FileSource@+, uint priority = M_MAX_UNSIGNED)", asMETHODPR(ResourceCache, AddFileSource, (FileSource*, unsigned), bool), asCALL_THISCALL);
+    engine->RegisterObjectMethod("ResourceCache", "bool AddFileSource(const String&in, const String&in, uint priority = M_MAX_UNSIGNED)", asFUNCTION(ResourceCacheAddFileSource), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod("ResourceCache", "bool AddManualResource(Resource@+)", asMETHOD(ResourceCache, AddManualResource), asCALL_THISCALL);
     engine->RegisterObjectMethod("ResourceCache", "void RemoveResourceDir(const String&in)", asMETHOD(ResourceCache, RemoveResourceDir), asCALL_THISCALL);
     engine->RegisterObjectMethod("ResourceCache", "void RemovePackageFile(PackageFile@+, bool releaseResources = true, bool forceRelease = false)", asMETHODPR(ResourceCache, RemovePackageFile, (PackageFile*, bool, bool), void), asCALL_THISCALL);
     engine->RegisterObjectMethod("ResourceCache", "void RemovePackageFile(const String&in, bool releaseResources = true, bool forceRelease = false)", asMETHODPR(ResourceCache, RemovePackageFile, (const String&, bool, bool), void), asCALL_THISCALL);
+    engine->RegisterObjectMethod("ResourceCache", "void RemoveFileSource(FileSource@+, bool releaseResources = true, bool forceRelease = false)", asMETHODPR(ResourceCache, RemoveFileSource, (FileSource*, bool, bool), void), asCALL_THISCALL);
+    engine->RegisterObjectMethod("ResourceCache", "void RemoveFileSource(const String&in, bool releaseResources = true, bool forceRelease = false)", asMETHODPR(ResourceCache, RemoveFileSource, (const String&, bool, bool), void), asCALL_THISCALL);
     engine->RegisterObjectMethod("ResourceCache", "void ReleaseResource(const String&in, const String&in, bool force = false)", asFUNCTION(ResourceCacheReleaseResource), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod("ResourceCache", "void ReleaseResources(StringHash, bool force = false)", asMETHODPR(ResourceCache, ReleaseResources, (StringHash, bool), void), asCALL_THISCALL);
     engine->RegisterObjectMethod("ResourceCache", "void ReleaseResources(const String&in, const String&in, bool force = false)", asFUNCTION(ResourceCacheReleaseResourcesPartial), asCALL_CDECL_OBJLAST);
@@ -173,7 +187,8 @@ static void RegisterResourceCache(asIScriptEngine* engine)
     engine->RegisterObjectMethod("ResourceCache", "uint64 get_memoryUse(const String&in) const", asFUNCTION(ResourceCacheGetMemoryUse), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod("ResourceCache", "uint64 get_totalMemoryUse() const", asMETHOD(ResourceCache, GetTotalMemoryUse), asCALL_THISCALL);
     engine->RegisterObjectMethod("ResourceCache", "Array<String>@ get_resourceDirs() const", asFUNCTION(ResourceCacheGetResourceDirs), asCALL_CDECL_OBJLAST);
-    engine->RegisterObjectMethod("ResourceCache", "Array<PackageFile@>@ get_packageFiles() const", asFUNCTION(ResourceCacheGetPackageFiles), asCALL_CDECL_OBJLAST);
+    engine->RegisterObjectMethod("ResourceCache", "Array<FileSource@>@ get_packageFiles() const", asFUNCTION(ResourceCacheGetPackageFiles), asCALL_CDECL_OBJLAST);
+    engine->RegisterObjectMethod("ResourceCache", "Array<FileSource@>@ get_fileSources() const", asFUNCTION(ResourceCacheGetFileSources), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod("ResourceCache", "void set_searchPackagesFirst(bool)", asMETHOD(ResourceCache, SetSearchPackagesFirst), asCALL_THISCALL);
     engine->RegisterObjectMethod("ResourceCache", "bool get_seachPackagesFirst() const", asMETHOD(ResourceCache, GetSearchPackagesFirst), asCALL_THISCALL);
     engine->RegisterObjectMethod("ResourceCache", "void set_autoReloadResources(bool)", asMETHOD(ResourceCache, SetAutoReloadResources), asCALL_THISCALL);

--- a/Source/Urho3D/AngelScript/ScriptAPIDump.cpp
+++ b/Source/Urho3D/AngelScript/ScriptAPIDump.cpp
@@ -24,7 +24,7 @@
 
 #include "../AngelScript/Script.h"
 #include "../Core/Context.h"
-#include "../IO/File.h"
+#include "../IO/PhysicalFile.h"
 #include "../IO/FileSystem.h"
 #include "../IO/Log.h"
 
@@ -229,7 +229,7 @@ void Script::DumpAPI(DumpMode mode, const String& sourceTree)
 
             for (unsigned i = 0; i < headerFiles.Size(); ++i)
             {
-                SharedPtr<File> file(new File(context_, path + headerFiles[i].fileName, FILE_READ));
+                SharedPtr<File> file(new PhysicalFile(context_, path + headerFiles[i].fileName, FILE_READ));
                 if (!file->IsOpen())
                     continue;
 

--- a/Source/Urho3D/AngelScript/ScriptAPIDump.cpp
+++ b/Source/Urho3D/AngelScript/ScriptAPIDump.cpp
@@ -24,7 +24,7 @@
 
 #include "../AngelScript/Script.h"
 #include "../Core/Context.h"
-#include "../IO/PhysicalFile.h"
+#include "../IO/SystemFile.h"
 #include "../IO/FileSystem.h"
 #include "../IO/Log.h"
 
@@ -229,7 +229,7 @@ void Script::DumpAPI(DumpMode mode, const String& sourceTree)
 
             for (unsigned i = 0; i < headerFiles.Size(); ++i)
             {
-                SharedPtr<File> file(new PhysicalFile(context_, path + headerFiles[i].fileName, FILE_READ));
+                SharedPtr<File> file(new SystemFile(context_, path + headerFiles[i].fileName, FILE_READ));
                 if (!file->IsOpen())
                     continue;
 

--- a/Source/Urho3D/AngelScript/UIAPI.cpp
+++ b/Source/Urho3D/AngelScript/UIAPI.cpp
@@ -24,6 +24,7 @@
 
 #include "../AngelScript/APITemplates.h"
 #include "../Input/Input.h"
+#include "../IO/SystemFile.h"
 #include "../UI/CheckBox.h"
 #include "../UI/DropDownList.h"
 #include "../UI/FileSelector.h"
@@ -58,7 +59,7 @@ static bool FontSaveXML(const String& fileName, int pointSize, bool usedGlyphs, 
     if (fileName.Empty())
         return false;
 
-    File file(ptr->GetContext(), fileName, FILE_WRITE);
+    SystemFile file(ptr->GetContext(), fileName, FILE_WRITE);
     return ptr->SaveXML(file, pointSize, usedGlyphs, indentation);
 }
 

--- a/Source/Urho3D/Engine/Engine.cpp
+++ b/Source/Urho3D/Engine/Engine.cpp
@@ -329,11 +329,11 @@ bool Engine::InitializeResourceCache(const VariantMap& parameters, bool removeOl
     if (removeOld)
     {
         Vector<String> resourceDirs = cache->GetResourceDirs();
-        Vector<SharedPtr<PackageFile> > packageFiles = cache->GetPackageFiles();
+        Vector<SharedPtr<FileSource> > packageFiles = cache->GetFileSources();
         for (unsigned i = 0; i < resourceDirs.Size(); ++i)
             cache->RemoveResourceDir(resourceDirs[i]);
         for (unsigned i = 0; i < packageFiles.Size(); ++i)
-            cache->RemovePackageFile(packageFiles[i]);
+            cache->RemoveFileSource(packageFiles[i]);
     }
 
     // Add resource paths

--- a/Source/Urho3D/Graphics/Animation.cpp
+++ b/Source/Urho3D/Graphics/Animation.cpp
@@ -30,6 +30,7 @@
 #include "../IO/FileSystem.h"
 #include "../IO/Log.h"
 #include "../IO/Serializer.h"
+#include "../IO/PhysicalFile.h"
 #include "../Resource/ResourceCache.h"
 #include "../Resource/XMLFile.h"
 #include "../Resource/JSONFile.h"
@@ -273,7 +274,7 @@ bool Animation::Save(Serializer& dest) const
 
             SaveMetadataToXML(rootElem);
 
-            File xmlFile(context_, xmlName, FILE_WRITE);
+            PhysicalFile xmlFile(context_, xmlName, FILE_WRITE);
             xml->Save(xmlFile);
         }
         else

--- a/Source/Urho3D/Graphics/Animation.cpp
+++ b/Source/Urho3D/Graphics/Animation.cpp
@@ -30,7 +30,7 @@
 #include "../IO/FileSystem.h"
 #include "../IO/Log.h"
 #include "../IO/Serializer.h"
-#include "../IO/PhysicalFile.h"
+#include "../IO/SystemFile.h"
 #include "../Resource/ResourceCache.h"
 #include "../Resource/XMLFile.h"
 #include "../Resource/JSONFile.h"
@@ -274,7 +274,7 @@ bool Animation::Save(Serializer& dest) const
 
             SaveMetadataToXML(rootElem);
 
-            PhysicalFile xmlFile(context_, xmlName, FILE_WRITE);
+            SystemFile xmlFile(context_, xmlName, FILE_WRITE);
             xml->Save(xmlFile);
         }
         else

--- a/Source/Urho3D/Graphics/Direct3D11/D3D11ShaderVariation.cpp
+++ b/Source/Urho3D/Graphics/Direct3D11/D3D11ShaderVariation.cpp
@@ -26,7 +26,7 @@
 #include "../../Graphics/GraphicsImpl.h"
 #include "../../Graphics/Shader.h"
 #include "../../Graphics/VertexBuffer.h"
-#include "../../IO/File.h"
+#include "../../IO/PhysicalFile.h"
 #include "../../IO/FileSystem.h"
 #include "../../IO/Log.h"
 #include "../../Resource/ResourceCache.h"
@@ -432,7 +432,7 @@ void ShaderVariation::SaveByteCode(const String& binaryShaderName)
     if (!fileSystem->DirExists(path))
         fileSystem->CreateDir(path);
 
-    SharedPtr<File> file(new File(owner_->GetContext(), fullName, FILE_WRITE));
+    SharedPtr<File> file(new PhysicalFile(owner_->GetContext(), fullName, FILE_WRITE));
     if (!file->IsOpen())
         return;
 

--- a/Source/Urho3D/Graphics/Direct3D11/D3D11ShaderVariation.cpp
+++ b/Source/Urho3D/Graphics/Direct3D11/D3D11ShaderVariation.cpp
@@ -26,7 +26,7 @@
 #include "../../Graphics/GraphicsImpl.h"
 #include "../../Graphics/Shader.h"
 #include "../../Graphics/VertexBuffer.h"
-#include "../../IO/PhysicalFile.h"
+#include "../../IO/SystemFile.h"
 #include "../../IO/FileSystem.h"
 #include "../../IO/Log.h"
 #include "../../Resource/ResourceCache.h"
@@ -432,7 +432,7 @@ void ShaderVariation::SaveByteCode(const String& binaryShaderName)
     if (!fileSystem->DirExists(path))
         fileSystem->CreateDir(path);
 
-    SharedPtr<File> file(new PhysicalFile(owner_->GetContext(), fullName, FILE_WRITE));
+    SharedPtr<File> file(new SystemFile(owner_->GetContext(), fullName, FILE_WRITE));
     if (!file->IsOpen())
         return;
 

--- a/Source/Urho3D/Graphics/Direct3D9/D3D9ShaderVariation.cpp
+++ b/Source/Urho3D/Graphics/Direct3D9/D3D9ShaderVariation.cpp
@@ -26,7 +26,7 @@
 #include "../../Graphics/GraphicsImpl.h"
 #include "../../Graphics/Shader.h"
 #include "../../Graphics/ShaderVariation.h"
-#include "../../IO/File.h"
+#include "../../IO/PhysicalFile.h"
 #include "../../IO/FileSystem.h"
 #include "../../IO/Log.h"
 #include "../../Resource/ResourceCache.h"
@@ -386,7 +386,7 @@ void ShaderVariation::SaveByteCode(const String& binaryShaderName)
     if (!fileSystem->DirExists(path))
         fileSystem->CreateDir(path);
 
-    SharedPtr<File> file(new File(owner_->GetContext(), fullName, FILE_WRITE));
+    SharedPtr<File> file(new PhysicalFile(owner_->GetContext(), fullName, FILE_WRITE));
     if (!file->IsOpen())
         return;
 

--- a/Source/Urho3D/Graphics/Direct3D9/D3D9ShaderVariation.cpp
+++ b/Source/Urho3D/Graphics/Direct3D9/D3D9ShaderVariation.cpp
@@ -26,7 +26,7 @@
 #include "../../Graphics/GraphicsImpl.h"
 #include "../../Graphics/Shader.h"
 #include "../../Graphics/ShaderVariation.h"
-#include "../../IO/PhysicalFile.h"
+#include "../../IO/SystemFile.h"
 #include "../../IO/FileSystem.h"
 #include "../../IO/Log.h"
 #include "../../Resource/ResourceCache.h"
@@ -386,7 +386,7 @@ void ShaderVariation::SaveByteCode(const String& binaryShaderName)
     if (!fileSystem->DirExists(path))
         fileSystem->CreateDir(path);
 
-    SharedPtr<File> file(new PhysicalFile(owner_->GetContext(), fullName, FILE_WRITE));
+    SharedPtr<File> file(new SystemFile(owner_->GetContext(), fullName, FILE_WRITE));
     if (!file->IsOpen())
         return;
 

--- a/Source/Urho3D/Graphics/Model.cpp
+++ b/Source/Urho3D/Graphics/Model.cpp
@@ -30,7 +30,7 @@
 #include "../Graphics/Graphics.h"
 #include "../Graphics/VertexBuffer.h"
 #include "../IO/Log.h"
-#include "../IO/File.h"
+#include "../IO/PhysicalFile.h"
 #include "../IO/FileSystem.h"
 #include "../Resource/ResourceCache.h"
 #include "../Resource/XMLFile.h"
@@ -475,7 +475,7 @@ bool Model::Save(Serializer& dest) const
             XMLElement rootElem = xml->CreateRoot("model");
             SaveMetadataToXML(rootElem);
 
-            File xmlFile(context_, xmlName, FILE_WRITE);
+            PhysicalFile xmlFile(context_, xmlName, FILE_WRITE);
             xml->Save(xmlFile);
         }
         else

--- a/Source/Urho3D/Graphics/Model.cpp
+++ b/Source/Urho3D/Graphics/Model.cpp
@@ -30,7 +30,7 @@
 #include "../Graphics/Graphics.h"
 #include "../Graphics/VertexBuffer.h"
 #include "../IO/Log.h"
-#include "../IO/PhysicalFile.h"
+#include "../IO/SystemFile.h"
 #include "../IO/FileSystem.h"
 #include "../Resource/ResourceCache.h"
 #include "../Resource/XMLFile.h"
@@ -475,7 +475,7 @@ bool Model::Save(Serializer& dest) const
             XMLElement rootElem = xml->CreateRoot("model");
             SaveMetadataToXML(rootElem);
 
-            PhysicalFile xmlFile(context_, xmlName, FILE_WRITE);
+            SystemFile xmlFile(context_, xmlName, FILE_WRITE);
             xml->Save(xmlFile);
         }
         else

--- a/Source/Urho3D/Graphics/Shader.cpp
+++ b/Source/Urho3D/Graphics/Shader.cpp
@@ -29,7 +29,7 @@
 #include "../IO/Deserializer.h"
 #include "../IO/FileSystem.h"
 #include "../IO/Log.h"
-#include "../IO/PhysicalFile.h"
+#include "../IO/SystemFile.h"
 #include "../Resource/ResourceCache.h"
 
 #include "../DebugNew.h"
@@ -164,7 +164,7 @@ bool Shader::ProcessSource(String& code, Deserializer& source)
 
     // If the source if a non-packaged file, store the timestamp
     File* file = dynamic_cast<File*>(&source);
-    if (file && file->GetType() == PhysicalFile::GetTypeStatic())
+    if (file && file->GetType() == SystemFile::GetTypeStatic())
     {
         FileSystem* fileSystem = GetSubsystem<FileSystem>();
         String fullName = cache->GetResourceFileName(file->GetName());
@@ -187,11 +187,17 @@ bool Shader::ProcessSource(String& code, Deserializer& source)
 
             SharedPtr<File> includeFile = cache->GetFile(includeFileName);
             if (!includeFile)
+            {
+                URHO3D_LOGERROR("Could not open shader include file " + includeFileName);
                 return false;
+            }
 
             // Add the include file into the current code recursively
             if (!ProcessSource(code, *includeFile))
+            {
+                URHO3D_LOGERROR("Could not process shader include file " + includeFileName);
                 return false;
+            }
         }
         else
         {

--- a/Source/Urho3D/Graphics/Shader.cpp
+++ b/Source/Urho3D/Graphics/Shader.cpp
@@ -29,6 +29,7 @@
 #include "../IO/Deserializer.h"
 #include "../IO/FileSystem.h"
 #include "../IO/Log.h"
+#include "../IO/PhysicalFile.h"
 #include "../Resource/ResourceCache.h"
 
 #include "../DebugNew.h"
@@ -163,7 +164,7 @@ bool Shader::ProcessSource(String& code, Deserializer& source)
 
     // If the source if a non-packaged file, store the timestamp
     File* file = dynamic_cast<File*>(&source);
-    if (file && !file->IsPackaged())
+    if (file && file->GetType() == PhysicalFile::GetTypeStatic())
     {
         FileSystem* fileSystem = GetSubsystem<FileSystem>();
         String fullName = cache->GetResourceFileName(file->GetName());

--- a/Source/Urho3D/Graphics/ShaderPrecache.cpp
+++ b/Source/Urho3D/Graphics/ShaderPrecache.cpp
@@ -26,7 +26,7 @@
 #include "../Graphics/GraphicsImpl.h"
 #include "../Graphics/ShaderPrecache.h"
 #include "../Graphics/ShaderVariation.h"
-#include "../IO/File.h"
+#include "../IO/PhysicalFile.h"
 #include "../IO/FileSystem.h"
 #include "../IO/Log.h"
 
@@ -43,7 +43,7 @@ ShaderPrecache::ShaderPrecache(Context* context, const String& fileName) :
     if (GetSubsystem<FileSystem>()->FileExists(fileName))
     {
         // If file exists, read the already listed combinations
-        File source(context_, fileName);
+        PhysicalFile source(context_, fileName);
         xmlFile_.Load(source);
 
         XMLElement shader = xmlFile_.GetRoot().GetChild("shader");
@@ -71,7 +71,7 @@ ShaderPrecache::~ShaderPrecache()
     if (usedCombinations_.Empty())
         return;
 
-    File dest(context_, fileName_, FILE_WRITE);
+    PhysicalFile dest(context_, fileName_, FILE_WRITE);
     xmlFile_.Save(dest);
 }
 

--- a/Source/Urho3D/Graphics/ShaderPrecache.cpp
+++ b/Source/Urho3D/Graphics/ShaderPrecache.cpp
@@ -26,7 +26,7 @@
 #include "../Graphics/GraphicsImpl.h"
 #include "../Graphics/ShaderPrecache.h"
 #include "../Graphics/ShaderVariation.h"
-#include "../IO/PhysicalFile.h"
+#include "../IO/SystemFile.h"
 #include "../IO/FileSystem.h"
 #include "../IO/Log.h"
 
@@ -43,7 +43,7 @@ ShaderPrecache::ShaderPrecache(Context* context, const String& fileName) :
     if (GetSubsystem<FileSystem>()->FileExists(fileName))
     {
         // If file exists, read the already listed combinations
-        PhysicalFile source(context_, fileName);
+        SystemFile source(context_, fileName);
         xmlFile_.Load(source);
 
         XMLElement shader = xmlFile_.GetRoot().GetChild("shader");
@@ -71,7 +71,7 @@ ShaderPrecache::~ShaderPrecache()
     if (usedCombinations_.Empty())
         return;
 
-    PhysicalFile dest(context_, fileName_, FILE_WRITE);
+    SystemFile dest(context_, fileName_, FILE_WRITE);
     xmlFile_.Save(dest);
 }
 

--- a/Source/Urho3D/IO/File.cpp
+++ b/Source/Urho3D/IO/File.cpp
@@ -38,19 +38,17 @@ File::File(Context* context, const String& fileName, FileMode mode) :
     Object(context),
     mode_(FILE_READ)
 {
-    Open(fileName, mode);
 }
 
-File::File(Context* context, PackageFile* package, const String& fileName, FileMode mode) :
+File::File(Context* context, FileSource* package, const String& fileName, FileMode mode) :
     Object(context),
     mode_(FILE_READ)
 {
-    Open(package, fileName, mode);
 }
 
 bool File::Open(const String& fileName, FileMode mode)
 {
-    return Open(GetSubsystem<FileSystem>()->GetFileSource(this->GetType()), fileName, mode);
+    return this->Open(GetSubsystem<FileSystem>()->GetFileSource(this->GetType()), fileName, mode);
 }
 
 void File::SetName(const String& name)
@@ -58,13 +56,5 @@ void File::SetName(const String& name)
     fileName_ = name;
 }
 
-bool File::IsOpen() const
-{
-#ifdef __ANDROID__
-    return handle_ != 0 || assetHandle_ != 0;
-#else
-    return handle_ != nullptr;
-#endif
-}
 
 }

--- a/Source/Urho3D/IO/File.h
+++ b/Source/Urho3D/IO/File.h
@@ -71,7 +71,7 @@ public:
 
     // File Specific things
     /// Open a file with the default FileSource for this file kind of file, as registered in the resource cache. Return true if successful.
-    bool Open(const String& fileName, FileMode mode = FILE_READ);
+    virtual bool Open(const String& fileName, FileMode mode = FILE_READ);
     /// Open from within a given file source. Return true if successful. FileModes beyond FILE_READ may not be supported.
     virtual bool Open(FileSource* source, const String& fileName, FileMode mode = FILE_READ) = 0;
     /// Close the file.

--- a/Source/Urho3D/IO/FileSource.cpp
+++ b/Source/Urho3D/IO/FileSource.cpp
@@ -34,4 +34,9 @@ FileSource::FileSource(Context* context) :
 {
 }
 
+SharedPtr<File> FileSource::GetFile(const String &fileName, FileMode mode)
+{
+    return SharedPtr<File>(GetNewFile(fileName, mode));
+}
+
 }

--- a/Source/Urho3D/IO/FileSource.cpp
+++ b/Source/Urho3D/IO/FileSource.cpp
@@ -23,48 +23,15 @@
 #include "../Precompiled.h"
 
 #include "../IO/File.h"
-#include "../IO/FileSystem.h"
+#include "../IO/Log.h"
+#include "../IO/FileSource.h"
 
 namespace Urho3D
 {
 
-File::File(Context* context) :
-    Object(context),
-    mode_(FILE_READ)
+FileSource::FileSource(Context* context) :
+    Object(context)
 {
-}
-
-File::File(Context* context, const String& fileName, FileMode mode) :
-    Object(context),
-    mode_(FILE_READ)
-{
-    Open(fileName, mode);
-}
-
-File::File(Context* context, PackageFile* package, const String& fileName, FileMode mode) :
-    Object(context),
-    mode_(FILE_READ)
-{
-    Open(package, fileName, mode);
-}
-
-bool File::Open(const String& fileName, FileMode mode)
-{
-    return Open(GetSubsystem<FileSystem>()->GetFileSource(this->GetType()), fileName, mode);
-}
-
-void File::SetName(const String& name)
-{
-    fileName_ = name;
-}
-
-bool File::IsOpen() const
-{
-#ifdef __ANDROID__
-    return handle_ != 0 || assetHandle_ != 0;
-#else
-    return handle_ != nullptr;
-#endif
 }
 
 }

--- a/Source/Urho3D/IO/FileSource.h
+++ b/Source/Urho3D/IO/FileSource.h
@@ -51,8 +51,8 @@ public:
     /// Opens a file with the given name and returns a file shared pointer from the source.
     SharedPtr<File> GetFile(const String& fileName, FileMode mode = FILE_READ);
 
-    /// Open the package file, if applicable.
-    virtual bool Open(const String& filename) { return true; }
+    /// Open the package file, if applicable. Returns true on success.
+    virtual bool Open(const String& filename) = 0;
 
     // TODO: NEL: Possibly replace the -1 with a 0 and add a separate [Is]Loaded() or LoadSuccessful() function
     /// Return number of files if available. Should return non-zero if load successful.

--- a/Source/Urho3D/IO/FileSource.h
+++ b/Source/Urho3D/IO/FileSource.h
@@ -45,8 +45,11 @@ public:
     /// Return list of file names in the package, if available. Otherwise must store list of used resource names and use those.
     virtual const Vector<String> GetEntryNames() const = 0;
 
-    /// Return a file of the kind associate with this type of file source.
-    virtual SharedPtr<File> GetFile(const String& fileName, FileMode mode = FILE_READ) const = 0;
+    /// Opens a new file of the kind associate with this type of file source with the given name.
+    virtual File* GetNewFile(const String& fileName, FileMode mode = FILE_READ) = 0;
+
+    /// Opens a file with the given name and returns a file shared pointer from the source.
+    SharedPtr<File> GetFile(const String& fileName, FileMode mode = FILE_READ);
 
     /// Open the package file, if applicable.
     virtual bool Open(const String& filename) { return true; }
@@ -79,8 +82,6 @@ protected:
         nameHash_ = fileName_;
     }
 
-    /// File entries.
-    HashMap<String, PackageEntry> entries_;
     /// File name.
     String fileName_;
     /// Package file name hash.

--- a/Source/Urho3D/IO/FileSource.h
+++ b/Source/Urho3D/IO/FileSource.h
@@ -1,0 +1,90 @@
+//
+// Copyright (c) 2008-2017 the Urho3D project.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+#include "../Core/Object.h"
+#include "../IO/File.h"
+
+namespace Urho3D
+{
+
+/// Base class representing a source of a kind of file. Exists must be implemented.
+class URHO3D_API FileSource : public Object
+{
+    URHO3D_OBJECT(FileSource, Object);
+
+public:
+    /// Construct.
+    FileSource(Context* context);
+    /// Destruct.
+    virtual ~FileSource() override { }
+
+    /// Check if a file exists within the package file. This should be case-insensitive on Windows and case-sensitive on other platforms.
+    virtual bool Exists(const String& fileName) const = 0;
+
+    /// Return list of file names in the package, if available. Otherwise must store list of used resource names and use those.
+    virtual const Vector<String> GetEntryNames() const = 0;
+
+    /// Return a file of the kind associate with this type of file source.
+    virtual SharedPtr<File> GetFile(const String& fileName, FileMode mode = FILE_READ) const = 0;
+
+    /// Open the package file, if applicable.
+    virtual bool Open(const String& filename) { return true; }
+
+    // TODO: NEL: Possibly replace the -1 with a 0 and add a separate [Is]Loaded() or LoadSuccessful() function
+    /// Return number of files if available. Should return non-zero if load successful.
+    virtual unsigned GetNumFiles() const { return -1; }
+
+    /// Return total size of the package file or 0 if unavailable.
+    virtual unsigned GetTotalSize() const { return 0; }
+
+    /// Return total data size from all the file entries in the package file or 0 if unavailable.
+    virtual unsigned GetTotalDataSize() const { return 0; }
+
+    /// Return checksum of the package file contents or 0 if unavailable.
+    virtual unsigned GetChecksum() const { return 0; }
+
+    /// Return whether the files are compressed. Default false.
+    virtual bool IsCompressed() const { return false; }
+
+    /// Return the package file name.
+    const String& GetName() const { return fileName_; }
+
+    /// Return hash of the package file name.
+    StringHash GetNameHash() const { return nameHash_; }
+
+protected:
+    void SetName(const String& name) {
+        fileName_ = name;
+        nameHash_ = fileName_;
+    }
+
+    /// File entries.
+    HashMap<String, PackageEntry> entries_;
+    /// File name.
+    String fileName_;
+    /// Package file name hash.
+    StringHash nameHash_;
+};
+
+}

--- a/Source/Urho3D/IO/FileSystem.cpp
+++ b/Source/Urho3D/IO/FileSystem.cpp
@@ -27,7 +27,7 @@
 #include "../Core/CoreEvents.h"
 #include "../Core/Thread.h"
 #include "../Engine/EngineEvents.h"
-#include "../IO/PhysicalFile.h"
+#include "../IO/SystemFile.h"
 #include "../IO/FileSystem.h"
 #include "../IO/IOEvents.h"
 #include "../IO/Log.h"
@@ -127,7 +127,7 @@ int DoSystemCommand(const String& commandLine, bool redirectToLog, Context* cont
     // Capture the standard error stream
     if (!stderrFilename.Empty())
     {
-        SharedPtr<File> errFile(new PhysicalFile(context, stderrFilename, FILE_READ));
+        SharedPtr<File> errFile(new SystemFile(context, stderrFilename, FILE_READ));
         while (!errFile->IsEof())
         {
             unsigned numRead = errFile->Read(buffer, sizeof(buffer));
@@ -485,10 +485,10 @@ bool FileSystem::Copy(const String& srcFileName, const String& destFileName)
         return false;
     }
 
-    SharedPtr<File> srcFile(new PhysicalFile(context_, srcFileName, FILE_READ));
+    SharedPtr<File> srcFile(new SystemFile(context_, srcFileName, FILE_READ));
     if (!srcFile->IsOpen())
         return false;
-    SharedPtr<File> destFile(new PhysicalFile(context_, destFileName, FILE_WRITE));
+    SharedPtr<File> destFile(new SystemFile(context_, destFileName, FILE_WRITE));
     if (!destFile->IsOpen())
         return false;
 

--- a/Source/Urho3D/IO/FileSystem.cpp
+++ b/Source/Urho3D/IO/FileSystem.cpp
@@ -1085,7 +1085,7 @@ String FileSystem::GetTemporaryDir() const
 #endif
 }
 
-FileSource *FileSystem::GetFileSource(StringHash fileType) const
+FileSource *FileSystem::GetFileSource(StringHash fileType)
 {
     return fileSources_[fileType];
 }

--- a/Source/Urho3D/IO/FileSystem.cpp
+++ b/Source/Urho3D/IO/FileSystem.cpp
@@ -27,7 +27,7 @@
 #include "../Core/CoreEvents.h"
 #include "../Core/Thread.h"
 #include "../Engine/EngineEvents.h"
-#include "../IO/File.h"
+#include "../IO/PhysicalFile.h"
 #include "../IO/FileSystem.h"
 #include "../IO/IOEvents.h"
 #include "../IO/Log.h"
@@ -127,7 +127,7 @@ int DoSystemCommand(const String& commandLine, bool redirectToLog, Context* cont
     // Capture the standard error stream
     if (!stderrFilename.Empty())
     {
-        SharedPtr<File> errFile(new File(context, stderrFilename, FILE_READ));
+        SharedPtr<File> errFile(new PhysicalFile(context, stderrFilename, FILE_READ));
         while (!errFile->IsEof())
         {
             unsigned numRead = errFile->Read(buffer, sizeof(buffer));
@@ -485,10 +485,10 @@ bool FileSystem::Copy(const String& srcFileName, const String& destFileName)
         return false;
     }
 
-    SharedPtr<File> srcFile(new File(context_, srcFileName, FILE_READ));
+    SharedPtr<File> srcFile(new PhysicalFile(context_, srcFileName, FILE_READ));
     if (!srcFile->IsOpen())
         return false;
-    SharedPtr<File> destFile(new File(context_, destFileName, FILE_WRITE));
+    SharedPtr<File> destFile(new PhysicalFile(context_, destFileName, FILE_WRITE));
     if (!destFile->IsOpen())
         return false;
 
@@ -1083,6 +1083,19 @@ String FileSystem::GetTemporaryDir() const
     return "/tmp/";
 #endif
 #endif
+}
+
+FileSource *FileSystem::GetFileSource(StringHash fileType) const
+{
+    return fileSources_[fileType];
+}
+
+void FileSystem::RegisterFileSource(StringHash filetype, FileSource *source)
+{
+    if (!source)
+        fileSources_.Erase(filetype);
+    else
+        fileSources_[filetype] = source;
 }
 
 }

--- a/Source/Urho3D/IO/FileSystem.h
+++ b/Source/Urho3D/IO/FileSystem.h
@@ -25,6 +25,7 @@
 #include "../Container/HashSet.h"
 #include "../Container/List.h"
 #include "../Core/Object.h"
+#include "../IO/FileSource.h"
 
 namespace Urho3D
 {
@@ -104,6 +105,11 @@ public:
     /// Return path of temporary directory. Path always ends with a forward slash.
     String GetTemporaryDir() const;
 
+    /// Returns a regestired file source for a given file type
+    FileSource* GetFileSource(StringHash fileType) const; // TODO: should this return a WeakPtr?
+    /// Registers a FileSources as the default. Pass nullptr to unregister.
+    void RegisterFileSource(StringHash filetype, FileSource* source);
+
 private:
     /// Scan directory, called internally.
     void ScanDirInternal
@@ -121,6 +127,8 @@ private:
     unsigned nextAsyncExecID_;
     /// Flag for executing engine console commands as OS-specific system command. Default to true.
     bool executeConsoleCommands_;
+    /// Registered File Sources
+    HashMap<StringHash, SharedPtr<FileSource>> fileSources_;
 };
 
 /// Split a full path to path, filename and extension. The extension will be converted to lowercase by default.

--- a/Source/Urho3D/IO/FileSystem.h
+++ b/Source/Urho3D/IO/FileSystem.h
@@ -106,7 +106,7 @@ public:
     String GetTemporaryDir() const;
 
     /// Returns a regestired file source for a given file type
-    FileSource* GetFileSource(StringHash fileType) const; // TODO: should this return a WeakPtr?
+    FileSource* GetFileSource(StringHash fileType); // TODO: should this return a WeakPtr?
     /// Registers a FileSources as the default. Pass nullptr to unregister.
     void RegisterFileSource(StringHash filetype, FileSource* source);
 

--- a/Source/Urho3D/IO/Log.cpp
+++ b/Source/Urho3D/IO/Log.cpp
@@ -27,7 +27,7 @@
 #include "../Core/ProcessUtils.h"
 #include "../Core/Thread.h"
 #include "../Core/Timer.h"
-#include "../IO/File.h"
+#include "../IO/PhysicalFile.h"
 #include "../IO/IOEvents.h"
 #include "../IO/Log.h"
 
@@ -92,7 +92,7 @@ void Log::Open(const String& fileName)
             Close();
     }
 
-    logFile_ = new File(context_);
+    logFile_ = new PhysicalFile(context_);
     if (logFile_->Open(fileName, FILE_WRITE))
         Write(LOG_INFO, "Opened log file " + fileName);
     else

--- a/Source/Urho3D/IO/Log.cpp
+++ b/Source/Urho3D/IO/Log.cpp
@@ -27,7 +27,7 @@
 #include "../Core/ProcessUtils.h"
 #include "../Core/Thread.h"
 #include "../Core/Timer.h"
-#include "../IO/PhysicalFile.h"
+#include "../IO/SystemFile.h"
 #include "../IO/IOEvents.h"
 #include "../IO/Log.h"
 
@@ -92,7 +92,7 @@ void Log::Open(const String& fileName)
             Close();
     }
 
-    logFile_ = new PhysicalFile(context_);
+    logFile_ = new SystemFile(context_);
     if (logFile_->Open(fileName, FILE_WRITE))
         Write(LOG_INFO, "Opened log file " + fileName);
     else

--- a/Source/Urho3D/IO/PackageFile.cpp
+++ b/Source/Urho3D/IO/PackageFile.cpp
@@ -22,7 +22,7 @@
 
 #include "../Precompiled.h"
 
-#include "../IO/File.h"
+#include "../IO/PhysicalFile.h"
 #include "../IO/Log.h"
 #include "../IO/PackageFile.h"
 
@@ -30,7 +30,7 @@ namespace Urho3D
 {
 
 PackageFile::PackageFile(Context* context) :
-    Object(context),
+    FileSource(context),
     totalSize_(0),
     totalDataSize_(0),
     checksum_(0),
@@ -39,7 +39,7 @@ PackageFile::PackageFile(Context* context) :
 }
 
 PackageFile::PackageFile(Context* context, const String& fileName, unsigned startOffset) :
-    Object(context),
+    FileSource(context),
     totalSize_(0),
     totalDataSize_(0),
     checksum_(0),
@@ -54,7 +54,7 @@ PackageFile::~PackageFile()
 
 bool PackageFile::Open(const String& fileName, unsigned startOffset)
 {
-    SharedPtr<File> file(new File(context_, fileName));
+    SharedPtr<File> file(new PhysicalFile(context_, fileName));
     if (!file->IsOpen())
         return false;
 
@@ -132,6 +132,11 @@ bool PackageFile::Exists(const String& fileName) const
 #endif
 
     return found;
+}
+
+SharedPtr<PackedFile> PackageFile::GetFile(const String &fileName, FileMode mode) const
+{
+    return new PackedFile(context_,this,fileName,mode);
 }
 
 const PackageEntry* PackageFile::GetEntry(const String& fileName) const

--- a/Source/Urho3D/IO/PackageFile.cpp
+++ b/Source/Urho3D/IO/PackageFile.cpp
@@ -22,12 +22,15 @@
 
 #include "../Precompiled.h"
 
-#include "../IO/PhysicalFile.h"
+#include "../Core/Context.h"
+#include "../IO/SystemFile.h"
 #include "../IO/Log.h"
 #include "../IO/PackageFile.h"
 
 namespace Urho3D
 {
+
+extern const char* FILESOURCE_CATEGORY;
 
 PackageFile::PackageFile(Context* context) :
     FileSource(context),
@@ -54,7 +57,7 @@ PackageFile::~PackageFile()
 
 bool PackageFile::Open(const String& fileName, unsigned startOffset)
 {
-    SharedPtr<File> file(new PhysicalFile(context_, fileName));
+    SharedPtr<File> file(new SystemFile(context_, fileName));
     if (!file->IsOpen())
         return false;
 
@@ -158,6 +161,11 @@ const PackageEntry* PackageFile::GetEntry(const String& fileName) const
 #endif
 
     return nullptr;
+}
+
+void PackageFile::RegisterObject(Context *context)
+{
+    context->RegisterFactory<PackageFile>();
 }
 
 }

--- a/Source/Urho3D/IO/PackageFile.cpp
+++ b/Source/Urho3D/IO/PackageFile.cpp
@@ -134,7 +134,7 @@ bool PackageFile::Exists(const String& fileName) const
     return found;
 }
 
-SharedPtr<PackedFile> PackageFile::GetFile(const String &fileName, FileMode mode) const
+PackedFile* PackageFile::GetNewFile(const String &fileName, FileMode mode)
 {
     return new PackedFile(context_,this,fileName,mode);
 }

--- a/Source/Urho3D/IO/PackageFile.h
+++ b/Source/Urho3D/IO/PackageFile.h
@@ -53,7 +53,9 @@ public:
     virtual ~PackageFile() override;
 
     /// Open the package file. Return true if successful.
-    virtual bool Open(const String& fileName, unsigned startOffset = 0);// override;
+    virtual bool Open(const String& fileName, unsigned startOffset);
+    /// Open the package file. Return true if successful.
+    virtual bool Open(const String& fileName) override { return Open(fileName, 0); }
     /// Check if a file exists within the package file. This will be case-insensitive on Windows and case-sensitive on other platforms.
     virtual bool Exists(const String& fileName) const override;
     /// Get a PackedFile from the package contents
@@ -81,6 +83,9 @@ public:
 
     /// Return list of file names in the package.
     virtual const Vector<String> GetEntryNames() const override { return entries_.Keys(); }
+
+    /// Register object factory.
+    static void RegisterObject(Context* context);
 
 private:
     /// File entries.

--- a/Source/Urho3D/IO/PackageFile.h
+++ b/Source/Urho3D/IO/PackageFile.h
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include "../Core/Object.h"
+#include "../IO/FileSource.h"
 
 namespace Urho3D
 {
@@ -38,10 +38,12 @@ struct PackageEntry
     unsigned checksum_;
 };
 
+class PackedFile;
+
 /// Stores files of a directory tree sequentially for convenient access.
-class URHO3D_API PackageFile : public Object
+class URHO3D_API PackageFile : public FileSource
 {
-    URHO3D_OBJECT(PackageFile, Object);
+    URHO3D_OBJECT(PackageFile, FileSource);
 
 public:
     /// Construct.
@@ -52,46 +54,39 @@ public:
     virtual ~PackageFile() override;
 
     /// Open the package file. Return true if successful.
-    bool Open(const String& fileName, unsigned startOffset = 0);
+    virtual bool Open(const String& fileName, unsigned startOffset = 0) override;
     /// Check if a file exists within the package file. This will be case-insensitive on Windows and case-sensitive on other platforms.
-    bool Exists(const String& fileName) const;
+    virtual bool Exists(const String& fileName) const override;
+    /// TODO: NEL: If this SharedPtr thing doesn't work, just have it return SharedPtr<File> and add another GetNewFile that returns the raw pointer
+    /// Get a PackedFile from the package contents
+    virtual SharedPtr<PackedFile> GetFile(const String& fileName, FileMode mode = FILE_READ) const override;
     /// Return the file entry corresponding to the name, or null if not found. This will be case-insensitive on Windows and case-sensitive on other platforms.
     const PackageEntry* GetEntry(const String& fileName) const;
 
     /// Return all file entries.
     const HashMap<String, PackageEntry>& GetEntries() const { return entries_; }
 
-    /// Return the package file name.
-    const String& GetName() const { return fileName_; }
-
-    /// Return hash of the package file name.
-    StringHash GetNameHash() const { return nameHash_; }
-
     /// Return number of files.
-    unsigned GetNumFiles() const { return entries_.Size(); }
+    virtual unsigned GetNumFiles() const override { return entries_.Size(); }
 
     /// Return total size of the package file.
-    unsigned GetTotalSize() const { return totalSize_; }
+    virtual unsigned GetTotalSize() const override { return totalSize_; }
 
     /// Return total data size from all the file entries in the package file.
-    unsigned GetTotalDataSize() const { return totalDataSize_; }
+    virtual unsigned GetTotalDataSize() const override { return totalDataSize_; }
 
     /// Return checksum of the package file contents.
-    unsigned GetChecksum() const { return checksum_; }
+    virtual unsigned GetChecksum() const override { return checksum_; }
 
     /// Return whether the files are compressed.
-    bool IsCompressed() const { return compressed_; }
+    virtual bool IsCompressed() const override { return compressed_; }
 
     /// Return list of file names in the package.
-    const Vector<String> GetEntryNames() const { return entries_.Keys(); }
+    virtual const Vector<String> GetEntryNames() const override { return entries_.Keys(); }
 
 private:
     /// File entries.
     HashMap<String, PackageEntry> entries_;
-    /// File name.
-    String fileName_;
-    /// Package file name hash.
-    StringHash nameHash_;
     /// Package file total size.
     unsigned totalSize_;
     /// Total data size in the package using each entry's actual size if it is a compressed package file.

--- a/Source/Urho3D/IO/PackageFile.h
+++ b/Source/Urho3D/IO/PackageFile.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "../IO/FileSource.h"
+#include "../IO/PackedFile.h"
 
 namespace Urho3D
 {
@@ -38,8 +39,6 @@ struct PackageEntry
     unsigned checksum_;
 };
 
-class PackedFile;
-
 /// Stores files of a directory tree sequentially for convenient access.
 class URHO3D_API PackageFile : public FileSource
 {
@@ -54,12 +53,11 @@ public:
     virtual ~PackageFile() override;
 
     /// Open the package file. Return true if successful.
-    virtual bool Open(const String& fileName, unsigned startOffset = 0) override;
+    virtual bool Open(const String& fileName, unsigned startOffset = 0);// override;
     /// Check if a file exists within the package file. This will be case-insensitive on Windows and case-sensitive on other platforms.
     virtual bool Exists(const String& fileName) const override;
-    /// TODO: NEL: If this SharedPtr thing doesn't work, just have it return SharedPtr<File> and add another GetNewFile that returns the raw pointer
     /// Get a PackedFile from the package contents
-    virtual SharedPtr<PackedFile> GetFile(const String& fileName, FileMode mode = FILE_READ) const override;
+    virtual PackedFile* GetNewFile(const String& fileName, FileMode mode = FILE_READ) override;
     /// Return the file entry corresponding to the name, or null if not found. This will be case-insensitive on Windows and case-sensitive on other platforms.
     const PackageEntry* GetEntry(const String& fileName) const;
 

--- a/Source/Urho3D/IO/PackedFile.cpp
+++ b/Source/Urho3D/IO/PackedFile.cpp
@@ -344,11 +344,6 @@ void PackedFile::Flush()
         fflush((FILE*)handle_);
 }
 
-void PackedFile::SetName(const String& name)
-{
-    fileName_ = name;
-}
-
 bool PackedFile::IsOpen() const
 {
 #ifdef __ANDROID__

--- a/Source/Urho3D/IO/PackedFile.cpp
+++ b/Source/Urho3D/IO/PackedFile.cpp
@@ -1,0 +1,460 @@
+//
+// Copyright (c) 2008-2017 the Urho3D project.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include "../Precompiled.h"
+
+#include "../Core/Profiler.h"
+#include "../IO/File.h"
+#include "../IO/FileSystem.h"
+#include "../IO/Log.h"
+#include "../IO/MemoryBuffer.h"
+#include "../IO/PackageFile.h"
+#include "../IO/PackedFile.h"
+
+#ifdef __ANDROID__
+#include <SDL/SDL_rwops.h>
+#endif
+
+#include <cstdio>
+#include <LZ4/lz4.h>
+
+#include "../DebugNew.h"
+
+namespace Urho3D
+{
+
+
+#ifdef __ANDROID__
+const char* APK = "/apk/";
+static const unsigned READ_BUFFER_SIZE = 32768;
+#endif
+static const unsigned SKIP_BUFFER_SIZE = 1024;
+
+PackedFile::PackedFile(Context* context) :
+    Object(context),
+    mode_(FILE_READ),
+    handle_(nullptr),
+#ifdef __ANDROID__
+    assetHandle_(0),
+#endif
+    readBufferOffset_(0),
+    readBufferSize_(0),
+    offset_(0),
+    checksum_(0),
+    compressed_(false),
+    readSyncNeeded_(false),
+    writeSyncNeeded_(false)
+{
+}
+
+PackedFile::PackedFile(Context* context, PackageFile* package, const String& fileName) :
+    Object(context),
+    mode_(FILE_READ),
+    handle_(nullptr),
+#ifdef __ANDROID__
+    assetHandle_(0),
+#endif
+    readBufferOffset_(0),
+    readBufferSize_(0),
+    offset_(0),
+    checksum_(0),
+    compressed_(false),
+    readSyncNeeded_(false),
+    writeSyncNeeded_(false)
+{
+    Open(package, fileName);
+}
+
+PackedFile::~PackedFile()
+{
+    Close();
+}
+
+
+bool PackedFile::Open(PackageFile* package, const String& fileName)
+{
+    if (!package)
+        return false;
+
+    const PackageEntry* entry = package->GetEntry(fileName);
+    if (!entry)
+        return false;
+
+    bool success = OpenInternal(package->GetName());
+    if (!success)
+    {
+        URHO3D_LOGERROR("Could not open package file " + fileName);
+        return false;
+    }
+
+    fileName_ = fileName;
+    offset_ = entry->offset_;
+    checksum_ = entry->checksum_;
+    size_ = entry->size_;
+    compressed_ = package->IsCompressed();
+
+    // Seek to beginning of package entry's file data
+    SeekInternal(offset_);
+    return true;
+}
+
+unsigned PackedFile::Read(void* dest, unsigned size)
+{
+    if (!IsOpen())
+    {
+        // If file not open, do not log the error further here to prevent spamming the stderr stream
+        return 0;
+    }
+
+    if (mode_ == FILE_WRITE)
+    {
+        URHO3D_LOGERROR("PackedFile not opened for reading");
+        return 0;
+    }
+
+    if (size + position_ > size_)
+        size = size_ - position_;
+    if (!size)
+        return 0;
+
+#ifdef __ANDROID__
+    if (assetHandle_ && !compressed_)
+    {
+        // If not using a compressed package file, buffer file reads on Android for better performance
+        if (!readBuffer_)
+        {
+            readBuffer_ = new unsigned char[READ_BUFFER_SIZE];
+            readBufferOffset_ = 0;
+            readBufferSize_ = 0;
+        }
+
+        unsigned sizeLeft = size;
+        unsigned char* destPtr = (unsigned char*)dest;
+
+        while (sizeLeft)
+        {
+            if (readBufferOffset_ >= readBufferSize_)
+            {
+                readBufferSize_ = Min(size_ - position_, READ_BUFFER_SIZE);
+                readBufferOffset_ = 0;
+                ReadInternal(readBuffer_.Get(), readBufferSize_);
+            }
+
+            unsigned copySize = Min((readBufferSize_ - readBufferOffset_), sizeLeft);
+            memcpy(destPtr, readBuffer_.Get() + readBufferOffset_, copySize);
+            destPtr += copySize;
+            sizeLeft -= copySize;
+            readBufferOffset_ += copySize;
+            position_ += copySize;
+        }
+
+        return size;
+    }
+#endif
+
+    if (compressed_)
+    {
+        unsigned sizeLeft = size;
+        unsigned char* destPtr = (unsigned char*)dest;
+
+        while (sizeLeft)
+        {
+            if (!readBuffer_ || readBufferOffset_ >= readBufferSize_)
+            {
+                unsigned char blockHeaderBytes[4];
+                ReadInternal(blockHeaderBytes, sizeof blockHeaderBytes);
+
+                MemoryBuffer blockHeader(&blockHeaderBytes[0], sizeof blockHeaderBytes);
+                unsigned unpackedSize = blockHeader.ReadUShort();
+                unsigned packedSize = blockHeader.ReadUShort();
+
+                if (!readBuffer_)
+                {
+                    readBuffer_ = new unsigned char[unpackedSize];
+                    inputBuffer_ = new unsigned char[LZ4_compressBound(unpackedSize)];
+                }
+
+                /// \todo Handle errors
+                ReadInternal(inputBuffer_.Get(), packedSize);
+                LZ4_decompress_fast((const char*)inputBuffer_.Get(), (char*)readBuffer_.Get(), unpackedSize);
+
+                readBufferSize_ = unpackedSize;
+                readBufferOffset_ = 0;
+            }
+
+            unsigned copySize = Min((readBufferSize_ - readBufferOffset_), sizeLeft);
+            memcpy(destPtr, readBuffer_.Get() + readBufferOffset_, copySize);
+            destPtr += copySize;
+            sizeLeft -= copySize;
+            readBufferOffset_ += copySize;
+            position_ += copySize;
+        }
+
+        return size;
+    }
+
+    // Need to reassign the position due to internal buffering when transitioning from writing to reading
+    if (readSyncNeeded_)
+    {
+        SeekInternal(position_ + offset_);
+        readSyncNeeded_ = false;
+    }
+
+    if (!ReadInternal(dest, size))
+    {
+        // Return to the position where the read began
+        SeekInternal(position_ + offset_);
+        URHO3D_LOGERROR("Error while reading from file " + GetName());
+        return 0;
+    }
+
+    writeSyncNeeded_ = true;
+    position_ += size;
+    return size;
+}
+
+unsigned PackedFile::Seek(unsigned position)
+{
+    if (!IsOpen())
+    {
+        // If file not open, do not log the error further here to prevent spamming the stderr stream
+        return 0;
+    }
+
+    // Allow sparse seeks if writing
+    if (mode_ == FILE_READ && position > size_)
+        position = size_;
+
+    if (compressed_)
+    {
+        // Start over from the beginning
+        if (position == 0)
+        {
+            position_ = 0;
+            readBufferOffset_ = 0;
+            readBufferSize_ = 0;
+            SeekInternal(offset_);
+        }
+        // Skip bytes
+        else if (position >= position_)
+        {
+            unsigned char skipBuffer[SKIP_BUFFER_SIZE];
+            while (position > position_)
+                Read(skipBuffer, Min(position - position_, SKIP_BUFFER_SIZE));
+        }
+        else
+            URHO3D_LOGERROR("Seeking backward in a compressed file is not supported");
+
+        return position_;
+    }
+
+    SeekInternal(position + offset_);
+    position_ = position;
+    readSyncNeeded_ = false;
+    writeSyncNeeded_ = false;
+    return position_;
+}
+
+unsigned PackedFile::Write(const void* data, unsigned size)
+{
+    if (!IsOpen())
+    {
+        // If file not open, do not log the error further here to prevent spamming the stderr stream
+        return 0;
+    }
+
+    URHO3D_LOGERROR("PackedFile does not support writing. Tried to write to " + GetName());
+    return 0;
+}
+
+unsigned PackedFile::GetChecksum()
+{
+    if (offset_ || checksum_)
+        return checksum_;
+#ifdef __ANDROID__
+    if ((!handle_ && !assetHandle_) || mode_ == FILE_WRITE)
+#else
+    if (!handle_ || mode_ == FILE_WRITE)
+#endif
+        return 0;
+
+    URHO3D_PROFILE(CalculateFileChecksum);
+
+    unsigned oldPos = position_;
+    checksum_ = 0;
+
+    Seek(0);
+    while (!IsEof())
+    {
+        unsigned char block[1024];
+        unsigned readBytes = Read(block, 1024);
+        for (unsigned i = 0; i < readBytes; ++i)
+            checksum_ = SDBMHash(checksum_, block[i]);
+    }
+
+    Seek(oldPos);
+    return checksum_;
+}
+
+void PackedFile::Close()
+{
+#ifdef __ANDROID__
+    if (assetHandle_)
+    {
+        SDL_RWclose(assetHandle_);
+        assetHandle_ = 0;
+    }
+#endif
+
+    readBuffer_.Reset();
+    inputBuffer_.Reset();
+
+    if (handle_)
+    {
+        fclose((FILE*)handle_);
+        handle_ = nullptr;
+        position_ = 0;
+        size_ = 0;
+        offset_ = 0;
+        checksum_ = 0;
+    }
+}
+
+void PackedFile::Flush()
+{
+    if (handle_)
+        fflush((FILE*)handle_);
+}
+
+void PackedFile::SetName(const String& name)
+{
+    fileName_ = name;
+}
+
+bool PackedFile::IsOpen() const
+{
+#ifdef __ANDROID__
+    return handle_ != 0 || assetHandle_ != 0;
+#else
+    return handle_ != nullptr;
+#endif
+}
+
+bool PackedFile::OpenInternal(const String& fileName)
+{
+    Close();
+
+    compressed_ = false;
+    readSyncNeeded_ = false;
+    writeSyncNeeded_ = false;
+
+    FileSystem* fileSystem = GetSubsystem<FileSystem>();
+    if (fileSystem && !fileSystem->CheckAccess(GetPath(fileName)))
+    {
+        URHO3D_LOGERRORF("Access denied to %s", fileName.CString());
+        return false;
+    }
+
+    if (fileName.Empty())
+    {
+        URHO3D_LOGERROR("Could not open file with empty name");
+        return false;
+    }
+
+#ifdef __ANDROID__
+    if (URHO3D_IS_ASSET(fileName))
+    {
+        if (mode != FILE_READ)
+        {
+            URHO3D_LOGERROR("Only read mode is supported for Android asset files");
+            return false;
+        }
+
+        assetHandle_ = SDL_RWFromFile(URHO3D_ASSET(fileName), "rb");
+        if (!assetHandle_)
+        {
+            URHO3D_LOGERRORF("Could not open Android asset file %s", fileName.CString());
+            return false;
+        }
+        else
+        {
+            fileName_ = fileName;
+            mode_ = mode;
+            position_ = 0;
+            if (!fromPackage)
+            {
+                size_ = SDL_RWsize(assetHandle_);
+                offset_ = 0;
+            }
+            checksum_ = 0;
+            return true;
+        }
+    }
+#endif
+
+#ifdef _WIN32
+    handle_ = _wfopen(GetWideNativePath(fileName).CString(), L"rb");
+#else
+    handle_ = fopen(GetNativePath(fileName).CString(), "rb");
+#endif
+
+    if (!handle_)
+    {
+        URHO3D_LOGERRORF("Could not open file %s", fileName.CString());
+        return false;
+    }
+
+    fileName_ = fileName;
+    position_ = 0;
+    checksum_ = 0;
+
+    return true;
+}
+
+bool PackedFile::ReadInternal(void* dest, unsigned size)
+{
+#ifdef __ANDROID__
+    if (assetHandle_)
+    {
+        return SDL_RWread(assetHandle_, dest, size, 1) == 1;
+    }
+    else
+#endif
+        return fread(dest, size, 1, (FILE*)handle_) == 1;
+}
+
+void PackedFile::SeekInternal(unsigned newPosition)
+{
+#ifdef __ANDROID__
+    if (assetHandle_)
+    {
+        SDL_RWseek(assetHandle_, newPosition, SEEK_SET);
+        // Reset buffering after seek
+        readBufferOffset_ = 0;
+        readBufferSize_ = 0;
+    }
+    else
+#endif
+        fseek((FILE*)handle_, newPosition, SEEK_SET);
+}
+
+}

--- a/Source/Urho3D/IO/PackedFile.h
+++ b/Source/Urho3D/IO/PackedFile.h
@@ -80,11 +80,6 @@ public:
     void Close();
     /// Flush any buffered output to the file.
     void Flush();
-    /// Change the file name. Used by the resource system.
-    void SetName(const String& name);
-
-    /// Return the open mode.
-    FileMode GetMode() const { return FILE_READ; }
 
     /// Return whether is open.
     bool IsOpen() const;
@@ -103,8 +98,6 @@ private:
     /// Seek in file internally using either C standard IO functions or SDL RWops for Android asset files.
     void SeekInternal(unsigned newPosition);
 
-    /// File name.
-    String fileName_;
     /// File handle.
     void* handle_;
 #ifdef __ANDROID__

--- a/Source/Urho3D/IO/PackedFile.h
+++ b/Source/Urho3D/IO/PackedFile.h
@@ -90,7 +90,7 @@ public:
     void* GetHandle() const { return handle_; }
 
     /// Return whether the file originates from a package.
-    bool IsPackaged() const { return true; }
+    // bool IsPackaged() const { return true; }
 
 private:
     /// Open file internally using either C standard IO functions or SDL RWops for Android asset files. Return true if successful.

--- a/Source/Urho3D/IO/PackedFile.h
+++ b/Source/Urho3D/IO/PackedFile.h
@@ -57,8 +57,10 @@ class URHO3D_API PackedFile : public File
 public:
     /// Construct.
     PackedFile(Context* context);
+    /// Construct and open from the default package.
+    PackedFile(Context* context, const String& fileName, FileMode mode = FILE_READ);
     /// Construct and open from a package file.
-    PackedFile(Context* context, PackageFile* package, const String& fileName, FileMode mode = FILE_READ);
+    PackedFile(Context* context, FileSource* package, const String& fileName, FileMode mode = FILE_READ);
     /// Destruct. Close the file if open.
     virtual ~PackedFile() override;
 
@@ -72,8 +74,8 @@ public:
     /// Return a checksum of the file contents using the SDBM hash algorithm.
     virtual unsigned GetChecksum() override;
 
-    /// Open from within a package file. Return true if successful.
-    bool Open(PackageFile* package, const String& fileName, FileMode mode = FILE_READ);
+    // Open a file with the default PackageFile, as registered in the resource cache. Return true if successful.
+    using File::Open;
     /// Open from within a package file. Return true if successful.
     virtual bool Open(FileSource* package, const String& fileName, FileMode mode = FILE_READ) override;
     /// Close the file.

--- a/Source/Urho3D/IO/PackedFile.h
+++ b/Source/Urho3D/IO/PackedFile.h
@@ -24,7 +24,7 @@
 
 #include "../Container/ArrayPtr.h"
 #include "../Core/Object.h"
-#include "../IO/AbstractFile.h"
+#include "../IO/File.h"
 
 #ifdef __ANDROID__
 struct SDL_RWops;
@@ -48,10 +48,9 @@ extern const char* APK;
 
 
 class PackageFile;
-class File;
 
 /// %File opened either through the filesystem or from within a package file.
-class URHO3D_API PackedFile : public Object, public File
+class URHO3D_API PackedFile : public File
 {
     URHO3D_OBJECT(PackedFile, File);
 
@@ -59,7 +58,7 @@ public:
     /// Construct.
     PackedFile(Context* context);
     /// Construct and open from a package file.
-    PackedFile(Context* context, PackageFile* package, const String& fileName);
+    PackedFile(Context* context, PackageFile* package, const String& fileName, FileMode mode = FILE_READ);
     /// Destruct. Close the file if open.
     virtual ~PackedFile() override;
 
@@ -74,7 +73,9 @@ public:
     virtual unsigned GetChecksum() override;
 
     /// Open from within a package file. Return true if successful.
-    bool Open(PackageFile* package, const String& fileName);
+    bool Open(PackageFile* package, const String& fileName, FileMode mode = FILE_READ);
+    /// Open from within a package file. Return true if successful.
+    virtual bool Open(FileSource* package, const String& fileName, FileMode mode = FILE_READ) override;
     /// Close the file.
     void Close();
     /// Flush any buffered output to the file.
@@ -83,7 +84,7 @@ public:
     void SetName(const String& name);
 
     /// Return the open mode.
-    FileMode GetMode() const { return mode_; }
+    FileMode GetMode() const { return FILE_READ; }
 
     /// Return whether is open.
     bool IsOpen() const;

--- a/Source/Urho3D/IO/PackedFile.h
+++ b/Source/Urho3D/IO/PackedFile.h
@@ -1,0 +1,131 @@
+//
+// Copyright (c) 2008-2017 the Urho3D project.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+#include "../Container/ArrayPtr.h"
+#include "../Core/Object.h"
+#include "../IO/AbstractFile.h"
+
+#ifdef __ANDROID__
+struct SDL_RWops;
+#endif
+
+namespace Urho3D
+{
+
+#ifdef __ANDROID__
+extern const char* APK;
+
+// Macro for checking if a given pathname is inside APK's assets directory
+#define URHO3D_IS_ASSET(p) p.StartsWith(APK)
+// Macro for truncating the APK prefix string from the asset pathname and at the same time patching the directory name components (see custom_rules.xml)
+#ifdef ASSET_DIR_INDICATOR
+#define URHO3D_ASSET(p) p.Substring(5).Replaced("/", ASSET_DIR_INDICATOR "/").CString()
+#else
+#define URHO3D_ASSET(p) p.Substring(5).CString()
+#endif
+#endif
+
+
+class PackageFile;
+class File;
+
+/// %File opened either through the filesystem or from within a package file.
+class URHO3D_API PackedFile : public Object, public File
+{
+    URHO3D_OBJECT(PackedFile, File);
+
+public:
+    /// Construct.
+    PackedFile(Context* context);
+    /// Construct and open from a package file.
+    PackedFile(Context* context, PackageFile* package, const String& fileName);
+    /// Destruct. Close the file if open.
+    virtual ~PackedFile() override;
+
+    /// Read bytes from the file. Return number of bytes actually read.
+    virtual unsigned Read(void* dest, unsigned size) override;
+    /// Set position from the beginning of the file.
+    virtual unsigned Seek(unsigned position) override;
+    /// PackedFile cannot write. Logs an error if the file is open.
+    virtual unsigned Write(const void* data, unsigned size) override;
+
+    /// Return a checksum of the file contents using the SDBM hash algorithm.
+    virtual unsigned GetChecksum() override;
+
+    /// Open from within a package file. Return true if successful.
+    bool Open(PackageFile* package, const String& fileName);
+    /// Close the file.
+    void Close();
+    /// Flush any buffered output to the file.
+    void Flush();
+    /// Change the file name. Used by the resource system.
+    void SetName(const String& name);
+
+    /// Return the open mode.
+    FileMode GetMode() const { return mode_; }
+
+    /// Return whether is open.
+    bool IsOpen() const;
+
+    /// Return the file handle.
+    void* GetHandle() const { return handle_; }
+
+    /// Return whether the file originates from a package.
+    bool IsPackaged() const { return true; }
+
+private:
+    /// Open file internally using either C standard IO functions or SDL RWops for Android asset files. Return true if successful.
+    bool OpenInternal(const String& fileName);
+    /// Perform the file read internally using either C standard IO functions or SDL RWops for Android asset files. Return true if successful. This does not handle compressed package file reading.
+    bool ReadInternal(void* dest, unsigned size);
+    /// Seek in file internally using either C standard IO functions or SDL RWops for Android asset files.
+    void SeekInternal(unsigned newPosition);
+
+    /// File name.
+    String fileName_;
+    /// File handle.
+    void* handle_;
+#ifdef __ANDROID__
+    /// SDL RWops context for Android asset loading.
+    SDL_RWops* assetHandle_;
+#endif
+    /// Read buffer for Android asset or compressed file loading.
+    SharedArrayPtr<unsigned char> readBuffer_;
+    /// Decompression input buffer for compressed file loading.
+    SharedArrayPtr<unsigned char> inputBuffer_;
+    /// Read buffer position.
+    unsigned readBufferOffset_;
+    /// Bytes in the current read buffer.
+    unsigned readBufferSize_;
+    /// Start position within a package file, 0 for regular files.
+    unsigned offset_;
+    /// Content checksum.
+    unsigned checksum_;
+    /// Compression flag.
+    bool compressed_;
+    /// Synchronization needed before read -flag.
+    bool readSyncNeeded_;
+};
+
+}

--- a/Source/Urho3D/IO/PhysicalFile.cpp
+++ b/Source/Urho3D/IO/PhysicalFile.cpp
@@ -65,7 +65,7 @@ static const unsigned READ_BUFFER_SIZE = 32768;
 static const unsigned SKIP_BUFFER_SIZE = 1024;
 
 PhysicalFile::PhysicalFile(Context* context) :
-    Object(context),
+    File(context),
     mode_(FILE_READ),
     handle_(nullptr),
 #ifdef __ANDROID__
@@ -80,7 +80,7 @@ PhysicalFile::PhysicalFile(Context* context) :
 }
 
 PhysicalFile::PhysicalFile(Context* context, const String& fileName, FileMode mode) :
-    Object(context),
+    File(context),
     mode_(FILE_READ),
     handle_(nullptr),
 #ifdef __ANDROID__
@@ -163,7 +163,7 @@ unsigned PhysicalFile::Read(void* dest, unsigned size)
     // Need to reassign the position due to internal buffering when transitioning from writing to reading
     if (readSyncNeeded_)
     {
-        SeekInternal(position_ + offset_);
+        SeekInternal(position_);
         readSyncNeeded_ = false;
     }
 
@@ -219,7 +219,7 @@ unsigned PhysicalFile::Write(const void* data, unsigned size)
     // Need to reassign the position due to internal buffering when transitioning from reading to writing
     if (writeSyncNeeded_)
     {
-        fseek((FILE*)handle_, position_ + offset_, SEEK_SET);
+        fseek((FILE*)handle_, position_, SEEK_SET);
         writeSyncNeeded_ = false;
     }
 
@@ -352,7 +352,6 @@ bool PhysicalFile::OpenInternal(const String& fileName, FileMode mode)
             mode_ = mode;
             position_ = 0;
             size_ = SDL_RWsize(assetHandle_);
-            offset_ = 0;
             checksum_ = 0;
             return true;
         }

--- a/Source/Urho3D/IO/PhysicalFile.cpp
+++ b/Source/Urho3D/IO/PhysicalFile.cpp
@@ -1,0 +1,431 @@
+//
+// Copyright (c) 2008-2017 the Urho3D project.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include "../Precompiled.h"
+
+#include "../Core/Profiler.h"
+#include "../IO/PhysicalFile.h"
+#include "../IO/FileSystem.h"
+#include "../IO/Log.h"
+#include "../IO/MemoryBuffer.h"
+
+#ifdef __ANDROID__
+#include <SDL/SDL_rwops.h>
+#endif
+
+#include <cstdio>
+#include <LZ4/lz4.h>
+
+#include "../DebugNew.h"
+
+namespace Urho3D
+{
+
+#ifdef _WIN32
+static const wchar_t* openMode[] =
+{
+    L"rb",
+    L"wb",
+    L"r+b",
+    L"w+b"
+};
+#else
+static const char* openMode[] =
+{
+    "rb",
+    "wb",
+    "r+b",
+    "w+b"
+};
+#endif
+
+#ifdef __ANDROID__
+const char* APK = "/apk/";
+static const unsigned READ_BUFFER_SIZE = 32768;
+#endif
+static const unsigned SKIP_BUFFER_SIZE = 1024;
+
+PhysicalFile::PhysicalFile(Context* context) :
+    Object(context),
+    mode_(FILE_READ),
+    handle_(nullptr),
+#ifdef __ANDROID__
+    assetHandle_(0),
+#endif
+    readBufferOffset_(0),
+    readBufferSize_(0),
+    checksum_(0),
+    readSyncNeeded_(false),
+    writeSyncNeeded_(false)
+{
+}
+
+PhysicalFile::PhysicalFile(Context* context, const String& fileName, FileMode mode) :
+    Object(context),
+    mode_(FILE_READ),
+    handle_(nullptr),
+#ifdef __ANDROID__
+    assetHandle_(0),
+#endif
+    readBufferOffset_(0),
+    readBufferSize_(0),
+    checksum_(0),
+    readSyncNeeded_(false),
+    writeSyncNeeded_(false)
+{
+    Open(fileName, mode);
+}
+
+PhysicalFile::~PhysicalFile()
+{
+    Close();
+}
+
+bool PhysicalFile::Open(const String& fileName, FileMode mode)
+{
+    return OpenInternal(fileName, mode);
+}
+
+unsigned PhysicalFile::Read(void* dest, unsigned size)
+{
+    if (!IsOpen())
+    {
+        // If file not open, do not log the error further here to prevent spamming the stderr stream
+        return 0;
+    }
+
+    if (mode_ == FILE_WRITE)
+    {
+        URHO3D_LOGERROR("PhysicalFile not opened for reading");
+        return 0;
+    }
+
+    if (size + position_ > size_)
+        size = size_ - position_;
+    if (!size)
+        return 0;
+
+#ifdef __ANDROID__
+    if (assetHandle_)
+    {
+        // Buffer file reads on Android for better performance
+        if (!readBuffer_)
+        {
+            readBuffer_ = new unsigned char[READ_BUFFER_SIZE];
+            readBufferOffset_ = 0;
+            readBufferSize_ = 0;
+        }
+
+        unsigned sizeLeft = size;
+        unsigned char* destPtr = (unsigned char*)dest;
+
+        while (sizeLeft)
+        {
+            if (readBufferOffset_ >= readBufferSize_)
+            {
+                readBufferSize_ = Min(size_ - position_, READ_BUFFER_SIZE);
+                readBufferOffset_ = 0;
+                ReadInternal(readBuffer_.Get(), readBufferSize_);
+            }
+
+            unsigned copySize = Min((readBufferSize_ - readBufferOffset_), sizeLeft);
+            memcpy(destPtr, readBuffer_.Get() + readBufferOffset_, copySize);
+            destPtr += copySize;
+            sizeLeft -= copySize;
+            readBufferOffset_ += copySize;
+            position_ += copySize;
+        }
+
+        return size;
+    }
+#endif
+
+
+    // Need to reassign the position due to internal buffering when transitioning from writing to reading
+    if (readSyncNeeded_)
+    {
+        SeekInternal(position_ + offset_);
+        readSyncNeeded_ = false;
+    }
+
+    if (!ReadInternal(dest, size))
+    {
+        // Return to the position where the read began
+        SeekInternal(position_);
+        URHO3D_LOGERROR("Error while reading from file " + GetName());
+        return 0;
+    }
+
+    writeSyncNeeded_ = true;
+    position_ += size;
+    return size;
+}
+
+unsigned PhysicalFile::Seek(unsigned position)
+{
+    if (!IsOpen())
+    {
+        // If file not open, do not log the error further here to prevent spamming the stderr stream
+        return 0;
+    }
+
+    // Allow sparse seeks if writing
+    if (mode_ == FILE_READ && position > size_)
+        position = size_;
+
+    SeekInternal(position);
+    position_ = position;
+    readSyncNeeded_ = false;
+    writeSyncNeeded_ = false;
+    return position_;
+}
+
+unsigned PhysicalFile::Write(const void* data, unsigned size)
+{
+    if (!IsOpen())
+    {
+        // If file not open, do not log the error further here to prevent spamming the stderr stream
+        return 0;
+    }
+
+    if (mode_ == FILE_READ)
+    {
+        URHO3D_LOGERROR("PhysicalFile not opened for writing");
+        return 0;
+    }
+
+    if (!size)
+        return 0;
+
+    // Need to reassign the position due to internal buffering when transitioning from reading to writing
+    if (writeSyncNeeded_)
+    {
+        fseek((FILE*)handle_, position_ + offset_, SEEK_SET);
+        writeSyncNeeded_ = false;
+    }
+
+    if (fwrite(data, size, 1, (FILE*)handle_) != 1)
+    {
+        // Return to the position where the write began
+        fseek((FILE*)handle_, position_, SEEK_SET);
+        URHO3D_LOGERROR("Error while writing to file " + GetName());
+        return 0;
+    }
+
+    readSyncNeeded_ = true;
+    position_ += size;
+    if (position_ > size_)
+        size_ = position_;
+
+    return size;
+}
+
+unsigned PhysicalFile::GetChecksum()
+{
+    if (checksum_)
+        return checksum_;
+#ifdef __ANDROID__
+    if ((!handle_ && !assetHandle_) || mode_ == FILE_WRITE)
+#else
+    if (!handle_ || mode_ == FILE_WRITE)
+#endif
+        return 0;
+
+    URHO3D_PROFILE(CalculateFileChecksum);
+
+    unsigned oldPos = position_;
+    checksum_ = 0;
+
+    Seek(0);
+    while (!IsEof())
+    {
+        unsigned char block[1024];
+        unsigned readBytes = Read(block, 1024);
+        for (unsigned i = 0; i < readBytes; ++i)
+            checksum_ = SDBMHash(checksum_, block[i]);
+    }
+
+    Seek(oldPos);
+    return checksum_;
+}
+
+void PhysicalFile::Close()
+{
+#ifdef __ANDROID__
+    if (assetHandle_)
+    {
+        SDL_RWclose(assetHandle_);
+        assetHandle_ = 0;
+    }
+#endif
+
+    readBuffer_.Reset();
+    inputBuffer_.Reset();
+
+    if (handle_)
+    {
+        fclose((FILE*)handle_);
+        handle_ = nullptr;
+        position_ = 0;
+        size_ = 0;
+        checksum_ = 0;
+    }
+}
+
+void PhysicalFile::Flush()
+{
+    if (handle_)
+        fflush((FILE*)handle_);
+}
+
+void PhysicalFile::SetName(const String& name)
+{
+    fileName_ = name;
+}
+
+bool PhysicalFile::IsOpen() const
+{
+#ifdef __ANDROID__
+    return handle_ != 0 || assetHandle_ != 0;
+#else
+    return handle_ != nullptr;
+#endif
+}
+
+bool PhysicalFile::OpenInternal(const String& fileName, FileMode mode)
+{
+    Close();
+
+    readSyncNeeded_ = false;
+    writeSyncNeeded_ = false;
+    
+    FileSystem* fileSystem = GetSubsystem<FileSystem>();
+    if (fileSystem && !fileSystem->CheckAccess(GetPath(fileName)))
+    {
+        URHO3D_LOGERRORF("Access denied to %s", fileName.CString());
+        return false;
+    }
+
+    if (fileName.Empty())
+    {
+        URHO3D_LOGERROR("Could not open file with empty name");
+        return false;
+    }
+
+#ifdef __ANDROID__
+    if (URHO3D_IS_ASSET(fileName))
+    {
+        if (mode != FILE_READ)
+        {
+            URHO3D_LOGERROR("Only read mode is supported for Android asset files");
+            return false;
+        }
+
+        assetHandle_ = SDL_RWFromFile(URHO3D_ASSET(fileName), "rb");
+        if (!assetHandle_)
+        {
+            URHO3D_LOGERRORF("Could not open Android asset file %s", fileName.CString());
+            return false;
+        }
+        else
+        {
+            fileName_ = fileName;
+            mode_ = mode;
+            position_ = 0;
+            size_ = SDL_RWsize(assetHandle_);
+            offset_ = 0;
+            checksum_ = 0;
+            return true;
+        }
+    }
+#endif
+
+#ifdef _WIN32
+    handle_ = _wfopen(GetWideNativePath(fileName).CString(), openMode[mode]);
+#else
+    handle_ = fopen(GetNativePath(fileName).CString(), openMode[mode]);
+#endif
+
+    // If file did not exist in readwrite mode, retry with write-update mode
+    if (mode == FILE_READWRITE && !handle_)
+    {
+#ifdef _WIN32
+        handle_ = _wfopen(GetWideNativePath(fileName).CString(), openMode[mode + 1]);
+#else
+        handle_ = fopen(GetNativePath(fileName).CString(), openMode[mode + 1]);
+#endif
+    }
+
+    if (!handle_)
+    {
+        URHO3D_LOGERRORF("Could not open file %s", fileName.CString());
+        return false;
+    }
+
+    fseek((FILE*)handle_, 0, SEEK_END);
+    long size = ftell((FILE*)handle_);
+    fseek((FILE*)handle_, 0, SEEK_SET);
+    if (size > M_MAX_UNSIGNED)
+    {
+        URHO3D_LOGERRORF("Could not open file %s which is larger than 4GB", fileName.CString());
+        Close();
+        size_ = 0;
+        return false;
+    }
+    size_ = (unsigned)size;
+
+    fileName_ = fileName;
+    mode_ = mode;
+    position_ = 0;
+    checksum_ = 0;
+
+    return true;
+}
+
+bool PhysicalFile::ReadInternal(void* dest, unsigned size)
+{
+#ifdef __ANDROID__
+    if (assetHandle_)
+    {
+        return SDL_RWread(assetHandle_, dest, size, 1) == 1;
+    }
+    else
+#endif
+        return fread(dest, size, 1, (FILE*)handle_) == 1;
+}
+
+void PhysicalFile::SeekInternal(unsigned newPosition)
+{
+#ifdef __ANDROID__
+    if (assetHandle_)
+    {
+        SDL_RWseek(assetHandle_, newPosition, SEEK_SET);
+        // Reset buffering after seek
+        readBufferOffset_ = 0;
+        readBufferSize_ = 0;
+    }
+    else
+#endif
+        fseek((FILE*)handle_, newPosition, SEEK_SET);
+}
+
+}

--- a/Source/Urho3D/IO/PhysicalFile.h
+++ b/Source/Urho3D/IO/PhysicalFile.h
@@ -46,17 +46,9 @@ extern const char* APK;
 #endif
 #endif
 
-/// PhysicalFile open mode.
-enum FileMode
-{
-    FILE_READ = 0,
-    FILE_WRITE,
-    FILE_READWRITE
-};
-
 /// %PhysicalFile opened either through the filesystem or from within a package file.
 /// TODO: would SystemFile be a prefered name?
-class URHO3D_API PhysicalFile : public Object, public File
+class URHO3D_API PhysicalFile : public File
 {
     URHO3D_OBJECT(PhysicalFile, File);
 
@@ -81,6 +73,8 @@ public:
     /// Return a checksum of the file contents using the SDBM hash algorithm.
     virtual unsigned GetChecksum() override;
 
+    /// Open a filesystem file. Return true if successful.
+    bool Open(FileSource* source, const String& fileName, FileMode mode = FILE_READ) { return Open(fileName, mode); }
     /// Open a filesystem file. Return true if successful.
     bool Open(const String& fileName, FileMode mode = FILE_READ);
     /// Close the file.

--- a/Source/Urho3D/IO/PhysicalFile.h
+++ b/Source/Urho3D/IO/PhysicalFile.h
@@ -1,0 +1,139 @@
+//
+// Copyright (c) 2008-2017 the Urho3D project.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+#include "../Container/ArrayPtr.h"
+#include "../Core/Object.h"
+#include "../IO/File.h"
+
+#ifdef __ANDROID__
+struct SDL_RWops;
+#endif
+
+namespace Urho3D
+{
+
+#ifdef __ANDROID__
+extern const char* APK;
+
+// Macro for checking if a given pathname is inside APK's assets directory
+#define URHO3D_IS_ASSET(p) p.StartsWith(APK)
+// Macro for truncating the APK prefix string from the asset pathname and at the same time patching the directory name components (see custom_rules.xml)
+#ifdef ASSET_DIR_INDICATOR
+#define URHO3D_ASSET(p) p.Substring(5).Replaced("/", ASSET_DIR_INDICATOR "/").CString()
+#else
+#define URHO3D_ASSET(p) p.Substring(5).CString()
+#endif
+#endif
+
+/// PhysicalFile open mode.
+enum FileMode
+{
+    FILE_READ = 0,
+    FILE_WRITE,
+    FILE_READWRITE
+};
+
+/// %PhysicalFile opened either through the filesystem or from within a package file.
+/// TODO: would SystemFile be a prefered name?
+class URHO3D_API PhysicalFile : public Object, public File
+{
+    URHO3D_OBJECT(PhysicalFile, File);
+
+public:
+    /// Construct.
+    PhysicalFile(Context* context);
+    /// Construct and open a filesystem file.
+    PhysicalFile(Context* context, const String& fileName, FileMode mode = FILE_READ);
+    /// Destruct. Close the file if open.
+    virtual ~PhysicalFile() override;
+
+    /// Read bytes from the file. Return number of bytes actually read.
+    virtual unsigned Read(void* dest, unsigned size) override;
+    /// Set position from the beginning of the file.
+    virtual unsigned Seek(unsigned position) override;
+    /// Write bytes to the file. Return number of bytes actually written.
+    virtual unsigned Write(const void* data, unsigned size) override;
+
+    /// Return the file name.
+    virtual const String& GetName() const override { return fileName_; }
+
+    /// Return a checksum of the file contents using the SDBM hash algorithm.
+    virtual unsigned GetChecksum() override;
+
+    /// Open a filesystem file. Return true if successful.
+    bool Open(const String& fileName, FileMode mode = FILE_READ);
+    /// Close the file.
+    void Close();
+    /// Flush any buffered output to the file.
+    void Flush();
+    /// Change the file name. Used by the resource system.
+    void SetName(const String& name);
+
+    /// Return the open mode.
+    FileMode GetMode() const { return mode_; }
+
+    /// Return whether is open.
+    bool IsOpen() const;
+
+    /// Return the file handle.
+    void* GetHandle() const { return handle_; }
+
+    /// Return whether the file originates from a package.
+    bool IsPackaged() const { return false; }
+
+private:
+    /// Open file internally using either C standard IO functions or SDL RWops for Android asset files. Return true if successful.
+    bool OpenInternal(const String& fileName, FileMode mode);
+    /// Perform the file read internally using either C standard IO functions or SDL RWops for Android asset files. Return true if successful.
+    bool ReadInternal(void* dest, unsigned size);
+    /// Seek in file internally using either C standard IO functions or SDL RWops for Android asset files.
+    void SeekInternal(unsigned newPosition);
+
+    /// PhysicalFile name.
+    String fileName_;
+    /// Open mode.
+    FileMode mode_;
+    /// PhysicalFile handle.
+    void* handle_;
+#ifdef __ANDROID__
+    /// SDL RWops context for Android asset loading.
+    SDL_RWops* assetHandle_;
+#endif
+    /// Read buffer for Android asset or compressed file loading.
+    SharedArrayPtr<unsigned char> readBuffer_;
+    /// Decompression input buffer for compressed file loading.
+    SharedArrayPtr<unsigned char> inputBuffer_;
+    /// Read buffer position.
+    unsigned readBufferOffset_;
+    /// Bytes in the current read buffer.
+    unsigned readBufferSize_;
+    /// Content checksum.
+    unsigned checksum_;
+    /// Synchronization needed before read -flag.
+    bool readSyncNeeded_;
+    /// Synchronization needed before write -flag.
+    bool writeSyncNeeded_;
+};
+
+}

--- a/Source/Urho3D/IO/SystemFile.cpp
+++ b/Source/Urho3D/IO/SystemFile.cpp
@@ -23,7 +23,7 @@
 #include "../Precompiled.h"
 
 #include "../Core/Profiler.h"
-#include "../IO/PhysicalFile.h"
+#include "../IO/SystemFile.h"
 #include "../IO/FileSystem.h"
 #include "../IO/Log.h"
 #include "../IO/MemoryBuffer.h"
@@ -64,9 +64,8 @@ static const unsigned READ_BUFFER_SIZE = 32768;
 #endif
 static const unsigned SKIP_BUFFER_SIZE = 1024;
 
-PhysicalFile::PhysicalFile(Context* context) :
+SystemFile::SystemFile(Context* context) :
     File(context),
-    mode_(FILE_READ),
     handle_(nullptr),
 #ifdef __ANDROID__
     assetHandle_(0),
@@ -79,9 +78,8 @@ PhysicalFile::PhysicalFile(Context* context) :
 {
 }
 
-PhysicalFile::PhysicalFile(Context* context, const String& fileName, FileMode mode) :
+SystemFile::SystemFile(Context* context, const String& fileName, FileMode mode) :
     File(context),
-    mode_(FILE_READ),
     handle_(nullptr),
 #ifdef __ANDROID__
     assetHandle_(0),
@@ -95,17 +93,17 @@ PhysicalFile::PhysicalFile(Context* context, const String& fileName, FileMode mo
     Open(fileName, mode);
 }
 
-PhysicalFile::~PhysicalFile()
+SystemFile::~SystemFile()
 {
     Close();
 }
 
-bool PhysicalFile::Open(const String& fileName, FileMode mode)
+bool SystemFile::Open(const String& fileName, FileMode mode)
 {
     return OpenInternal(fileName, mode);
 }
 
-unsigned PhysicalFile::Read(void* dest, unsigned size)
+unsigned SystemFile::Read(void* dest, unsigned size)
 {
     if (!IsOpen())
     {
@@ -115,7 +113,7 @@ unsigned PhysicalFile::Read(void* dest, unsigned size)
 
     if (mode_ == FILE_WRITE)
     {
-        URHO3D_LOGERROR("PhysicalFile not opened for reading");
+        URHO3D_LOGERROR("File not opened for reading");
         return 0;
     }
 
@@ -180,7 +178,7 @@ unsigned PhysicalFile::Read(void* dest, unsigned size)
     return size;
 }
 
-unsigned PhysicalFile::Seek(unsigned position)
+unsigned SystemFile::Seek(unsigned position)
 {
     if (!IsOpen())
     {
@@ -199,7 +197,7 @@ unsigned PhysicalFile::Seek(unsigned position)
     return position_;
 }
 
-unsigned PhysicalFile::Write(const void* data, unsigned size)
+unsigned SystemFile::Write(const void* data, unsigned size)
 {
     if (!IsOpen())
     {
@@ -209,7 +207,7 @@ unsigned PhysicalFile::Write(const void* data, unsigned size)
 
     if (mode_ == FILE_READ)
     {
-        URHO3D_LOGERROR("PhysicalFile not opened for writing");
+        URHO3D_LOGERROR("File not opened for writing");
         return 0;
     }
 
@@ -239,7 +237,7 @@ unsigned PhysicalFile::Write(const void* data, unsigned size)
     return size;
 }
 
-unsigned PhysicalFile::GetChecksum()
+unsigned SystemFile::GetChecksum()
 {
     if (checksum_)
         return checksum_;
@@ -268,7 +266,7 @@ unsigned PhysicalFile::GetChecksum()
     return checksum_;
 }
 
-void PhysicalFile::Close()
+void SystemFile::Close()
 {
 #ifdef __ANDROID__
     if (assetHandle_)
@@ -291,18 +289,13 @@ void PhysicalFile::Close()
     }
 }
 
-void PhysicalFile::Flush()
+void SystemFile::Flush()
 {
     if (handle_)
         fflush((FILE*)handle_);
 }
 
-void PhysicalFile::SetName(const String& name)
-{
-    fileName_ = name;
-}
-
-bool PhysicalFile::IsOpen() const
+bool SystemFile::IsOpen() const
 {
 #ifdef __ANDROID__
     return handle_ != 0 || assetHandle_ != 0;
@@ -311,7 +304,7 @@ bool PhysicalFile::IsOpen() const
 #endif
 }
 
-bool PhysicalFile::OpenInternal(const String& fileName, FileMode mode)
+bool SystemFile::OpenInternal(const String& fileName, FileMode mode)
 {
     Close();
 
@@ -400,7 +393,7 @@ bool PhysicalFile::OpenInternal(const String& fileName, FileMode mode)
     return true;
 }
 
-bool PhysicalFile::ReadInternal(void* dest, unsigned size)
+bool SystemFile::ReadInternal(void* dest, unsigned size)
 {
 #ifdef __ANDROID__
     if (assetHandle_)
@@ -412,7 +405,7 @@ bool PhysicalFile::ReadInternal(void* dest, unsigned size)
         return fread(dest, size, 1, (FILE*)handle_) == 1;
 }
 
-void PhysicalFile::SeekInternal(unsigned newPosition)
+void SystemFile::SeekInternal(unsigned newPosition)
 {
 #ifdef __ANDROID__
     if (assetHandle_)

--- a/Source/Urho3D/IO/SystemFile.cpp
+++ b/Source/Urho3D/IO/SystemFile.cpp
@@ -93,6 +93,12 @@ SystemFile::SystemFile(Context* context, const String& fileName, FileMode mode) 
     Open(fileName, mode);
 }
 
+SystemFile::SystemFile(Context *context, FileSource*, const String &fileName, FileMode mode) :
+    SystemFile(context, fileName, mode)
+{
+
+}
+
 SystemFile::~SystemFile()
 {
     Close();

--- a/Source/Urho3D/IO/SystemFile.h
+++ b/Source/Urho3D/IO/SystemFile.h
@@ -46,19 +46,19 @@ extern const char* APK;
 #endif
 #endif
 
-/// %PhysicalFile opened either through the filesystem or from within a package file.
+/// %SystemFile opened either through the filesystem or from within a package file.
 /// TODO: would SystemFile be a prefered name?
-class URHO3D_API PhysicalFile : public File
+class URHO3D_API SystemFile : public File
 {
-    URHO3D_OBJECT(PhysicalFile, File);
+    URHO3D_OBJECT(SystemFile, File);
 
 public:
     /// Construct.
-    PhysicalFile(Context* context);
+    SystemFile(Context* context);
     /// Construct and open a filesystem file.
-    PhysicalFile(Context* context, const String& fileName, FileMode mode = FILE_READ);
+    SystemFile(Context* context, const String& fileName, FileMode mode = FILE_READ);
     /// Destruct. Close the file if open.
-    virtual ~PhysicalFile() override;
+    virtual ~SystemFile() override;
 
     /// Read bytes from the file. Return number of bytes actually read.
     virtual unsigned Read(void* dest, unsigned size) override;
@@ -66,9 +66,6 @@ public:
     virtual unsigned Seek(unsigned position) override;
     /// Write bytes to the file. Return number of bytes actually written.
     virtual unsigned Write(const void* data, unsigned size) override;
-
-    /// Return the file name.
-    virtual const String& GetName() const override { return fileName_; }
 
     /// Return a checksum of the file contents using the SDBM hash algorithm.
     virtual unsigned GetChecksum() override;
@@ -81,11 +78,6 @@ public:
     void Close();
     /// Flush any buffered output to the file.
     void Flush();
-    /// Change the file name. Used by the resource system.
-    void SetName(const String& name);
-
-    /// Return the open mode.
-    FileMode GetMode() const { return mode_; }
 
     /// Return whether is open.
     bool IsOpen() const;
@@ -104,11 +96,7 @@ private:
     /// Seek in file internally using either C standard IO functions or SDL RWops for Android asset files.
     void SeekInternal(unsigned newPosition);
 
-    /// PhysicalFile name.
-    String fileName_;
-    /// Open mode.
-    FileMode mode_;
-    /// PhysicalFile handle.
+    /// File handle.
     void* handle_;
 #ifdef __ANDROID__
     /// SDL RWops context for Android asset loading.

--- a/Source/Urho3D/IO/SystemFile.h
+++ b/Source/Urho3D/IO/SystemFile.h
@@ -88,7 +88,7 @@ public:
     void* GetHandle() const { return handle_; }
 
     /// Return whether the file originates from a package.
-    bool IsPackaged() const { return false; }
+//    bool IsPackaged() const { return false; }
 
 private:
     /// Open file internally using either C standard IO functions or SDL RWops for Android asset files. Return true if successful.

--- a/Source/Urho3D/IO/SystemFile.h
+++ b/Source/Urho3D/IO/SystemFile.h
@@ -57,6 +57,8 @@ public:
     SystemFile(Context* context);
     /// Construct and open a filesystem file.
     SystemFile(Context* context, const String& fileName, FileMode mode = FILE_READ);
+    /// Construct and open a filesystem file. FilseSource* ignored.
+    SystemFile(Context* context, FileSource*, const String& fileName, FileMode mode = FILE_READ);
     /// Destruct. Close the file if open.
     virtual ~SystemFile() override;
 

--- a/Source/Urho3D/LuaScript/pkgs/Audio/Sound.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Audio/Sound.pkg
@@ -1,4 +1,4 @@
-$#include "IO/File.h"
+$#include "IO/SystemFile.h"
 $#include "Audio/Sound.h"
 
 class Sound : public ResourceWithMetadata
@@ -58,7 +58,7 @@ static bool SoundLoadRaw(Sound* sound, const String& fileName)
     if (!sound)
         return false;
 
-    File file(sound->GetContext());
+    SystemFile file(sound->GetContext());
     if (!file.Open(fileName, FILE_READ))
         return false;
 
@@ -70,7 +70,7 @@ static bool SoundLoadWav(Sound* sound, const String& fileName)
     if (!sound)
         return false;
 
-    File file(sound->GetContext());
+    SystemFile file(sound->GetContext());
     if (!file.Open(fileName, FILE_READ))
         return false;
 
@@ -82,7 +82,7 @@ static bool SoundLoadOggVorbis(Sound* sound, const String& fileName)
     if (!sound)
         return false;
 
-    File file(sound->GetContext());
+    SystemFile file(sound->GetContext());
     if (!file.Open(fileName, FILE_READ))
         return false;
 

--- a/Source/Urho3D/LuaScript/pkgs/Graphics/Graphics.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Graphics/Graphics.pkg
@@ -1,4 +1,4 @@
-$#include "IO/File.h"
+$#include "IO/SystemFile.h"
 $#include "Graphics/Graphics.h"
 
 class Graphics : public Object
@@ -132,7 +132,7 @@ static void GraphicsPrecacheShaders(Graphics* graphics, const String& fileName)
     if (!graphics)
         return;
 
-    File file(graphics->GetContext());
+    SystemFile file(graphics->GetContext());
     if (file.Open(fileName, FILE_READ))
         graphics->PrecacheShaders(file);
 }

--- a/Source/Urho3D/LuaScript/pkgs/IO/File.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/IO/File.pkg
@@ -123,7 +123,6 @@ class File : public Object
     
     tolua_readonly tolua_property__get_set FileMode mode;
     tolua_readonly tolua_property__is_set bool open;
-    // tolua_readonly tolua_property__is_set bool packaged;
     
     // From Deserializer
     tolua_readonly tolua_property__get_set String name;

--- a/Source/Urho3D/LuaScript/pkgs/IO/FileSource.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/IO/FileSource.pkg
@@ -1,0 +1,23 @@
+$#include "IO/FileSource.h"
+
+class FileSource : public Object
+{
+    bool Open(const String fileName);
+    bool Exists(const String fileName) const;
+
+    const String GetName() const;
+    StringHash GetNameHash() const;
+    unsigned GetNumFiles() const;
+    unsigned GetTotalSize() const;
+    unsigned GetTotalDataSize() const;
+    unsigned GetChecksum() const;
+    bool IsCompressed() const;
+
+    tolua_readonly tolua_property__get_set String name;
+    tolua_readonly tolua_property__get_set StringHash nameHash;
+    tolua_readonly tolua_property__get_set unsigned numFiles;
+    tolua_readonly tolua_property__get_set unsigned totalSize;
+    tolua_readonly tolua_property__get_set unsigned totalDataSize;
+    tolua_readonly tolua_property__get_set unsigned checksum;
+    tolua_readonly tolua_property__is_set bool compressed;
+};

--- a/Source/Urho3D/LuaScript/pkgs/IO/PackageFile.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/IO/PackageFile.pkg
@@ -7,13 +7,14 @@ struct PackageEntry
     unsigned checksum_ @ checksum;
 };
 
-class PackageFile : public Object
+class PackageFile : public FileSource
 {
     PackageFile();
     PackageFile(const String fileName, unsigned startOffset = 0);
     ~PackageFile();
 
-    bool Open(const String fileName, unsigned startOffset = 0);
+    bool Open(const String fileName);
+    bool Open(const String fileName, unsigned startOffset);
     bool Exists(const String fileName) const;
     const PackageEntry* GetEntry(const String fileName) const;
     const HashMap<String, PackageEntry>& GetEntries() const;

--- a/Source/Urho3D/LuaScript/pkgs/IO/PackedFile.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/IO/PackedFile.pkg
@@ -1,16 +1,15 @@
-$#include "IO/File.h"
+$#include "IO/PackedFile.h"
 
-enum FileMode
+class PackedFile : public File
 {
-    FILE_READ = 0,
-    FILE_WRITE,
-    FILE_READWRITE
-};
-
-class File : public Object
-{
+    PackedFile();
+    PackedFile(const String fileName, FileMode mode = FILE_READ);
+    PackedFile(PackageFile* package, const String fileName);
+    ~PackedFile();
+    
+    // From File
     bool Open(const String fileName, FileMode mode = FILE_READ);
-    bool Open(FileSource* source, const String fileName, FileMode mode = FILE_READ);
+    bool Open(PackageFile* package, const String fileName, FileMode mode = FILE_READ);
     void Close();
     void Flush();
     void SetName(const String name);
@@ -18,6 +17,7 @@ class File : public Object
     FileMode GetMode() const;
     bool IsOpen() const;
     void* GetHandle() const;
+    // bool IsPackaged() const;
     
     // From Deserializer
     // unsigned Read(void* dest, unsigned size);
@@ -132,3 +132,123 @@ class File : public Object
     tolua_readonly tolua_property__get_set unsigned size;
     tolua_readonly tolua_property__is_set bool eof;
 };
+
+${
+#define TOLUA_DISABLE_tolua_IOLuaAPI_PackedFile_new00
+static int tolua_IOLuaAPI_PackedFile_new00(lua_State* tolua_S)
+{
+    return ToluaNewObject<PackedFile>(tolua_S);
+}
+
+#define TOLUA_DISABLE_tolua_IOLuaAPI_PackedFile_new00_local
+static int tolua_IOLuaAPI_PackedFile_new00_local(lua_State* tolua_S)
+{
+    return ToluaNewObjectGC<PackedFile>(tolua_S);
+}
+
+/* method: new of class  PackedFile */
+#define TOLUA_DISABLE_tolua_IOLuaAPI_PackedFile_new01
+static int tolua_IOLuaAPI_PackedFile_new01(lua_State* tolua_S)
+{
+ tolua_Error tolua_err;
+ if (
+ !tolua_isusertable(tolua_S,1,"PackedFile",0,&tolua_err) ||
+ !tolua_isurho3dstring(tolua_S,2,0,&tolua_err) ||
+ !tolua_isnumber(tolua_S,3,1,&tolua_err) ||
+ !tolua_isnoobj(tolua_S,4,&tolua_err)
+ )
+ goto tolua_lerror;
+ else
+ {
+  const String fileName = ((const String)  tolua_tourho3dstring(tolua_S,2,0));
+  FileMode mode = ((FileMode) (int)  tolua_tonumber(tolua_S,3,FILE_READ));
+ {
+  PackedFile* tolua_ret = (PackedFile*)  Mtolua_new((PackedFile)(GetContext(tolua_S),fileName,mode));
+  tolua_pushusertype(tolua_S,(void*)tolua_ret,"PackedFile");
+ }
+ }
+ return 1;
+tolua_lerror:
+ return tolua_IOLuaAPI_PackedFile_new00(tolua_S);
+}
+
+/* method: new_local of class  PackedFile */
+#define TOLUA_DISABLE_tolua_IOLuaAPI_PackedFile_new01_local
+static int tolua_IOLuaAPI_PackedFile_new01_local(lua_State* tolua_S)
+{
+ tolua_Error tolua_err;
+ if (
+ !tolua_isusertable(tolua_S,1,"PackedFile",0,&tolua_err) ||
+ !tolua_isurho3dstring(tolua_S,2,0,&tolua_err) ||
+ !tolua_isnumber(tolua_S,3,1,&tolua_err) ||
+ !tolua_isnoobj(tolua_S,4,&tolua_err)
+ )
+ goto tolua_lerror;
+ else
+ {
+  const String fileName = ((const String)  tolua_tourho3dstring(tolua_S,2,0));
+  FileMode mode = ((FileMode) (int)  tolua_tonumber(tolua_S,3,FILE_READ));
+ {
+  PackedFile* tolua_ret = (PackedFile*)  Mtolua_new((PackedFile)(GetContext(tolua_S),fileName,mode));
+  tolua_pushusertype(tolua_S,(void*)tolua_ret,"PackedFile");
+ tolua_register_gc(tolua_S,lua_gettop(tolua_S));
+ }
+ }
+ return 1;
+tolua_lerror:
+ return tolua_IOLuaAPI_PackedFile_new00_local(tolua_S);
+}
+
+/* method: new of class  PackedFile */
+#define TOLUA_DISABLE_tolua_IOLuaAPI_PackedFile_new02
+static int tolua_IOLuaAPI_PackedFile_new02(lua_State* tolua_S)
+{
+ tolua_Error tolua_err;
+ if (
+ !tolua_isusertable(tolua_S,1,"PackedFile",0,&tolua_err) ||
+ !tolua_isusertype(tolua_S,2,"PackageFile",0,&tolua_err) ||
+ !tolua_isurho3dstring(tolua_S,3,0,&tolua_err) ||
+ !tolua_isnoobj(tolua_S,4,&tolua_err)
+ )
+ goto tolua_lerror;
+ else
+ {
+  PackageFile* package = ((PackageFile*)  tolua_tousertype(tolua_S,2,0));
+  const String fileName = ((const String)  tolua_tourho3dstring(tolua_S,3,0));
+ {
+  PackedFile* tolua_ret = (PackedFile*)  Mtolua_new((PackedFile)(GetContext(tolua_S),package,fileName));
+  tolua_pushusertype(tolua_S,(void*)tolua_ret,"PackedFile");
+ }
+ }
+ return 1;
+tolua_lerror:
+ return tolua_IOLuaAPI_PackedFile_new01(tolua_S);
+}
+
+/* method: new_local of class  PackedFile */
+#define TOLUA_DISABLE_tolua_IOLuaAPI_PackedFile_new02_local
+static int tolua_IOLuaAPI_PackedFile_new02_local(lua_State* tolua_S)
+{
+ tolua_Error tolua_err;
+ if (
+ !tolua_isusertable(tolua_S,1,"PackedFile",0,&tolua_err) ||
+ !tolua_isusertype(tolua_S,2,"PackageFile",0,&tolua_err) ||
+ !tolua_isurho3dstring(tolua_S,3,0,&tolua_err) ||
+ !tolua_isnoobj(tolua_S,4,&tolua_err)
+ )
+ goto tolua_lerror;
+ else
+ {
+  PackageFile* package = ((PackageFile*)  tolua_tousertype(tolua_S,2,0));
+  const String fileName = ((const String)  tolua_tourho3dstring(tolua_S,3,0));
+ {
+  PackedFile* tolua_ret = (PackedFile*)  Mtolua_new((PackedFile)(GetContext(tolua_S),package,fileName));
+  tolua_pushusertype(tolua_S,(void*)tolua_ret,"PackedFile");
+ tolua_register_gc(tolua_S,lua_gettop(tolua_S));
+ }
+ }
+ return 1;
+tolua_lerror:
+ return tolua_IOLuaAPI_PackedFile_new01_local(tolua_S);
+}
+$}

--- a/Source/Urho3D/LuaScript/pkgs/IO/PackedFile.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/IO/PackedFile.pkg
@@ -17,7 +17,6 @@ class PackedFile : public File
     FileMode GetMode() const;
     bool IsOpen() const;
     void* GetHandle() const;
-    // bool IsPackaged() const;
     
     // From Deserializer
     // unsigned Read(void* dest, unsigned size);
@@ -123,7 +122,6 @@ class PackedFile : public File
     
     tolua_readonly tolua_property__get_set FileMode mode;
     tolua_readonly tolua_property__is_set bool open;
-    // tolua_readonly tolua_property__is_set bool packaged;
     
     // From Deserializer
     tolua_readonly tolua_property__get_set String name;

--- a/Source/Urho3D/LuaScript/pkgs/IO/SystemFile.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/IO/SystemFile.pkg
@@ -17,7 +17,6 @@ class SystemFile : public File
     FileMode GetMode() const;
     bool IsOpen() const;
     void* GetHandle() const;
-    // bool IsPackaged() const;
     
     // From Deserializer
     // unsigned Read(void* dest, unsigned size);
@@ -123,7 +122,6 @@ class SystemFile : public File
     
     tolua_readonly tolua_property__get_set FileMode mode;
     tolua_readonly tolua_property__is_set bool open;
-    // tolua_readonly tolua_property__is_set bool packaged;
     
     // From Deserializer
     tolua_readonly tolua_property__get_set String name;

--- a/Source/Urho3D/LuaScript/pkgs/IO/SystemFile.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/IO/SystemFile.pkg
@@ -1,16 +1,15 @@
-$#include "IO/File.h"
+$#include "IO/SystemFile.h"
 
-enum FileMode
+class SystemFile : public File
 {
-    FILE_READ = 0,
-    FILE_WRITE,
-    FILE_READWRITE
-};
-
-class File : public Object
-{
+    SystemFile();
+    SystemFile(const String fileName, FileMode mode = FILE_READ);
+    SystemFile(PackageFile* package, const String fileName);
+    ~SystemFile();
+    
+    // From File
     bool Open(const String fileName, FileMode mode = FILE_READ);
-    bool Open(FileSource* source, const String fileName, FileMode mode = FILE_READ);
+    bool Open(PackageFile* package, const String fileName, FileMode mode = FILE_READ);
     void Close();
     void Flush();
     void SetName(const String name);
@@ -18,6 +17,7 @@ class File : public Object
     FileMode GetMode() const;
     bool IsOpen() const;
     void* GetHandle() const;
+    // bool IsPackaged() const;
     
     // From Deserializer
     // unsigned Read(void* dest, unsigned size);
@@ -132,3 +132,123 @@ class File : public Object
     tolua_readonly tolua_property__get_set unsigned size;
     tolua_readonly tolua_property__is_set bool eof;
 };
+
+${
+#define TOLUA_DISABLE_tolua_IOLuaAPI_SystemFile_new00
+static int tolua_IOLuaAPI_SystemFile_new00(lua_State* tolua_S)
+{
+    return ToluaNewObject<SystemFile>(tolua_S);
+}
+
+#define TOLUA_DISABLE_tolua_IOLuaAPI_SystemFile_new00_local
+static int tolua_IOLuaAPI_SystemFile_new00_local(lua_State* tolua_S)
+{
+    return ToluaNewObjectGC<SystemFile>(tolua_S);
+}
+
+/* method: new of class  SystemFile */
+#define TOLUA_DISABLE_tolua_IOLuaAPI_SystemFile_new01
+static int tolua_IOLuaAPI_SystemFile_new01(lua_State* tolua_S)
+{
+ tolua_Error tolua_err;
+ if (
+ !tolua_isusertable(tolua_S,1,"SystemFile",0,&tolua_err) ||
+ !tolua_isurho3dstring(tolua_S,2,0,&tolua_err) ||
+ !tolua_isnumber(tolua_S,3,1,&tolua_err) ||
+ !tolua_isnoobj(tolua_S,4,&tolua_err)
+ )
+ goto tolua_lerror;
+ else
+ {
+  const String fileName = ((const String)  tolua_tourho3dstring(tolua_S,2,0));
+  FileMode mode = ((FileMode) (int)  tolua_tonumber(tolua_S,3,FILE_READ));
+ {
+  SystemFile* tolua_ret = (SystemFile*)  Mtolua_new((SystemFile)(GetContext(tolua_S),fileName,mode));
+  tolua_pushusertype(tolua_S,(void*)tolua_ret,"SystemFile");
+ }
+ }
+ return 1;
+tolua_lerror:
+ return tolua_IOLuaAPI_SystemFile_new00(tolua_S);
+}
+
+/* method: new_local of class  SystemFile */
+#define TOLUA_DISABLE_tolua_IOLuaAPI_SystemFile_new01_local
+static int tolua_IOLuaAPI_SystemFile_new01_local(lua_State* tolua_S)
+{
+ tolua_Error tolua_err;
+ if (
+ !tolua_isusertable(tolua_S,1,"SystemFile",0,&tolua_err) ||
+ !tolua_isurho3dstring(tolua_S,2,0,&tolua_err) ||
+ !tolua_isnumber(tolua_S,3,1,&tolua_err) ||
+ !tolua_isnoobj(tolua_S,4,&tolua_err)
+ )
+ goto tolua_lerror;
+ else
+ {
+  const String fileName = ((const String)  tolua_tourho3dstring(tolua_S,2,0));
+  FileMode mode = ((FileMode) (int)  tolua_tonumber(tolua_S,3,FILE_READ));
+ {
+  SystemFile* tolua_ret = (SystemFile*)  Mtolua_new((SystemFile)(GetContext(tolua_S),fileName,mode));
+  tolua_pushusertype(tolua_S,(void*)tolua_ret,"SystemFile");
+ tolua_register_gc(tolua_S,lua_gettop(tolua_S));
+ }
+ }
+ return 1;
+tolua_lerror:
+ return tolua_IOLuaAPI_SystemFile_new00_local(tolua_S);
+}
+
+/* method: new of class  SystemFile */
+#define TOLUA_DISABLE_tolua_IOLuaAPI_SystemFile_new02
+static int tolua_IOLuaAPI_SystemFile_new02(lua_State* tolua_S)
+{
+ tolua_Error tolua_err;
+ if (
+ !tolua_isusertable(tolua_S,1,"SystemFile",0,&tolua_err) ||
+ !tolua_isusertype(tolua_S,2,"PackageFile",0,&tolua_err) ||
+ !tolua_isurho3dstring(tolua_S,3,0,&tolua_err) ||
+ !tolua_isnoobj(tolua_S,4,&tolua_err)
+ )
+ goto tolua_lerror;
+ else
+ {
+  PackageFile* package = ((PackageFile*)  tolua_tousertype(tolua_S,2,0));
+  const String fileName = ((const String)  tolua_tourho3dstring(tolua_S,3,0));
+ {
+  SystemFile* tolua_ret = (SystemFile*)  Mtolua_new((SystemFile)(GetContext(tolua_S),package,fileName));
+  tolua_pushusertype(tolua_S,(void*)tolua_ret,"SystemFile");
+ }
+ }
+ return 1;
+tolua_lerror:
+ return tolua_IOLuaAPI_SystemFile_new01(tolua_S);
+}
+
+/* method: new_local of class  SystemFile */
+#define TOLUA_DISABLE_tolua_IOLuaAPI_SystemFile_new02_local
+static int tolua_IOLuaAPI_SystemFile_new02_local(lua_State* tolua_S)
+{
+ tolua_Error tolua_err;
+ if (
+ !tolua_isusertable(tolua_S,1,"SystemFile",0,&tolua_err) ||
+ !tolua_isusertype(tolua_S,2,"PackageFile",0,&tolua_err) ||
+ !tolua_isurho3dstring(tolua_S,3,0,&tolua_err) ||
+ !tolua_isnoobj(tolua_S,4,&tolua_err)
+ )
+ goto tolua_lerror;
+ else
+ {
+  PackageFile* package = ((PackageFile*)  tolua_tousertype(tolua_S,2,0));
+  const String fileName = ((const String)  tolua_tourho3dstring(tolua_S,3,0));
+ {
+  SystemFile* tolua_ret = (SystemFile*)  Mtolua_new((SystemFile)(GetContext(tolua_S),package,fileName));
+  tolua_pushusertype(tolua_S,(void*)tolua_ret,"SystemFile");
+ tolua_register_gc(tolua_S,lua_gettop(tolua_S));
+ }
+ }
+ return 1;
+tolua_lerror:
+ return tolua_IOLuaAPI_SystemFile_new01_local(tolua_S);
+}
+$}

--- a/Source/Urho3D/LuaScript/pkgs/IOLuaAPI.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/IOLuaAPI.pkg
@@ -1,6 +1,8 @@
 $pfile "IO/Compression.pkg"
 $pfile "IO/Deserializer.pkg"
 $pfile "IO/File.pkg"
+$pfile "IO/SystemFile.pkg"
+$pfile "IO/PackedFile.pkg"
 $pfile "IO/FileSystem.pkg"
 $pfile "IO/Log.pkg"
 $pfile "IO/NamedPipe.pkg"

--- a/Source/Urho3D/LuaScript/pkgs/Input/Input.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Input/Input.pkg
@@ -1,4 +1,4 @@
-$#include "IO/File.h"
+$#include "IO/SystemFile.h"
 $#include "Input/Input.h"
 
 enum MouseMode
@@ -147,19 +147,19 @@ static unsigned InputLoadGestures(Input* input, File* file)
 
 static bool InputSaveGestures(Input* input, const String& fileName)
 {
-    File file(input->GetContext(), fileName, FILE_WRITE);
+    SystemFile file(input->GetContext(), fileName, FILE_WRITE);
     return file.IsOpen() ? input->SaveGestures(file) : false;
 }
 
 static bool InputSaveGesture(Input* input, const String& fileName, unsigned gestureID)
 {
-    File file(input->GetContext(), fileName, FILE_WRITE);
+    SystemFile file(input->GetContext(), fileName, FILE_WRITE);
     return file.IsOpen() ? input->SaveGesture(file, gestureID) : false;
 }
 
 static unsigned InputLoadGestures(Input* input, const String& fileName)
 {
-    File file(input->GetContext(), fileName, FILE_READ);
+    SystemFile file(input->GetContext(), fileName, FILE_READ);
     return file.IsOpen() ? input->LoadGestures(file) : 0;
 }
 

--- a/Source/Urho3D/LuaScript/pkgs/Resource/Image.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Resource/Image.pkg
@@ -89,7 +89,7 @@ static bool ImageLoadColorLUT(Image* image, const String& fileName)
     if (!image)
         return false;
 
-    File file(image->GetContext());
+    SystemFile file(image->GetContext());
     if (!file.Open(fileName, FILE_READ))
         return false;
 

--- a/Source/Urho3D/LuaScript/pkgs/Resource/JSONFile.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Resource/JSONFile.pkg
@@ -29,7 +29,7 @@ static bool JSONFileSave(const JSONFile* resource, const String& fileName, const
     if (!resource)
         return false;
 
-    File file(resource->GetContext());
+    SystemFile file(resource->GetContext());
     return file.Open(fileName, FILE_WRITE) && resource->Save(file, indentation);
 }
 $}

--- a/Source/Urho3D/LuaScript/pkgs/Resource/XMLFile.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Resource/XMLFile.pkg
@@ -37,7 +37,7 @@ static bool XMLFileSave(const XMLFile* resource, const String& fileName, const S
     if (!resource)
         return false;
 
-    File file(resource->GetContext());
+    SystemFile file(resource->GetContext());
     return file.Open(fileName, FILE_WRITE) && resource->Save(file, indentation);
 }
 $}

--- a/Source/Urho3D/LuaScript/pkgs/Scene/Node.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Scene/Node.pkg
@@ -1,4 +1,4 @@
-$#include "IO/File.h"
+$#include "IO/SystemFile.h"
 $#include "LuaScript/LuaFile.h"
 $#include "LuaScript/LuaScriptInstance.h"
 $#include "Scene/Node.h"

--- a/Source/Urho3D/LuaScript/pkgs/Scene/Scene.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Scene/Scene.pkg
@@ -126,13 +126,13 @@ static bool SceneSave(const Scene* scene, File* file)
 
 static bool SceneLoad(Scene* scene, const String& fileName)
 {
-    File file(scene->GetContext(), fileName, FILE_READ);
+    SystemFile file(scene->GetContext(), fileName, FILE_READ);
     return file.IsOpen() && scene->Load(file);
 }
 
 static bool SceneSave(const Scene* scene, const String& fileName)
 {
-    File file(scene->GetContext(), fileName, FILE_WRITE);
+    SystemFile file(scene->GetContext(), fileName, FILE_WRITE);
     return file.IsOpen() && scene->Save(file);
 }
 
@@ -148,7 +148,7 @@ static bool SceneSaveXML(const Scene* scene, File* file, const String& indentati
 
 static bool SceneLoadXML(Scene* scene, const String& fileName)
 {
-    File file(scene->GetContext(), fileName, FILE_READ);
+    SystemFile file(scene->GetContext(), fileName, FILE_READ);
     return file.IsOpen() && scene->LoadXML(file);
 }
 
@@ -162,7 +162,7 @@ static const PODVector<Node*>& SceneGetNodesWithTag(const Scene* scene, const St
 
 static bool SceneSaveXML(const Scene* scene, const String& fileName, const String& indentation)
 {
-    File file(scene->GetContext(), fileName, FILE_WRITE);
+    SystemFile file(scene->GetContext(), fileName, FILE_WRITE);
     if (!file.IsOpen())
         return false;
     return scene->SaveXML(file, indentation);
@@ -180,13 +180,13 @@ static bool SceneSaveJSON(const Scene* scene, File* file, const String& indentat
 
 static bool SceneLoadJSON(Scene* scene, const String& fileName)
 {
-    File file(scene->GetContext(), fileName, FILE_READ);
+    SystemFile file(scene->GetContext(), fileName, FILE_READ);
     return file.IsOpen() && scene->LoadJSON(file);
 }
 
 static bool SceneSaveJSON(const Scene* scene, const String& fileName, const String& indentation)
 {
-    File file(scene->GetContext(), fileName, FILE_WRITE);
+    SystemFile file(scene->GetContext(), fileName, FILE_WRITE);
     if (!file.IsOpen())
         return false;
     return scene->SaveJSON(file, indentation);
@@ -194,13 +194,13 @@ static bool SceneSaveJSON(const Scene* scene, const String& fileName, const Stri
 
 static bool SceneLoadAsync(Scene* scene, const String& fileName, LoadMode mode)
 {
-    SharedPtr<File> file(new File(scene->GetContext(), fileName, FILE_READ));
+    SharedPtr<File> file(new SystemFile(scene->GetContext(), fileName, FILE_READ));
     return file->IsOpen() && scene->LoadAsync(file, mode);
 }
 
 static bool SceneLoadAsyncXML(Scene* scene, const String& fileName, LoadMode mode)
 {
-    SharedPtr<File> file(new File(scene->GetContext(), fileName, FILE_READ));
+    SharedPtr<File> file(new SystemFile(scene->GetContext(), fileName, FILE_READ));
     return file->IsOpen() && scene->LoadAsyncXML(file, mode);
 }
 
@@ -211,7 +211,7 @@ static Node* SceneInstantiate(Scene* scene, File* file, const Vector3& position,
 
 static Node* SceneInstantiate(Scene* scene, const String& fileName, const Vector3& position, const Quaternion& rotation, CreateMode mode)
 {
-    File file(scene->GetContext(), fileName, FILE_READ);
+    SystemFile file(scene->GetContext(), fileName, FILE_READ);
     return file.IsOpen() ? scene->Instantiate(file, position, rotation, mode) : 0;
 }
 
@@ -222,13 +222,13 @@ static Node* SceneInstantiateXML(Scene* scene, File* file, const Vector3& positi
 
 static Node* SceneInstantiateXML(Scene* scene, const String& fileName, const Vector3& position, const Quaternion& rotation, CreateMode mode)
 {
-    File file(scene->GetContext(), fileName, FILE_READ);
+    SystemFile file(scene->GetContext(), fileName, FILE_READ);
     return file.IsOpen() ? scene->InstantiateXML(file, position, rotation, mode) : 0;
 }
 
 static Node* SceneInstantiateJSON(Scene* scene, const String& fileName, const Vector3& position, const Quaternion& rotation, CreateMode mode)
 {
-    File file(scene->GetContext(), fileName, FILE_READ);
+    SystemFile file(scene->GetContext(), fileName, FILE_READ);
     return file.IsOpen() ? scene->InstantiateJSON(file, position, rotation, mode) : 0;
 }
 $}

--- a/Source/Urho3D/LuaScript/pkgs/UI/UI.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/UI/UI.pkg
@@ -108,7 +108,7 @@ static UIElement* UILoadLayout(UI* ui, File* source, XMLFile* styleFile)
 
 static UIElement* UILoadLayout(UI* ui, const String& fileName, XMLFile* styleFile)
 {
-    File file(ui->GetContext(), fileName, FILE_READ);
+    SystemFile file(ui->GetContext(), fileName, FILE_READ);
     if (!file.IsOpen())
         return 0;
 

--- a/Source/Urho3D/LuaScript/pkgs/UI/UIElement.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/UI/UIElement.pkg
@@ -1,4 +1,4 @@
-$#include "IO/File.h"
+$#include "IO/SystemFile.h"
 $#include "UI/UIElement.h"
 
 enum HorizontalAlignment
@@ -332,7 +332,7 @@ static bool UIElementLoadXML(UIElement* element, const String& fileName)
     if (!element)
         return false;
 
-    File file(element->GetContext());
+    SystemFile file(element->GetContext());
     if (!file.Open(fileName, FILE_READ))
         return false;
 
@@ -344,7 +344,7 @@ static bool UIElementSaveXML(const UIElement* element, const String& fileName, c
     if (!element)
         return false;
 
-    File file(element->GetContext());
+    SystemFile file(element->GetContext());
     if (!file.Open(fileName, FILE_WRITE))
         return false;
 

--- a/Source/Urho3D/Network/Connection.cpp
+++ b/Source/Urho3D/Network/Connection.cpp
@@ -24,7 +24,7 @@
 
 #include "../Core/Profiler.h"
 #include "../IO/File.h"
-#include "../IO/PhysicalFile.h"
+#include "../IO/SystemFile.h"
 #include "../IO/FileSystem.h"
 #include "../IO/Log.h"
 #include "../IO/MemoryBuffer.h"
@@ -751,7 +751,7 @@ void Connection::ProcessPackageDownload(int msgID, MemoryBuffer& msg)
                     }
 
                     // Try to open the file now
-                    SharedPtr<File> file(new PhysicalFile(context_, packageFullName));
+                    SharedPtr<File> file(new SystemFile(context_, packageFullName));
                     if (!file->IsOpen())
                     {
                         URHO3D_LOGERROR("Failed to transmit package file " + name);
@@ -803,7 +803,7 @@ void Connection::ProcessPackageDownload(int msgID, MemoryBuffer& msg)
             // If file has not yet been opened, try to open now. Prepend the checksum to the filename to allow multiple versions
             if (!download.file_)
             {
-                download.file_ = new PhysicalFile(context_,
+                download.file_ = new SystemFile(context_,
                     GetSubsystem<Network>()->GetPackageCacheDir() + ToStringHex(download.checksum_) + "_" + download.name_,
                     FILE_WRITE);
                 if (!download.file_->IsOpen())

--- a/Source/Urho3D/Network/Connection.cpp
+++ b/Source/Urho3D/Network/Connection.cpp
@@ -474,12 +474,10 @@ void Connection::ProcessLoadScene(int msgID, MemoryBuffer& msg)
     ResourceCache* cache = GetSubsystem<ResourceCache>();
     const String& packageCacheDir = GetSubsystem<Network>()->GetPackageCacheDir();
 
-    Vector<SharedPtr<PackageFile> > packages = cache->GetPackageFiles();
-    for (unsigned i = 0; i < packages.Size(); ++i)
+    for (const SharedPtr<FileSource>& source : cache->GetFileSources())
     {
-        PackageFile* package = packages[i];
-        if (!package->GetName().Find(packageCacheDir))
-            cache->RemovePackageFile(package, true);
+        if (!source->GetName().Find(packageCacheDir))
+            cache->RemoveFileSource(source, true);
     }
 
     // Now check which packages we have in the resource cache or in the download cache, and which we need to download
@@ -1382,7 +1380,7 @@ bool Connection::RequestNeededPackages(unsigned numPackages, MemoryBuffer& msg)
     ResourceCache* cache = GetSubsystem<ResourceCache>();
     const String& packageCacheDir = GetSubsystem<Network>()->GetPackageCacheDir();
 
-    Vector<SharedPtr<PackageFile> > packages = cache->GetPackageFiles();
+    Vector<SharedPtr<FileSource> > packages = cache->GetFileSources();
     Vector<String> downloadedPackages;
     bool packagesScanned = false;
 
@@ -1397,7 +1395,7 @@ bool Connection::RequestNeededPackages(unsigned numPackages, MemoryBuffer& msg)
         // Check first the resource cache
         for (unsigned j = 0; j < packages.Size(); ++j)
         {
-            PackageFile* package = packages[j];
+            FileSource* package = packages[j];
             if (!GetFileNameAndExtension(package->GetName()).Compare(name, false) && package->GetTotalSize() == fileSize &&
                 package->GetChecksum() == checksum) //TODO: Swap order of comparisons as size and checksum are fast-fail
             {

--- a/Source/Urho3D/Network/Connection.cpp
+++ b/Source/Urho3D/Network/Connection.cpp
@@ -24,6 +24,7 @@
 
 #include "../Core/Profiler.h"
 #include "../IO/File.h"
+#include "../IO/PhysicalFile.h"
 #include "../IO/FileSystem.h"
 #include "../IO/Log.h"
 #include "../IO/MemoryBuffer.h"
@@ -752,7 +753,7 @@ void Connection::ProcessPackageDownload(int msgID, MemoryBuffer& msg)
                     }
 
                     // Try to open the file now
-                    SharedPtr<File> file(new File(context_, packageFullName));
+                    SharedPtr<File> file(new PhysicalFile(context_, packageFullName));
                     if (!file->IsOpen())
                     {
                         URHO3D_LOGERROR("Failed to transmit package file " + name);
@@ -804,7 +805,7 @@ void Connection::ProcessPackageDownload(int msgID, MemoryBuffer& msg)
             // If file has not yet been opened, try to open now. Prepend the checksum to the filename to allow multiple versions
             if (!download.file_)
             {
-                download.file_ = new File(context_,
+                download.file_ = new PhysicalFile(context_,
                     GetSubsystem<Network>()->GetPackageCacheDir() + ToStringHex(download.checksum_) + "_" + download.name_,
                     FILE_WRITE);
                 if (!download.file_->IsOpen())
@@ -1398,7 +1399,7 @@ bool Connection::RequestNeededPackages(unsigned numPackages, MemoryBuffer& msg)
         {
             PackageFile* package = packages[j];
             if (!GetFileNameAndExtension(package->GetName()).Compare(name, false) && package->GetTotalSize() == fileSize &&
-                package->GetChecksum() == checksum)
+                package->GetChecksum() == checksum) //TODO: Swap order of comparisons as size and checksum are fast-fail
             {
                 found = true;
                 break;

--- a/Source/Urho3D/Resource/Image.cpp
+++ b/Source/Urho3D/Resource/Image.cpp
@@ -24,7 +24,7 @@
 
 #include "../Core/Context.h"
 #include "../Core/Profiler.h"
-#include "../IO/PhysicalFile.h"
+#include "../IO/SystemFile.h"
 #include "../IO/FileSystem.h"
 #include "../IO/Log.h"
 #include "../Resource/Decompress.h"
@@ -1251,7 +1251,7 @@ bool Image::SavePNG(const String& fileName) const
 {
     URHO3D_PROFILE(SaveImagePNG);
 
-    PhysicalFile outFile(context_, fileName, FILE_WRITE);
+    SystemFile outFile(context_, fileName, FILE_WRITE);
     if (outFile.IsOpen())
         return Image::Save(outFile); // Save uses PNG format
     else
@@ -1308,7 +1308,7 @@ bool Image::SaveDDS(const String& fileName) const
 {
     URHO3D_PROFILE(SaveImageDDS);
 
-    PhysicalFile outFile(context_, fileName, FILE_WRITE);
+    SystemFile outFile(context_, fileName, FILE_WRITE);
     if (!outFile.IsOpen())
     {
         URHO3D_LOGERROR("Access denied to " + fileName);
@@ -1362,7 +1362,7 @@ bool Image::SaveWEBP(const String& fileName, float compression /* = 0.0f */) con
     URHO3D_PROFILE(SaveImageWEBP);
 
     FileSystem* fileSystem(GetSubsystem<FileSystem>());
-    PhysicalFile outFile(context_, fileName, FILE_WRITE);
+    SystemFile outFile(context_, fileName, FILE_WRITE);
 
     if (fileSystem && !fileSystem->CheckAccess(GetPath(fileName)))
     {

--- a/Source/Urho3D/Resource/Image.cpp
+++ b/Source/Urho3D/Resource/Image.cpp
@@ -24,7 +24,7 @@
 
 #include "../Core/Context.h"
 #include "../Core/Profiler.h"
-#include "../IO/File.h"
+#include "../IO/PhysicalFile.h"
 #include "../IO/FileSystem.h"
 #include "../IO/Log.h"
 #include "../Resource/Decompress.h"
@@ -1251,7 +1251,7 @@ bool Image::SavePNG(const String& fileName) const
 {
     URHO3D_PROFILE(SaveImagePNG);
 
-    File outFile(context_, fileName, FILE_WRITE);
+    PhysicalFile outFile(context_, fileName, FILE_WRITE);
     if (outFile.IsOpen())
         return Image::Save(outFile); // Save uses PNG format
     else
@@ -1308,7 +1308,7 @@ bool Image::SaveDDS(const String& fileName) const
 {
     URHO3D_PROFILE(SaveImageDDS);
 
-    File outFile(context_, fileName, FILE_WRITE);
+    PhysicalFile outFile(context_, fileName, FILE_WRITE);
     if (!outFile.IsOpen())
     {
         URHO3D_LOGERROR("Access denied to " + fileName);
@@ -1362,7 +1362,7 @@ bool Image::SaveWEBP(const String& fileName, float compression /* = 0.0f */) con
     URHO3D_PROFILE(SaveImageWEBP);
 
     FileSystem* fileSystem(GetSubsystem<FileSystem>());
-    File outFile(context_, fileName, FILE_WRITE);
+    PhysicalFile outFile(context_, fileName, FILE_WRITE);
 
     if (fileSystem && !fileSystem->CheckAccess(GetPath(fileName)))
     {

--- a/Source/Urho3D/Resource/Resource.cpp
+++ b/Source/Urho3D/Resource/Resource.cpp
@@ -23,7 +23,7 @@
 #include "../Precompiled.h"
 
 #include "../Core/Profiler.h"
-#include "../IO/PhysicalFile.h"
+#include "../IO/SystemFile.h"
 #include "../IO/Log.h"
 #include "../Resource/Resource.h"
 #include "../Resource/XMLElement.h"
@@ -86,13 +86,13 @@ bool Resource::Save(Serializer& dest) const
 
 bool Resource::LoadFile(const String& fileName)
 {
-    PhysicalFile file(context_);
+    SystemFile file(context_);
     return file.Open(fileName, FILE_READ) && Load(file);
 }
 
 bool Resource::SaveFile(const String& fileName) const
 {
-    PhysicalFile file(context_);
+    SystemFile file(context_);
     return file.Open(fileName, FILE_WRITE) && Save(file);
 }
 

--- a/Source/Urho3D/Resource/Resource.cpp
+++ b/Source/Urho3D/Resource/Resource.cpp
@@ -23,7 +23,7 @@
 #include "../Precompiled.h"
 
 #include "../Core/Profiler.h"
-#include "../IO/File.h"
+#include "../IO/PhysicalFile.h"
 #include "../IO/Log.h"
 #include "../Resource/Resource.h"
 #include "../Resource/XMLElement.h"
@@ -86,13 +86,13 @@ bool Resource::Save(Serializer& dest) const
 
 bool Resource::LoadFile(const String& fileName)
 {
-    File file(context_);
+    PhysicalFile file(context_);
     return file.Open(fileName, FILE_READ) && Load(file);
 }
 
 bool Resource::SaveFile(const String& fileName) const
 {
-    File file(context_);
+    PhysicalFile file(context_);
     return file.Open(fileName, FILE_WRITE) && Save(file);
 }
 

--- a/Source/Urho3D/Resource/ResourceCache.cpp
+++ b/Source/Urho3D/Resource/ResourceCache.cpp
@@ -192,8 +192,13 @@ bool ResourceCache::AddFileSource(FileSource* source, unsigned priority)
 
 bool ResourceCache::AddFileSource(const StringHash sourceType, const String& fileName, unsigned priority)
 {
-    SharedPtr<FileSource> source(context_->CreateObject(sourceType));
-    return source->Open(fileName) && AddFileSource(source);
+    SharedPtr<Object> obj(context_->CreateObject(sourceType));
+    if (obj && obj->IsInstanceOf<FileSource>())
+    {
+        SharedPtr<FileSource> source((FileSource*)obj.Get());
+        return source->Open(fileName) && AddFileSource(source);
+    }
+    return false;
 }
 
 bool ResourceCache::AddManualResource(Resource* resource)

--- a/Source/Urho3D/Resource/ResourceCache.cpp
+++ b/Source/Urho3D/Resource/ResourceCache.cpp
@@ -30,6 +30,7 @@
 #include "../IO/FileWatcher.h"
 #include "../IO/Log.h"
 #include "../IO/PackageFile.h"
+#include "../IO/PhysicalFile.h"
 #include "../Resource/BackgroundLoader.h"
 #include "../Resource/Image.h"
 #include "../Resource/JSONFile.h"
@@ -133,30 +134,66 @@ bool ResourceCache::AddResourceDir(const String& pathName, unsigned priority)
     return true;
 }
 
-bool ResourceCache::AddPackageFile(PackageFile* package, unsigned priority)
+bool ResourceCache::AddPackageFile(PackageFile *package, unsigned priority)
+{
+    return AddFileSource(package, priority);
+}
+
+bool ResourceCache::AddPackageFile(const String &fileName, unsigned priority)
+{
+    return AddFileSource(PackageFile::GetTypeStatic(), fileName, priority);
+}
+
+//bool ResourceCache::AddPackageFile(PackageFile* package, unsigned priority)
+//{
+//    MutexLock lock(resourceMutex_);
+
+//    // Do not add packages that failed to load
+//    if (!package || !package->GetNumFiles())
+//    {
+//        URHO3D_LOGERRORF("Could not add package file %s due to load failure", package->GetName().CString());
+//        return false;
+//    }
+
+//    if (priority < fileSources_.Size())
+//        fileSources_.Insert(priority, SharedPtr<PackageFile>(package));
+//    else
+//        fileSources_.Push(SharedPtr<PackageFile>(package));
+
+//    URHO3D_LOGINFO("Added resource package " + package->GetName());
+//    return true;
+//}
+
+//bool ResourceCache::AddPackageFile(const String& fileName, unsigned priority)
+//{
+//    SharedPtr<PackageFile> package(new PackageFile(context_));
+//    return package->Open(fileName) && AddPackageFile(package);
+//}
+
+bool ResourceCache::AddFileSource(FileSource* source, unsigned priority)
 {
     MutexLock lock(resourceMutex_);
 
     // Do not add packages that failed to load
-    if (!package || !package->GetNumFiles())
+    if (!source || !source->GetNumFiles())
     {
-        URHO3D_LOGERRORF("Could not add package file %s due to load failure", package->GetName().CString());
+        URHO3D_LOGERRORF("Could not add package file %s due to load failure", source->GetName().CString());
         return false;
     }
 
-    if (priority < packages_.Size())
-        packages_.Insert(priority, SharedPtr<PackageFile>(package));
+    if (priority < fileSources_.Size())
+        fileSources_.Insert(priority, SharedPtr<FileSource>(source));
     else
-        packages_.Push(SharedPtr<PackageFile>(package));
+        fileSources_.Push(SharedPtr<FileSource>(source));
 
-    URHO3D_LOGINFO("Added resource package " + package->GetName());
+    URHO3D_LOGINFO("Added resource package " + source->GetName());
     return true;
 }
 
-bool ResourceCache::AddPackageFile(const String& fileName, unsigned priority)
+bool ResourceCache::AddFileSource(const StringHash sourceType, const String& fileName, unsigned priority)
 {
-    SharedPtr<PackageFile> package(new PackageFile(context_));
-    return package->Open(fileName) && AddPackageFile(package);
+    SharedPtr<FileSource> source(context_->CreateObject(sourceType));
+    return source->Open(fileName) && AddFileSource(source);
 }
 
 bool ResourceCache::AddManualResource(Resource* resource)
@@ -206,41 +243,51 @@ void ResourceCache::RemoveResourceDir(const String& pathName)
     }
 }
 
-void ResourceCache::RemovePackageFile(PackageFile* package, bool releaseResources, bool forceRelease)
+void ResourceCache::RemoveFileSource(FileSource* source, bool releaseResources, bool forceRelease)
 {
     MutexLock lock(resourceMutex_);
 
-    for (Vector<SharedPtr<PackageFile> >::Iterator i = packages_.Begin(); i != packages_.End(); ++i)
+    for (Vector<SharedPtr<FileSource> >::Iterator i = fileSources_.Begin(); i != fileSources_.End(); ++i)
     {
-        if (*i == package)
+        if (*i == source)
         {
             if (releaseResources)
-                ReleasePackageResources(*i, forceRelease);
+                ReleaseSourceResources(*i, forceRelease);
             URHO3D_LOGINFO("Removed resource package " + (*i)->GetName());
-            packages_.Erase(i);
+            fileSources_.Erase(i);
             return;
         }
     }
 }
 
-void ResourceCache::RemovePackageFile(const String& fileName, bool releaseResources, bool forceRelease)
+void ResourceCache::RemoveFileSource(const String& fileName, bool releaseResources, bool forceRelease)
 {
     MutexLock lock(resourceMutex_);
 
     // Compare the name and extension only, not the path
     String fileNameNoPath = GetFileNameAndExtension(fileName);
 
-    for (Vector<SharedPtr<PackageFile> >::Iterator i = packages_.Begin(); i != packages_.End(); ++i)
+    for (Vector<SharedPtr<FileSource> >::Iterator i = fileSources_.Begin(); i != fileSources_.End(); ++i)
     {
         if (!GetFileNameAndExtension((*i)->GetName()).Compare(fileNameNoPath, false))
         {
             if (releaseResources)
-                ReleasePackageResources(*i, forceRelease);
+                ReleaseSourceResources(*i, forceRelease);
             URHO3D_LOGINFO("Removed resource package " + (*i)->GetName());
-            packages_.Erase(i);
+            fileSources_.Erase(i);
             return;
         }
     }
+}
+
+void ResourceCache::RemovePackageFile(PackageFile *package, bool releaseResources, bool forceRelease)
+{
+    RemoveFileSource(package, releaseResources, forceRelease);
+}
+
+void ResourceCache::RemovePackageFile(const String &fileName, bool releaseResources, bool forceRelease)
+{
+    RemoveFileSource(fileName, releaseResources, forceRelease);
 }
 
 void ResourceCache::ReleaseResource(StringHash type, const String& name, bool force)
@@ -745,9 +792,9 @@ bool ResourceCache::Exists(const String& nameIn) const
     if (name.Empty())
         return false;
 
-    for (unsigned i = 0; i < packages_.Size(); ++i)
+    for (unsigned i = 0; i < fileSources_.Size(); ++i)
     {
-        if (packages_[i]->Exists(name))
+        if (fileSources_[i]->Exists(name))
             return true;
     }
 
@@ -1000,14 +1047,13 @@ const SharedPtr<Resource>& ResourceCache::FindResource(StringHash nameHash)
     return noResource;
 }
 
-void ResourceCache::ReleasePackageResources(PackageFile* package, bool force)
+void ResourceCache::ReleaseSourceResources(FileSource *source, bool force)
 {
     HashSet<StringHash> affectedGroups;
 
-    const HashMap<String, PackageEntry>& entries = package->GetEntries();
-    for (HashMap<String, PackageEntry>::ConstIterator i = entries.Begin(); i != entries.End(); ++i)
+    for (const String& entry : source->GetEntryNames())
     {
-        StringHash nameHash(i->first_);
+        StringHash nameHash(entry);
 
         // We do not know the actual resource type, so search all type containers
         for (HashMap<StringHash, ResourceGroup>::Iterator j = resourceGroups_.Begin(); j != resourceGroups_.End(); ++j)
@@ -1107,7 +1153,7 @@ File* ResourceCache::SearchResourceDirs(const String& nameIn)
         {
             // Construct the file first with full path, then rename it to not contain the resource path,
             // so that the file's name can be used in further GetFile() calls (for example over the network)
-            File* file(new File(context_, resourceDirs_[i] + nameIn));
+            File* file(new PhysicalFile(context_, resourceDirs_[i] + nameIn));
             file->SetName(nameIn);
             return file;
         }
@@ -1115,17 +1161,17 @@ File* ResourceCache::SearchResourceDirs(const String& nameIn)
 
     // Fallback using absolute path
     if (fileSystem->FileExists(nameIn))
-        return new File(context_, nameIn);
+        return new PhysicalFile(context_, nameIn);
 
     return nullptr;
 }
 
 File* ResourceCache::SearchPackages(const String& nameIn)
 {
-    for (unsigned i = 0; i < packages_.Size(); ++i)
+    for (unsigned i = 0; i < fileSources_.Size(); ++i)
     {
-        if (packages_[i]->Exists(nameIn))
-            return new File(context_, packages_[i], nameIn);
+        if (fileSources_[i]->Exists(nameIn))
+            return fileSources_[i]->GetFile(nameIn);
     }
 
     return nullptr;

--- a/Source/Urho3D/Resource/ResourceCache.h
+++ b/Source/Urho3D/Resource/ResourceCache.h
@@ -170,7 +170,7 @@ public:
 
     /// Return added file sources.
     const Vector<SharedPtr<FileSource> >& GetFileSources() const { return fileSources_; }
-    /// Deprecated for GetFileSources
+    /// Deprecated for GetFileSources. Returns copy of sources including only PackageFiles.
     const Vector<SharedPtr<FileSource> >& GetPackageFiles() const { return fileSources_; }
 
     /// Template version of returning a resource by name.

--- a/Source/Urho3D/Resource/ResourceCache.h
+++ b/Source/Urho3D/Resource/ResourceCache.h
@@ -167,7 +167,9 @@ public:
     /// Return added resource load directories.
     const Vector<String>& GetResourceDirs() const { return resourceDirs_; }
 
-    /// Return added package files.
+    /// Return added file sources.
+    const Vector<SharedPtr<FileSource> >& GetFileSources() const { return fileSources_; }
+    /// Deprecated for GetFileSources
     const Vector<SharedPtr<FileSource> >& GetPackageFiles() const { return fileSources_; }
 
     /// Template version of returning a resource by name.
@@ -228,7 +230,7 @@ private:
     /// Find a resource by name only. Searches all type groups.
     const SharedPtr<Resource>& FindResource(StringHash nameHash);
     /// Release resources loaded from a file source.
-    void ReleaseSourceResources(FileSource* package, bool force = false);
+    void ReleaseSourceResources(FileSource* source, bool force = false);
     /// Update a resource group. Recalculate memory use and release resources if over memory budget.
     void UpdateResourceGroup(StringHash type);
     /// Handle begin frame event. Automatic resource reloads and the finalization of background loaded resources are processed here.
@@ -266,7 +268,7 @@ private:
     int finishBackgroundResourcesMs_;
 };
 
-template <class T> bool ResourceCache::AddFileSource(const String& filename, unsigned priority = PRIORITY_LAST)
+template <class T> bool ResourceCache::AddFileSource(const String& filename, unsigned priority)
 {
     StringHash sourceType = T::GetTypeStatic();
     return AddFileSource(sourceType, filename, priority);

--- a/Source/Urho3D/Resource/ResourceCache.h
+++ b/Source/Urho3D/Resource/ResourceCache.h
@@ -26,6 +26,7 @@
 #include "../Container/List.h"
 #include "../Core/Mutex.h"
 #include "../IO/File.h"
+#include "../IO/SystemFile.h"
 #include "../Resource/Resource.h"
 
 namespace Urho3D

--- a/bin/Data/Scripts/11_Physics.as
+++ b/bin/Data/Scripts/11_Physics.as
@@ -196,12 +196,12 @@ void MoveCamera(float timeStep)
     // directory
     if (input.keyPress[KEY_F5])
     {
-        File saveFile(fileSystem.programDir + "Data/Scenes/Physics.xml", FILE_WRITE);
+        SystemFile saveFile(fileSystem.programDir + "Data/Scenes/Physics.xml", FILE_WRITE);
         scene_.SaveXML(saveFile);
     }
     if (input.keyPress[KEY_F7])
     {
-        File loadFile(fileSystem.programDir + "Data/Scenes/Physics.xml", FILE_READ);
+        SystemFile loadFile(fileSystem.programDir + "Data/Scenes/Physics.xml", FILE_READ);
         scene_.LoadXML(loadFile);
     }
 

--- a/bin/Data/Scripts/12_PhysicsStressTest.as
+++ b/bin/Data/Scripts/12_PhysicsStressTest.as
@@ -202,12 +202,12 @@ void MoveCamera(float timeStep)
     // Check for loading / saving the scene
     if (input.keyPress[KEY_F5])
     {
-        File saveFile(fileSystem.programDir + "Data/Scenes/PhysicsStressTest.xml", FILE_WRITE);
+        SystemFile saveFile(fileSystem.programDir + "Data/Scenes/PhysicsStressTest.xml", FILE_WRITE);
         scene_.SaveXML(saveFile);
     }
     if (input.keyPress[KEY_F7])
     {
-        File loadFile(fileSystem.programDir + "Data/Scenes/PhysicsStressTest.xml", FILE_READ);
+        SystemFile loadFile(fileSystem.programDir + "Data/Scenes/PhysicsStressTest.xml", FILE_READ);
         scene_.LoadXML(loadFile);
     }
 

--- a/bin/Data/Scripts/13_Ragdolls.as
+++ b/bin/Data/Scripts/13_Ragdolls.as
@@ -193,12 +193,12 @@ void MoveCamera(float timeStep)
     // Check for loading / saving the scene
     if (input.keyPress[KEY_F5])
     {
-        File saveFile(fileSystem.programDir + "Data/Scenes/Ragdolls.xml", FILE_WRITE);
+        SystemFile saveFile(fileSystem.programDir + "Data/Scenes/Ragdolls.xml", FILE_WRITE);
         scene_.SaveXML(saveFile);
     }
     if (input.keyPress[KEY_F7])
     {
-        File loadFile(fileSystem.programDir + "Data/Scenes/Ragdolls.xml", FILE_READ);
+        SystemFile loadFile(fileSystem.programDir + "Data/Scenes/Ragdolls.xml", FILE_READ);
         scene_.LoadXML(loadFile);
     }
 

--- a/bin/Data/Scripts/18_CharacterDemo.as
+++ b/bin/Data/Scripts/18_CharacterDemo.as
@@ -272,12 +272,12 @@ void HandleUpdate(StringHash eventType, VariantMap& eventData)
         // Check for loading / saving the scene
         if (input.keyPress[KEY_F5])
         {
-            File saveFile(fileSystem.programDir + "Data/Scenes/CharacterDemo.xml", FILE_WRITE);
+            SystemFile saveFile(fileSystem.programDir + "Data/Scenes/CharacterDemo.xml", FILE_WRITE);
             scene_.SaveXML(saveFile);
         }
         if (input.keyPress[KEY_F7])
         {
-            File loadFile(fileSystem.programDir + "Data/Scenes/CharacterDemo.xml", FILE_READ);
+            SystemFile loadFile(fileSystem.programDir + "Data/Scenes/CharacterDemo.xml", FILE_READ);
             scene_.LoadXML(loadFile);
             // After loading we have to reacquire the character scene node, as it has been recreated
             // Simply find by name as there's only one of them

--- a/bin/Data/Scripts/19_VehicleDemo.as
+++ b/bin/Data/Scripts/19_VehicleDemo.as
@@ -198,12 +198,12 @@ void HandleUpdate(StringHash eventType, VariantMap& eventData)
         // Check for loading / saving the scene
         if (input.keyPress[KEY_F5])
         {
-            File saveFile(fileSystem.programDir + "Data/Scenes/VehicleDemo.xml", FILE_WRITE);
+            SystemFile saveFile(fileSystem.programDir + "Data/Scenes/VehicleDemo.xml", FILE_WRITE);
             scene_.SaveXML(saveFile);
         }
         if (input.keyPress[KEY_F7])
         {
-            File loadFile(fileSystem.programDir + "Data/Scenes/VehicleDemo.xml", FILE_READ);
+            SystemFile loadFile(fileSystem.programDir + "Data/Scenes/VehicleDemo.xml", FILE_READ);
             scene_.LoadXML(loadFile);
             // After loading we have to reacquire the vehicle scene node, as it has been recreated
             // Simply find by name as there's only one of them

--- a/bin/Data/Scripts/32_Urho2DConstraints.as
+++ b/bin/Data/Scripts/32_Urho2DConstraints.as
@@ -378,7 +378,7 @@ void HandleUpdate(StringHash eventType, VariantMap& eventData)
     if (input.keyPress[KEY_SPACE]) drawDebug = !drawDebug; // Toggle debug geometry with space
     if (input.keyPress[KEY_F5]) // Save scene
     {
-        File saveFile(fileSystem.programDir + "Data/Scenes/Constraints.xml", FILE_WRITE);
+        SystemFile saveFile(fileSystem.programDir + "Data/Scenes/Constraints.xml", FILE_WRITE);
         scene_.SaveXML(saveFile);
     }
 }

--- a/bin/Data/Scripts/39_CrowdNavigation.as
+++ b/bin/Data/Scripts/39_CrowdNavigation.as
@@ -403,12 +403,12 @@ void MoveCamera(float timeStep)
     // Check for loading/saving the scene from/to the file Data/Scenes/CrowdNavigation.xml relative to the executable directory
     if (input.keyPress[KEY_F5])
     {
-        File saveFile(fileSystem.programDir + "Data/Scenes/CrowdNavigation.xml", FILE_WRITE);
+        SystemFile saveFile(fileSystem.programDir + "Data/Scenes/CrowdNavigation.xml", FILE_WRITE);
         scene_.SaveXML(saveFile);
     }
     else if (input.keyPress[KEY_F7])
     {
-        File loadFile(fileSystem.programDir + "Data/Scenes/CrowdNavigation.xml", FILE_READ);
+        SystemFile loadFile(fileSystem.programDir + "Data/Scenes/CrowdNavigation.xml", FILE_READ);
         scene_.LoadXML(loadFile);
     }
 

--- a/bin/Data/Scripts/46_RaycastVehicleDemo.as
+++ b/bin/Data/Scripts/46_RaycastVehicleDemo.as
@@ -191,12 +191,12 @@ void HandleUpdate(StringHash eventType, VariantMap& eventData)
         // Check for loading / saving the scene
         if (input.keyPress[KEY_F5])
         {
-            File saveFile(fileSystem.programDir + "Data/Scenes/RaycastScriptVehicleDemo.xml", FILE_WRITE);
+            SystemFile saveFile(fileSystem.programDir + "Data/Scenes/RaycastScriptVehicleDemo.xml", FILE_WRITE);
             scene_.SaveXML(saveFile);
         }
         if (input.keyPress[KEY_F7])
         {
-            File loadFile(fileSystem.programDir + "Data/Scenes/RaycastScriptVehicleDemo.xml", FILE_READ);
+            SystemFile loadFile(fileSystem.programDir + "Data/Scenes/RaycastScriptVehicleDemo.xml", FILE_READ);
             scene_.LoadXML(loadFile);
             // After loading we have to reacquire the vehicle scene node, as it has been recreated
             // Simply find by name as there's only one of them

--- a/bin/Data/Scripts/Editor.as
+++ b/bin/Data/Scripts/Editor.as
@@ -178,7 +178,7 @@ void LoadConfig()
         return;
 
     XMLFile config;
-    config.Load(File(configFileName, FILE_READ));
+    config.Load(SystemFile(configFileName, FILE_READ));
 
     XMLElement configElem = config.root;
     if (configElem.isNull)
@@ -439,7 +439,7 @@ void SaveConfig()
     
     SaveSoundTypes(soundTypesElem);
 
-    config.Save(File(configFileName, FILE_WRITE));
+    config.Save(SystemFile(configFileName, FILE_WRITE));
 }
 
 void MakeBackup(const String&in fileName)

--- a/bin/Data/Scripts/Editor/AttributeEditor.as
+++ b/bin/Data/Scripts/Editor/AttributeEditor.as
@@ -26,7 +26,7 @@ String sceneResourcePath = AddTrailingSlash(fileSystem.programDir + "Data");
 bool rememberResourcePath = true;
 
 // Exceptions for string attributes that should not be continuously edited
-Array<String> noTextChangedAttrs = {"Script File", "Class Name", "Script Object Type", "Script File Name"};
+Array<String> noTextChangedAttrs = {"Script File", "Class Name", "Script Object Type", "Script SystemFile Name"};
 
 // List of attributes that should be created with a bit selection editor
 const Array<String> bitSelectionAttrs = {"Collision Mask", "Collision Layer", "Light Mask", "Zone Mask", "View Mask", "Shadow Mask"};

--- a/bin/Data/Scripts/Editor/EditorCubeCapture.as
+++ b/bin/Data/Scripts/Editor/EditorCubeCapture.as
@@ -190,7 +190,7 @@ class EditorCubeCapture : ScriptObject // script object in order to get events
             faceElem.SetAttribute("name", GetResourceNameFromFullName(basePath + cubeName + String(target_.id) + "_" + GetFaceName(CubeMapFace(i)) + ".png"));
         }
 
-        file.Save(File(xmlPath, FILE_WRITE), "    ");
+        file.Save(SystemFile(xmlPath, FILE_WRITE), "    ");
 
         ResourceRef ref;
         ref.type = StringHash("TextureCube");

--- a/bin/Data/Scripts/Editor/EditorExport.as
+++ b/bin/Data/Scripts/Editor/EditorExport.as
@@ -29,7 +29,7 @@ void ExportSceneToOBJ(String fileName)
 
     RemoveDebugDrawables(drawables);
 
-    File@ file = File(fileName, FILE_WRITE);
+    File@ file = SystemFile(fileName, FILE_WRITE);
     if (WriteDrawablesToOBJ(drawables, file, objExportZUp_, objExportRightHanded_))
     {
         MessageBox("OBJ file written to " + fileName, "Success");
@@ -80,7 +80,7 @@ void ExportSelectedToOBJ(String fileName)
 
     if (drawables.length > 0)
     {
-        File@ file = File(fileName, FILE_WRITE);
+        File@ file = SystemFile(fileName, FILE_WRITE);
         if (WriteDrawablesToOBJ(drawables, file, objExportZUp_, objExportRightHanded_))
         {
             MessageBox("OBJ file written to " + fileName, "Success");

--- a/bin/Data/Scripts/Editor/EditorImport.as
+++ b/bin/Data/Scripts/Editor/EditorImport.as
@@ -154,7 +154,7 @@ void ImportTundraScene(const String&in fileName)
     fileSystem.CreateDir(sceneResourcePath + "Textures");
 
     XMLFile source;
-    source.Load(File(fileName, FILE_READ));
+    source.Load(SystemFile(fileName, FILE_READ));
     String filePath = GetPath(fileName);
 
     XMLElement sceneElem = source.root;
@@ -501,7 +501,7 @@ void ConvertMaterial(const String&in materialName, const String&in filePath, Arr
     Vector2 uvScale(1, 1);
     Color diffuse(1, 1, 1, 1);
 
-    File file(fileName, FILE_READ);
+    SystemFile file(fileName, FILE_READ);
     while (!file.eof)
     {
         String line = file.ReadLine().Trimmed();
@@ -568,7 +568,7 @@ void ConvertMaterial(const String&in materialName, const String&in filePath, Arr
         diffuseElem.SetColor("value", diffuse);
     }
 
-    File outFile(outFileName, FILE_WRITE);
+    SystemFile outFile(outFileName, FILE_WRITE);
     outMat.Save(outFile);
     outFile.Close();
 

--- a/bin/Data/Scripts/Editor/EditorMaterial.as
+++ b/bin/Data/Scripts/Editor/EditorMaterial.as
@@ -453,7 +453,7 @@ void SaveMaterial()
         return;
 
     MakeBackup(fullName);
-    File saveFile(fullName, FILE_WRITE);
+    SystemFile saveFile(fullName, FILE_WRITE);
     bool success;
     if (GetExtension(fullName) == ".json")
     {
@@ -505,7 +505,7 @@ void SaveMaterialAsDone(StringHash eventType, VariantMap& eventData)
         fullName = fullName + filter.Substring(1);
 
     MakeBackup(fullName);
-    File saveFile(fullName, FILE_WRITE);
+    SystemFile saveFile(fullName, FILE_WRITE);
     bool success;
     if (GetExtension(fullName) == ".json")
     {

--- a/bin/Data/Scripts/Editor/EditorParticleEffect.as
+++ b/bin/Data/Scripts/Editor/EditorParticleEffect.as
@@ -1672,7 +1672,7 @@ void SaveParticleEffect()
     if (fullName.empty)
         return;
 
-    File saveFile(fullName, FILE_WRITE);
+    SystemFile saveFile(fullName, FILE_WRITE);
     editParticleEffect.Save(saveFile);
 }
 
@@ -1714,7 +1714,7 @@ void SaveParticleEffectAsDone(StringHash eventType, VariantMap& eventData)
     if (GetExtension(fullName).empty && filter != "*.*")
         fullName = fullName + filter.Substring(1);
 
-    File saveFile(fullName, FILE_WRITE);
+    SystemFile saveFile(fullName, FILE_WRITE);
     if (editParticleEffect.Save(saveFile))
     {
         saveFile.Close();

--- a/bin/Data/Scripts/Editor/EditorResourceBrowser.as
+++ b/bin/Data/Scripts/Editor/EditorResourceBrowser.as
@@ -1295,7 +1295,7 @@ bool GetBinaryType(String path, StringHash &out fileType, bool useCache = false)
     }
     else
     {
-        File@ file = File();
+        File@ file = SystemFile();
         if (!file.Open(path))
             return false;
 
@@ -1344,7 +1344,7 @@ bool GetXmlType(String path, StringHash &out fileType, bool useCache = false)
     }
     else
     {
-        File@ file = File();
+        File@ file = SystemFile();
         if (!file.Open(path))
             return false;
 
@@ -1573,7 +1573,7 @@ void CreateResourcePreview(String path, Node@ previewNode)
     int resourceType = GetResourceType(path); 
     if (resourceType > 0)
     {
-        File file;
+        SystemFile file;
         file.Open(path);
 
         if (resourceType == RESOURCE_TYPE_MODEL)

--- a/bin/Data/Scripts/Editor/EditorScene.as
+++ b/bin/Data/Scripts/Editor/EditorScene.as
@@ -191,7 +191,7 @@ bool LoadScene(const String&in fileName)
         return false;
     }
 
-    File file(fileName, FILE_READ);
+    SystemFile file(fileName, FILE_READ);
     if (!file.open)
     {
         MessageBox("Could not open file.\n" + fileName);
@@ -256,7 +256,7 @@ bool SaveScene(const String&in fileName)
     editorScene.updateEnabled = true;
 
     MakeBackup(fileName);
-    File file(fileName, FILE_WRITE);
+    SystemFile file(fileName, FILE_WRITE);
     String extension = GetExtension(fileName);
     bool success;
     if (extension == ".xml")
@@ -366,7 +366,7 @@ Node@ LoadNode(const String&in fileName, Node@ parent = null, bool raycastToMous
         return null;
     }
 
-    File file(fileName, FILE_READ);
+    SystemFile file(fileName, FILE_READ);
     if (!file.open)
     {
         MessageBox("Could not open file.\n" + fileName);
@@ -454,7 +454,7 @@ bool SaveNode(const String&in fileName)
     ui.cursor.shape = CS_BUSY;
 
     MakeBackup(fileName);
-    File file(fileName, FILE_WRITE);
+    SystemFile file(fileName, FILE_WRITE);
     if (!file.open)
     {
         MessageBox("Could not open file.\n" + fileName);

--- a/bin/Data/Scripts/Editor/EditorUI.as
+++ b/bin/Data/Scripts/Editor/EditorUI.as
@@ -604,7 +604,7 @@ bool PickFile()
     if (action.empty)
         return false;
 
-    // File (Scene related)
+    // SystemFile (Scene related)
     if (action == "Open scene...")
     {
         CreateFileSelector("Open scene", "Open", "Cancel", uiScenePath, uiSceneFilters, uiSceneFilter);
@@ -1232,7 +1232,7 @@ void ExecuteScript(const String&in fileName)
     if (fileName.empty)
         return;
 
-    File@ file = File(fileName, FILE_READ);
+    File@ file = SystemFile(fileName, FILE_READ);
     if (file.open)
     {
         String scriptCode;
@@ -1880,7 +1880,7 @@ XMLFile@ GetEditorUIXMLFile(const String&in fileName)
     String fullFileName = fileSystem.programDir + "Data/" + fileName;
     if (fileSystem.FileExists(fullFileName))
     {
-        File@ file = File(fullFileName, FILE_READ);
+        File@ file = SystemFile(fullFileName, FILE_READ);
         XMLFile@ xml = XMLFile();
         xml.name = fileName;
         if (xml.Load(file))

--- a/bin/Data/Scripts/Editor/EditorUIElement.as
+++ b/bin/Data/Scripts/Editor/EditorUIElement.as
@@ -107,7 +107,7 @@ void OpenUILayout(const String&in fileName)
         return;
     }
 
-    File file(fileName, FILE_READ);
+    SystemFile file(fileName, FILE_READ);
     if (!file.open)
     {
         MessageBox("Could not open file.\n" + fileName);
@@ -244,7 +244,7 @@ bool SaveUILayout(const String&in fileName)
     ui.cursor.shape = CS_BUSY;
 
     MakeBackup(fileName);
-    File file(fileName, FILE_WRITE);
+    SystemFile file(fileName, FILE_WRITE);
     if (!file.open)
     {
         MessageBox("Could not open file.\n" + fileName);
@@ -304,7 +304,7 @@ void LoadChildUIElement(const String&in fileName)
         return;
     }
 
-    File file(fileName, FILE_READ);
+    SystemFile file(fileName, FILE_READ);
     if (!file.open)
     {
         MessageBox("Could not open file.\n" + fileName);
@@ -350,7 +350,7 @@ bool SaveChildUIElement(const String&in fileName)
     ui.cursor.shape = CS_BUSY;
 
     MakeBackup(fileName);
-    File file(fileName, FILE_WRITE);
+    SystemFile file(fileName, FILE_WRITE);
     if (!file.open)
     {
         MessageBox("Could not open file.\n" + fileName);
@@ -389,7 +389,7 @@ void SetUIElementDefaultStyle(const String&in fileName)
         return;
     }
 
-    File file(fileName, FILE_READ);
+    SystemFile file(fileName, FILE_READ);
     if (!file.open)
     {
         MessageBox("Could not open file.\n" + fileName);

--- a/bin/Data/Scripts/Utilities/2D/Sample2D.as
+++ b/bin/Data/Scripts/Utilities/2D/Sample2D.as
@@ -470,7 +470,7 @@ void SaveScene(bool initial)
     if (!initial)
         filename = demoFilename + "InGame";
 
-    File saveFile(fileSystem.programDir + "Data/Scenes/" + filename + ".xml", FILE_WRITE);
+    SystemFile saveFile(fileSystem.programDir + "Data/Scenes/" + filename + ".xml", FILE_WRITE);
     scene_.SaveXML(saveFile);
 }
 
@@ -480,7 +480,7 @@ void ReloadScene(bool reInit)
     if (!reInit)
         filename = demoFilename + "InGame";
 
-    File loadFile(fileSystem.programDir + "Data/Scenes/" + filename + ".xml", FILE_READ);
+    SystemFile loadFile(fileSystem.programDir + "Data/Scenes/" + filename + ".xml", FILE_READ);
     scene_.LoadXML(loadFile);
     // After loading we have to reacquire the character2D scene node, as it has been recreated
     // Simply find by name as there's only one of them


### PR DESCRIPTION
Inspired by #2198, I went ahead and abstracted the packed and unpacked behavior of the File class into two separate classes, and created an abstract base for PackageFile to allow the creation of different kinds of these FileSources (say for a different method of compression or encryption). Presently, I think it is in working order (it hasn't been thoroughly tested, but I checked that some of the samples ran as well as the Editor and NinjaSnowWar), and it only minimally breaks the API. I'm planning on maybe making an example other file source for gzipped files or something, but that hasn't yet been done.

Notable changes required include:

- Cannot construct a `File` as it is now an abstract class -- must use a `SystemFile` instead (assuming this is for reading/writing to the file system, which is the usual use for constructing a File directly).
- Certain resource cache operations are now `FileSource` based, not `PackageFile` based (e.g. `GetPackageFiles()` presently just returns the vector of FileSources.
- `IsPackaged()` was removed from the File class.
