### PR TITLE
Expose body_->GetContactList

### DIFF
--- a/Source/Urho3D/Urho2D/RigidBody2D.cpp
+++ b/Source/Urho3D/Urho2D/RigidBody2D.cpp
@@ -610,4 +610,25 @@ void RigidBody2D::OnMarkedDirty(Node* node)
         body_->SetTransform(newPosition, newAngle);
 }
 
+void RigidBody2D::GetContactList(Vector<std::tuple<Node*, Vector2, Vector<Vector2>>> &contactList) const
+{
+    auto b2ContactList = this->body_->GetContactList();
+    while (b2ContactList != NULL)
+    {
+        auto otherNode = ((RigidBody2D *)b2ContactList->other->GetUserData())->GetNode();
+        b2WorldManifold worldManifold;
+        auto contact = b2ContactList->contact;
+        contact->GetWorldManifold(&worldManifold);
+        auto normal = Vector2(worldManifold.normal.x, worldManifold.normal.y);
+        auto numPoints = contact->GetManifold()->pointCount;
+        Vector<Vector2> contactPoints;
+        for (decltype(numPoints) i = 0; i < numPoints; ++i)
+        {
+            contactPoints.Push(Vector2(worldManifold.points[i].x, worldManifold.points[i].y));
+        }
+        contactList.Push(std::make_tuple(otherNode, normal, contactPoints));
+        b2ContactList = b2ContactList->next;
+    }
+}
+
 }

--- a/Source/Urho3D/Urho2D/RigidBody2D.h
+++ b/Source/Urho3D/Urho2D/RigidBody2D.h
@@ -157,6 +157,9 @@ public:
     /// Return Box2D body.
     b2Body* GetBody() const { return body_; }
 
+    /// Return a list of all contacts.
+    void GetContactList(Vector<std::tuple<Node*, Vector2, Vector<Vector2>>> &contactList) const;
+
 private:
     /// Handle node being assigned.
     virtual void OnNodeSet(Node* node) override;


### PR DESCRIPTION
This provides a convenient method to get the list of bodies currently
colliding with the current body.

This is already possible through events, but this method is sometimes
more convenient.

Sample usage:

```
Vector<std::tuple<Node*, Vector2, Vector<Vector2>>> contactList;
this->playerBody->GetContactList(contactList);
for (auto& contact : contactList) {
    Node *node;
    Vector2 normal;
    Vector<Vector2> positions;
    std::tie(node, normal, positions) = contact;
    if (positions.Size() > 0) {
        std::cout << this->steps << std::endl;
        std::cout << "name: " << node->GetName().CString() << std::endl;
        std::cout << "normal: " << normal.ToString().CString() << std::endl;
        for (auto& position : positions) {
            std::cout << "position: " << position.ToString().CString() << std::endl;
        }
        std::cout << std::endl;
    }
}
```

If you guys want this, I could clean up the patch further to return a results class instead of tuple, which is more forward portable.

  