### PR TITLE
Fix OpenGL multisample resolve not working after context loss

### DIFF
--- a/Source/Urho3D/Graphics/OpenGL/OGLGraphics.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLGraphics.cpp
@@ -3160,6 +3160,8 @@ void Graphics::CleanupFramebuffers()
             DeleteFramebuffer(impl_->resolveSrcFBO_);
         if (impl_->resolveDestFBO_)
             DeleteFramebuffer(impl_->resolveDestFBO_);
+        impl_->resolveSrcFBO_ = 0;
+        impl_->resolveDestFBO_ = 0;
     }
     else
     {


### PR DESCRIPTION
This fixes issue #2286. The FBO object names were not being set to zero, so they were never recreated.