### PR TITLE
Fixed the 2D rendering order makes the layer priority higher than the Z

### DIFF
--- a/Source/Urho3D/Urho2D/Renderer2D.cpp
+++ b/Source/Urho3D/Urho2D/Renderer2D.cpp
@@ -404,11 +404,11 @@ void Renderer2D::GetDrawables(PODVector<Drawable2D*>& drawables, Node* node)
 
 static inline bool CompareSourceBatch2Ds(const SourceBatch2D* lhs, const SourceBatch2D* rhs)
 {
-    if (lhs->distance_ != rhs->distance_)
-        return lhs->distance_ > rhs->distance_;
-
     if (lhs->drawOrder_ != rhs->drawOrder_)
         return lhs->drawOrder_ < rhs->drawOrder_;
+
+    if (lhs->distance_ != rhs->distance_)
+        return lhs->distance_ > rhs->distance_;
 
     if (lhs->material_ != rhs->material_)
         return lhs->material_->GetNameHash() < rhs->material_->GetNameHash();


### PR DESCRIPTION
Hello everyone, I recently used StaticSprite2D to study the relationship between SetLayer andposition.z and found that z has priority over SetLayer. Layers only work when z is equal. I looked at the unity engine and found that it was the opposite. It was to consider layer first and then consider z. Which kind of order is universal? Should we be consistent with unity?