### PR TITLE
Use mipmap levels of 1 when texture usage is TEXTURE_DYNAMIC

### DIFF
--- a/Source/Urho3D/Graphics/Direct3D11/D3D11Texture2D.cpp
+++ b/Source/Urho3D/Graphics/Direct3D11/D3D11Texture2D.cpp
@@ -396,7 +396,7 @@ bool Texture2D::Create()
     textureDesc.Width = (UINT)width_;
     textureDesc.Height = (UINT)height_;
     // Disable mip levels from the multisample texture. Rather create them to the resolve texture
-    textureDesc.MipLevels = multiSample_ == 1 ? levels_ : 1;
+    textureDesc.MipLevels = (multiSample_ == 1 && usage_ != TEXTURE_DYNAMIC) ? levels_ : 1;
     textureDesc.ArraySize = 1;
     textureDesc.SampleDesc.Count = (UINT)multiSample_;
     textureDesc.SampleDesc.Quality = graphics_->GetImpl()->GetMultiSampleQuality(textureDesc.Format, multiSample_);
@@ -446,7 +446,7 @@ bool Texture2D::Create()
         resourceViewDesc.Format = (DXGI_FORMAT)GetSRVFormat(textureDesc.Format);
         resourceViewDesc.ViewDimension = (multiSample_ > 1 && !autoResolve_) ? D3D11_SRV_DIMENSION_TEXTURE2DMS :
             D3D11_SRV_DIMENSION_TEXTURE2D;
-        resourceViewDesc.Texture2D.MipLevels = (UINT)levels_;
+        resourceViewDesc.Texture2D.MipLevels = usage_ != TEXTURE_DYNAMIC ? (UINT)levels_ : 1;
 
         // Sample the resolve texture if created, otherwise the original
         ID3D11Resource* viewObject = resolveTexture_ ? (ID3D11Resource*)resolveTexture_ : (ID3D11Resource*)object_.ptr_;

--- a/Source/Urho3D/Graphics/Direct3D11/D3D11Texture2DArray.cpp
+++ b/Source/Urho3D/Graphics/Direct3D11/D3D11Texture2DArray.cpp
@@ -450,7 +450,7 @@ bool Texture2DArray::Create()
 
     textureDesc.Width = (UINT)width_;
     textureDesc.Height = (UINT)height_;
-    textureDesc.MipLevels = levels_;
+    textureDesc.MipLevels = usage_ != TEXTURE_DYNAMIC ? levels_ : 1;
     textureDesc.ArraySize = layers_;
     textureDesc.Format = (DXGI_FORMAT)(sRGB_ ? GetSRGBFormat(format_) : format_);
     textureDesc.SampleDesc.Count = 1;
