### PR TITLE
Coverity shader parameters CID127650

### DIFF
--- a/Source/Urho3D/Graphics/Direct3D11/D3D11ShaderVariation.cpp
+++ b/Source/Urho3D/Graphics/Direct3D11/D3D11ShaderVariation.cpp
@@ -198,13 +198,7 @@ bool ShaderVariation::LoadByteCode(const String& binaryShaderName)
         unsigned offset = file->ReadUInt();
         unsigned size = file->ReadUInt();
 
-        ShaderParameter parameter;
-        parameter.type_ = type_;
-        parameter.name_ = name;
-        parameter.buffer_ = buffer;
-        parameter.offset_ = offset;
-        parameter.size_ = size;
-        parameters_[StringHash(name)] = parameter;
+        parameters_[StringHash(name)] = ShaderParameter{type_, name, offset, size, buffer};
     }
 
     unsigned numTextureUnits = file->ReadUInt();
@@ -399,13 +393,7 @@ void ShaderVariation::ParseParameters(unsigned char* bufData, unsigned bufSize)
             if (varName[0] == 'c')
             {
                 varName = varName.Substring(1); // Strip the c to follow Urho3D constant naming convention
-                ShaderParameter parameter;
-                parameter.type_ = type_;
-                parameter.name_ = varName;
-                parameter.buffer_ = cbRegister;
-                parameter.offset_ = varDesc.StartOffset;
-                parameter.size_ = varDesc.Size;
-                parameters_[varName] = parameter;
+                parameters_[varName] = ShaderParameter{type_, varName, varDesc.StartOffset, varDesc.Size, cbRegister};
             }
         }
     }

--- a/Source/Urho3D/Graphics/Direct3D9/D3D9ShaderVariation.cpp
+++ b/Source/Urho3D/Graphics/Direct3D9/D3D9ShaderVariation.cpp
@@ -199,12 +199,7 @@ bool ShaderVariation::LoadByteCode(const String& binaryShaderName)
         unsigned reg = file->ReadUByte();
         unsigned regCount = file->ReadUByte();
 
-        ShaderParameter parameter;
-        parameter.type_ = type_;
-        parameter.name_ = name;
-        parameter.register_ = reg;
-        parameter.regCount_ = regCount;
-        parameters_[StringHash(name)] = parameter;
+        parameters_[StringHash(name)] = ShaderParameter{type_, name, reg, regCount};
     }
 
     unsigned numTextureUnits = file->ReadUInt();
@@ -355,12 +350,7 @@ void ShaderVariation::ParseParameters(unsigned char* bufData, unsigned bufSize)
         }
         else
         {
-            ShaderParameter parameter;
-            parameter.type_ = type_;
-            parameter.name_ = name;
-            parameter.register_ = reg;
-            parameter.regCount_ = regCount;
-            parameters_[StringHash(name)] = parameter;
+            parameters_[StringHash(name)] = ShaderParameter{type_, name, reg, regCount};
         }
     }
 

