### PR TITLE
Added SetSpriteTextureEdgeOffset method for TmxFile2D.

### DIFF
--- a/Source/Urho3D/AngelScript/Urho2DAPI.cpp
+++ b/Source/Urho3D/AngelScript/Urho2DAPI.cpp
@@ -270,6 +270,7 @@ static void RegisterTileMapDefs2D(asIScriptEngine* engine)
 static void RegisterTmxFile2D(asIScriptEngine* engine)
 {
     RegisterResource<TmxFile2D>(engine, "TmxFile2D");
+    engine->RegisterObjectMethod("TmxFile2D", "void set_sprite_texture_edge_offset(float)", asMETHOD(TmxFile2D, SetSpriteTextureEdgeOffset), asCALL_THISCALL);
 }
 
 static void RegisterTileMapLayer2D(asIScriptEngine* engine)

--- a/Source/Urho3D/LuaScript/pkgs/Urho2D/TmxFile2D.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Urho2D/TmxFile2D.pkg
@@ -2,4 +2,5 @@ $#include "Urho2D/TmxFile2D.h"
 
 class TmxFile2D : Resource
 {
+    void SetSpriteTextureEdgeOffset(float offset);
 };

--- a/Source/Urho3D/Urho2D/TmxFile2D.cpp
+++ b/Source/Urho3D/Urho2D/TmxFile2D.cpp
@@ -587,6 +587,15 @@ const TmxLayer2D* TmxFile2D::GetLayer(unsigned index) const
     return layers_[index];
 }
 
+void TmxFile2D::SetSpriteTextureEdgeOffset(float offset)
+{
+    for (HashMap<int, SharedPtr<Sprite2D> >::ConstIterator i = gidToSpriteMapping_.Begin();
+         i != gidToSpriteMapping_.End(); ++i)
+    {
+        i->second_->SetTextureEdgeOffset(offset);
+    }
+}
+
 SharedPtr<XMLFile> TmxFile2D::LoadTSXFile(const String& source)
 {
     String tsxFilePath = GetParentPath(GetName()) + source;

--- a/Source/Urho3D/Urho2D/TmxFile2D.cpp
+++ b/Source/Urho3D/Urho2D/TmxFile2D.cpp
@@ -589,10 +589,9 @@ const TmxLayer2D* TmxFile2D::GetLayer(unsigned index) const
 
 void TmxFile2D::SetSpriteTextureEdgeOffset(float offset)
 {
-    for (HashMap<int, SharedPtr<Sprite2D> >::ConstIterator i = gidToSpriteMapping_.Begin();
-         i != gidToSpriteMapping_.End(); ++i)
+    for (Urho3D::HashMap<int, Urho3D::SharedPtr<Urho3D::Sprite2D> >::KeyValue& i : gidToSpriteMapping_)
     {
-        i->second_->SetTextureEdgeOffset(offset);
+        i.second_->SetTextureEdgeOffset(offset);
     }
 }
 

--- a/Source/Urho3D/Urho2D/TmxFile2D.h
+++ b/Source/Urho3D/Urho2D/TmxFile2D.h
@@ -198,6 +198,9 @@ public:
     /// Return layer at index.
     const TmxLayer2D* GetLayer(unsigned index) const;
 
+    /// Set texture edge offset for all sprites, in pixels.
+    void SetSpriteTextureEdgeOffset(float offset);
+
 private:
     /// Load TSX file.
     SharedPtr<XMLFile> LoadTSXFile(const String& source);


### PR DESCRIPTION
A convenience method to remove texture bleeding from tilemap