@@ -477,13 +477,13 @@ bool Texture2DArray::Create()
     if (layers_ == 1)
     {
         srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
-        srvDesc.Texture2D.MipLevels = (UINT)levels_;
+        srvDesc.Texture2D.MipLevels = usage_ != TEXTURE_DYNAMIC ? (UINT)levels_ : 1;
         srvDesc.Texture2D.MostDetailedMip = 0;
     }
     else
     {
         srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
-        srvDesc.Texture2DArray.MipLevels = (UINT)levels_;
+        srvDesc.Texture2DArray.MipLevels = usage_ != TEXTURE_DYNAMIC ? (UINT)levels_ : 1;
         srvDesc.Texture2DArray.ArraySize = layers_;
         srvDesc.Texture2DArray.FirstArraySlice = 0;
         srvDesc.Texture2DArray.MostDetailedMip = 0;

--- a/Source/Urho3D/Graphics/Direct3D11/D3D11Texture3D.cpp
+++ b/Source/Urho3D/Graphics/Direct3D11/D3D11Texture3D.cpp
@@ -388,7 +388,7 @@ bool Texture3D::Create()
     textureDesc.Width = (UINT)width_;
     textureDesc.Height = (UINT)height_;
     textureDesc.Depth = (UINT)depth_;
-    textureDesc.MipLevels = levels_;
+    textureDesc.MipLevels = usage_ != TEXTURE_DYNAMIC ? levels_ : 1;
     textureDesc.Format = (DXGI_FORMAT)(sRGB_ ? GetSRGBFormat(format_) : format_);
     textureDesc.Usage = usage_ == TEXTURE_DYNAMIC ? D3D11_USAGE_DYNAMIC : D3D11_USAGE_DEFAULT;
     textureDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
@@ -406,7 +406,7 @@ bool Texture3D::Create()
     memset(&resourceViewDesc, 0, sizeof resourceViewDesc);
     resourceViewDesc.Format = (DXGI_FORMAT)GetSRVFormat(textureDesc.Format);
     resourceViewDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE3D;
-    resourceViewDesc.Texture3D.MipLevels = (UINT)levels_;
+    resourceViewDesc.Texture3D.MipLevels = usage_ != TEXTURE_DYNAMIC ? (UINT)levels_ : 1;
 
     hr = graphics_->GetImpl()->GetDevice()->CreateShaderResourceView((ID3D11Resource*)object_.ptr_, &resourceViewDesc,
         (ID3D11ShaderResourceView**)&shaderResourceView_);

--- a/Source/Urho3D/Graphics/Direct3D11/D3D11TextureCube.cpp
+++ b/Source/Urho3D/Graphics/Direct3D11/D3D11TextureCube.cpp
@@ -461,7 +461,7 @@ bool TextureCube::Create()
     textureDesc.Width = (UINT)width_;
     textureDesc.Height = (UINT)height_;
     // Disable mip levels from the multisample texture. Rather create them to the resolve texture
-    textureDesc.MipLevels = multiSample_ == 1 ? levels_ : 1;
+    textureDesc.MipLevels = (multiSample_ == 1 && usage_ != TEXTURE_DYNAMIC) ? levels_ : 1;
     textureDesc.ArraySize = MAX_CUBEMAP_FACES;
     textureDesc.SampleDesc.Count = (UINT)multiSample_;
     textureDesc.SampleDesc.Quality = graphics_->GetImpl()->GetMultiSampleQuality(textureDesc.Format, multiSample_);
@@ -507,7 +507,7 @@ bool TextureCube::Create()
     memset(&resourceViewDesc, 0, sizeof resourceViewDesc);
     resourceViewDesc.Format = (DXGI_FORMAT)GetSRVFormat(textureDesc.Format);
     resourceViewDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURECUBE;
-    resourceViewDesc.Texture2D.MipLevels = (UINT)levels_;
+    resourceViewDesc.Texture2D.MipLevels = usage_ != TEXTURE_DYNAMIC ? (UINT)levels_ : 1;
 
     // Sample the resolve texture if created, otherwise the original
     ID3D11Resource* viewObject = resolveTexture_ ? (ID3D11Resource*)resolveTexture_ : (ID3D11Resource*)object_.ptr_;

--- a/Source/Urho3D/Graphics/OpenGL/OGLTexture2D.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLTexture2D.cpp
@@ -460,7 +460,7 @@ bool Texture2D::Create()
     }
 
     // Set mipmapping
-    if (usage_ == TEXTURE_DEPTHSTENCIL)
+    if (usage_ == TEXTURE_DEPTHSTENCIL || usage_ == TEXTURE_DYNAMIC)
         requestedLevels_ = 1;
     else if (usage_ == TEXTURE_RENDERTARGET)
     {

--- a/Source/Urho3D/Graphics/OpenGL/OGLTexture2DArray.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLTexture2DArray.cpp
@@ -453,7 +453,7 @@ bool Texture2DArray::Create()
         URHO3D_LOGERROR("Failed to create texture array");
 
     // Set mipmapping
-    if (usage_ == TEXTURE_DEPTHSTENCIL)
+    if (usage_ == TEXTURE_DEPTHSTENCIL || usage_ == TEXTURE_DYNAMIC)
         requestedLevels_ = 1;
     else if (usage_ == TEXTURE_RENDERTARGET)
     {

--- a/Source/Urho3D/Graphics/OpenGL/OGLTextureCube.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLTextureCube.cpp
@@ -481,7 +481,7 @@ bool TextureCube::Create()
         URHO3D_LOGERROR("Failed to create texture");
 
     // Set mipmapping
-    if (usage_ == TEXTURE_DEPTHSTENCIL)
+    if (usage_ == TEXTURE_DEPTHSTENCIL || usage_ == TEXTURE_DYNAMIC)
         requestedLevels_ = 1;
     else if (usage_ == TEXTURE_RENDERTARGET)
     {


### PR DESCRIPTION
Closes #2253 and #2165

As #2165 mentions, these checks used to be there but were removed when textures were last reorganized some.