--- a/Source/Urho3D/Graphics/OpenGL/OGLShaderProgram.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLShaderProgram.cpp
@@ -277,10 +277,7 @@ bool ShaderProgram::Link()
         {
             // Store constant uniform
             String paramName = name.Substring(1);
-            ShaderParameter parameter;
-            parameter.name_ = paramName;
-            parameter.glType_ = type;
-            parameter.location_ = location;
+            ShaderParameter parameter{paramName, type, location};
             bool store = location >= 0;
 
 #ifndef GL_ES_VERSION_2_0

--- a/Source/Urho3D/Graphics/ShaderVariation.cpp
+++ b/Source/Urho3D/Graphics/ShaderVariation.cpp
@@ -31,6 +31,13 @@
 namespace Urho3D
 {
 
+ShaderParameter::ShaderParameter(const String& name, unsigned glType, int location) :
+    name_{name},
+    glType_{glType},
+    location_{location}
+{
+}
+
 ShaderVariation::ShaderVariation(Shader* owner, ShaderType type) :
     GPUObject(owner->GetSubsystem<Graphics>()),
     owner_(owner),

--- a/Source/Urho3D/Graphics/ShaderVariation.cpp
+++ b/Source/Urho3D/Graphics/ShaderVariation.cpp
@@ -38,6 +38,15 @@ ShaderParameter::ShaderParameter(const String& name, unsigned glType, int locati
 {
 }
 
+ShaderParameter::ShaderParameter(ShaderType type, const String& name, unsigned offset, unsigned size, unsigned buffer) :
+    type_{type},
+    name_{name},
+    offset_{offset},
+    size_{size},
+    buffer_{buffer}
+{
+}
+
 ShaderVariation::ShaderVariation(Shader* owner, ShaderType type) :
     GPUObject(owner->GetSubsystem<Graphics>()),
     owner_(owner),

--- a/Source/Urho3D/Graphics/ShaderVariation.cpp
+++ b/Source/Urho3D/Graphics/ShaderVariation.cpp
@@ -47,6 +47,14 @@ ShaderParameter::ShaderParameter(ShaderType type, const String& name, unsigned o
 {
 }
 
+ShaderParameter::ShaderParameter(ShaderType type, const String& name, unsigned reg, unsigned regCount) :
+    type_{type},
+    name_{name},
+    register_{reg},
+    regCount_{regCount}
+{
+}
+
 ShaderVariation::ShaderVariation(Shader* owner, ShaderType type) :
     GPUObject(owner->GetSubsystem<Graphics>()),
     owner_(owner),

--- a/Source/Urho3D/Graphics/ShaderVariation.h
+++ b/Source/Urho3D/Graphics/ShaderVariation.h
@@ -41,6 +41,8 @@ struct ShaderParameter
     ShaderParameter() = default;
     /// Construct with name, glType and location, leaving the remaining attributes zero-initialized (used only in OpenGL).
     ShaderParameter(const String& name, unsigned glType, int location);
+    /// Construct with type, name, offset, size, and buffer, leaving the remaining attributes zero-initialized (used only in Direct3D11).
+    ShaderParameter(ShaderType type, const String& name, unsigned offset, unsigned size, unsigned buffer);
 
     /// %Shader type.
     ShaderType type_{};

--- a/Source/Urho3D/Graphics/ShaderVariation.h
+++ b/Source/Urho3D/Graphics/ShaderVariation.h
@@ -38,20 +38,19 @@ class Shader;
 struct ShaderParameter
 {
     /// Construct with defaults.
-    ShaderParameter() :
-        bufferPtr_(nullptr)
-    {
-    }
+    ShaderParameter() = default;
+    /// Construct with name, glType and location, leaving the remaining attributes zero-initialized (used only in OpenGL).
+    ShaderParameter(const String& name, unsigned glType, int location);
 
     /// %Shader type.
-    ShaderType type_;
+    ShaderType type_{};
     /// Name of the parameter.
-    String name_;
+    String name_{};
 
     union
     {
         /// Offset in constant buffer.
-        unsigned offset_;
+        unsigned offset_{};
         /// OpenGL uniform location.
         int location_;
         /// Direct3D9 register index.
@@ -61,7 +60,7 @@ struct ShaderParameter
     union
     {
         /// Parameter size. Used only on Direct3D11 to calculate constant buffer size.
-        unsigned size_;
+        unsigned size_{};
         /// Parameter OpenGL type.
         unsigned glType_;
         /// Number of registers on Direct3D9.
@@ -69,9 +68,9 @@ struct ShaderParameter
     };
 
     /// Constant buffer index. Only used on Direct3D11.
-    unsigned buffer_;
+    unsigned buffer_{};
     /// Constant buffer pointer. Defined only in shader programs.
-    ConstantBuffer* bufferPtr_;
+    ConstantBuffer* bufferPtr_{};
 };
 
 /// Vertex or pixel shader on the GPU.

--- a/Source/Urho3D/Graphics/ShaderVariation.h
+++ b/Source/Urho3D/Graphics/ShaderVariation.h
@@ -43,6 +43,8 @@ struct ShaderParameter
     ShaderParameter(const String& name, unsigned glType, int location);
     /// Construct with type, name, offset, size, and buffer, leaving the remaining attributes zero-initialized (used only in Direct3D11).
     ShaderParameter(ShaderType type, const String& name, unsigned offset, unsigned size, unsigned buffer);
+    /// Construct with type, name, register, and register count, leaving the remaining attributes zero-initialized (used only in Direct3D9).
+    ShaderParameter(ShaderType type, const String& name, unsigned reg, unsigned regCount);
 
     /// %Shader type.
     ShaderType type_{};


### PR DESCRIPTION
Addresses  #2246.

I was unfortunately unable to test the DirectX cases, as I am on Linux here.  It would be great if someone could run the PBR sample with D3D9 and D3D11, with these changes, just to confirm everything is ok.