### PR TITLE
Fix: reverted bad changes to RaycastSingleSegmented()

### DIFF
--- a/Source/Urho3D/AngelScript/PhysicsAPI.cpp
+++ b/Source/Urho3D/AngelScript/PhysicsAPI.cpp
@@ -243,10 +243,10 @@ static PhysicsRaycastResult PhysicsWorldRaycastSingle(const Ray& ray, float maxD
     return result;
 }
 
-static PhysicsRaycastResult PhysicsWorldRaycastSingleSegmented(const Ray& ray, float maxDistance, float segmentDistance, unsigned collisionMask, PhysicsWorld* ptr)
+static PhysicsRaycastResult PhysicsWorldRaycastSingleSegmented(const Ray& ray, float maxDistance, float segmentDistance, unsigned collisionMask, float overlap_distance, PhysicsWorld* ptr)
 {
     PhysicsRaycastResult result;
-    ptr->RaycastSingleSegmented(result, ray, maxDistance, segmentDistance, collisionMask);
+    ptr->RaycastSingleSegmented(result, ray, maxDistance, segmentDistance, collisionMask, overlap_distance);
     return result;
 }
 
@@ -312,7 +312,7 @@ static void RegisterPhysicsWorld(asIScriptEngine* engine)
     engine->RegisterObjectMethod("PhysicsWorld", "void UpdateCollisions()", asMETHOD(PhysicsWorld, UpdateCollisions), asCALL_THISCALL);
     engine->RegisterObjectMethod("PhysicsWorld", "Array<PhysicsRaycastResult>@ Raycast(const Ray&in, float, uint collisionMask = 0xffff)", asFUNCTION(PhysicsWorldRaycast), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod("PhysicsWorld", "PhysicsRaycastResult RaycastSingle(const Ray&in, float, uint collisionMask = 0xffff)", asFUNCTION(PhysicsWorldRaycastSingle), asCALL_CDECL_OBJLAST);
-    engine->RegisterObjectMethod("PhysicsWorld", "PhysicsRaycastResult RaycastSingleSegmented(const Ray&in, float, float, uint collisionMask = 0xffff)", asFUNCTION(PhysicsWorldRaycastSingleSegmented), asCALL_CDECL_OBJLAST);
+    engine->RegisterObjectMethod("PhysicsWorld", "PhysicsRaycastResult RaycastSingleSegmented(const Ray&in, float, float, uint collisionMask = 0xffff, float overlap_distance = 0.1f)", asFUNCTION(PhysicsWorldRaycastSingleSegmented), asCALL_CDECL_OBJLAST);
     engine->RegisterObjectMethod("PhysicsWorld", "PhysicsRaycastResult SphereCast(const Ray&in, float, float, uint collisionMask = 0xffff)", asFUNCTION(PhysicsWorldSphereCast), asCALL_CDECL_OBJLAST);
     // There seems to be a bug in AngelScript resulting in a crash if we use an auto handle with this function.
     // Work around by manually releasing the CollisionShape handle

--- a/Source/Urho3D/Physics/PhysicsWorld.cpp
+++ b/Source/Urho3D/Physics/PhysicsWorld.cpp
@@ -439,12 +439,12 @@ void PhysicsWorld::RaycastSingleSegmented(PhysicsRaycastResult& result, const Ra
     btVector3 start = ToBtVector3(ray.origin_);
     btVector3 end;
     btVector3 direction = ToBtVector3(ray.direction_);
-    float remainingDistance = maxDistance;
-    auto count = RoundToInt(maxDistance / segmentDistance);
+    float distance;
 
-    for (auto i = 0; i < count; ++i)
+    for (float remainingDistance = maxDistance; remainingDistance > 0; remainingDistance -= segmentDistance)
     {
-        float distance = Min(remainingDistance, segmentDistance);     // The last segment may be shorter
+        distance = Min(remainingDistance, segmentDistance);
+
         end = start + distance * direction;
 
         btCollisionWorld::ClosestRayResultCallback rayCallback(start, end);
@@ -466,7 +466,6 @@ void PhysicsWorld::RaycastSingleSegmented(PhysicsRaycastResult& result, const Ra
 
         // Use the end position as the new start position
         start = end;
-        remainingDistance -= segmentDistance;
     }
 
     // Didn't hit anything

--- a/Source/Urho3D/Physics/PhysicsWorld.cpp
+++ b/Source/Urho3D/Physics/PhysicsWorld.cpp
@@ -429,23 +429,26 @@ void PhysicsWorld::RaycastSingle(PhysicsRaycastResult& result, const Ray& ray, f
     }
 }
 
-void PhysicsWorld::RaycastSingleSegmented(PhysicsRaycastResult& result, const Ray& ray, float maxDistance, float segmentDistance, unsigned collisionMask)
+void PhysicsWorld::RaycastSingleSegmented(PhysicsRaycastResult& result, const Ray& ray, float maxDistance, float segmentDistance, unsigned collisionMask, float overlap_distance)
 {
     URHO3D_PROFILE(PhysicsRaycastSingleSegmented);
+
+    assert(overlap_distance < segmentDistance);
 
     if (maxDistance >= M_INFINITY)
         URHO3D_LOGWARNING("Infinite maxDistance in physics raycast is not supported");
 
-    btVector3 start = ToBtVector3(ray.origin_);
+    auto start = ToBtVector3(ray.origin_);
     btVector3 end;
-    btVector3 direction = ToBtVector3(ray.direction_);
-    float distance;
+    const auto direction = ToBtVector3(ray.direction_);
+    const auto overlap = direction * overlap_distance; // overlap a bit with the previous segment for better precision, to avoid missing hits
 
-    for (float remainingDistance = maxDistance; remainingDistance > 0; remainingDistance -= segmentDistance)
+    // calculate distances using segment_index directly to avoid precision errors with floating point
+    float rayDistance = 0;
+    for(unsigned segment_index = 0; rayDistance < maxDistance; rayDistance = ++segment_index * segmentDistance) // NOLINT
     {
-        distance = Min(remainingDistance, segmentDistance);
-
-        end = start + distance * direction;
+        const auto remainingDistance = maxDistance - rayDistance;
+        end = start + direction * (remainingDistance < segmentDistance ? remainingDistance : segmentDistance);
 
         btCollisionWorld::ClosestRayResultCallback rayCallback(start, end);
         rayCallback.m_collisionFilterGroup = (short)0xffff;
@@ -465,7 +468,7 @@ void PhysicsWorld::RaycastSingleSegmented(PhysicsRaycastResult& result, const Ra
         }
 
         // Use the end position as the new start position
-        start = end;
+        start = end - overlap;
     }
 
     // Didn't hit anything

--- a/Source/Urho3D/Physics/PhysicsWorld.h
+++ b/Source/Urho3D/Physics/PhysicsWorld.h
@@ -189,7 +189,8 @@ public:
     /// Perform a physics world raycast and return the closest hit.
     void RaycastSingle(PhysicsRaycastResult& result, const Ray& ray, float maxDistance, unsigned collisionMask = M_MAX_UNSIGNED);
     /// Perform a physics world segmented raycast and return the closest hit. Useful for big scenes with many bodies.
-    void RaycastSingleSegmented(PhysicsRaycastResult& result, const Ray& ray, float maxDistance, float segmentDistance, unsigned collisionMask = M_MAX_UNSIGNED);
+	/// overlap_distance is used to make sure there are no gap between segments, and must be smaller than segmentDistance.
+    void RaycastSingleSegmented(PhysicsRaycastResult& result, const Ray& ray, float maxDistance, float segmentDistance, unsigned collisionMask = M_MAX_UNSIGNED, float overlap_distance = 0.1f);
     /// Perform a physics world swept sphere test and return the closest hit.
     void SphereCast
         (PhysicsRaycastResult& result, const Ray& ray, float radius, float maxDistance, unsigned collisionMask = M_MAX_UNSIGNED);


### PR DESCRIPTION
Wrong rounding that causes it to have 0 segments if the raycast length is smaller than segment length.
And in general the changes are only likely to cause performance regression and have no benefit, so these changes should be reverted.