### PR TITLE
Use non-zero default edge offset for Sprite2D.

### DIFF
--- a/Source/Urho3D/Urho2D/Sprite2D.cpp
+++ b/Source/Urho3D/Urho2D/Sprite2D.cpp
@@ -39,7 +39,7 @@ Sprite2D::Sprite2D(Context* context) :
     Resource(context),
     hotSpot_(0.5f, 0.5f),
     offset_(0, 0),
-    edgeOffset_(0.0f)
+    edgeOffset_(M_LARGE_EPSILON)
 {
 
 }


### PR DESCRIPTION
There was some bug noticed by @kostik1337 
There were same artifacts in newly added demos by @thesquib
I suppose that small non-zero default edge (0.00005f) should be used by default, since it most likely doesn't disturb any rendering, but prevent atlases from leaking edges (as far as I could see).