### PR TITLE
Added URHO3D_URHO2D guard that seems omitted

### DIFF
--- a/Source/Samples/49_Urho2DIsometricDemo/CMakeLists.txt
+++ b/Source/Samples/49_Urho2DIsometricDemo/CMakeLists.txt
@@ -20,6 +20,10 @@
 # THE SOFTWARE.
 #
 
+if (NOT URHO3D_URHO2D)
+    return ()
+endif ()
+
 # Define target name
 set (TARGET_NAME 49_Urho2DIsometricDemo)
 

--- a/Source/Samples/50_Urho2DPlatformer/CMakeLists.txt
+++ b/Source/Samples/50_Urho2DPlatformer/CMakeLists.txt
@@ -20,6 +20,10 @@
 # THE SOFTWARE.
 #
 
+if (NOT URHO3D_URHO2D)
+    return ()
+endif ()
+
 # Define target name
 set (TARGET_NAME 50_Urho2DPlatformer)
 


### PR DESCRIPTION
Samples 49_Urho2DIsometricDemo and 50_Urho2DPlatformer fail in the build process when URHO3D_URHO2D is not selected in CMake configuration. This pull request resolves it.