### PR TITLE
Re-enable suspending main loop when application is paused on android

### DIFF
--- a/Source/ThirdParty/SDL/src/video/android/SDL_androidevents.c
+++ b/Source/ThirdParty/SDL/src/video/android/SDL_androidevents.c
@@ -26,8 +26,7 @@
 #if SDL_VIDEO_DRIVER_ANDROID
 
 /* We're going to do this by default */
-// Urho3D: do not block on pause to allow exiting the application
-//#define SDL_ANDROID_BLOCK_ON_PAUSE  1
+#define SDL_ANDROID_BLOCK_ON_PAUSE  1
 
 #include "SDL_androidevents.h"
 #include "SDL_events.h"


### PR DESCRIPTION
Fixes #2328.

Previous behaviour allowed main loop to spin (at 10fps, as if window is minimized) while application was in background. This is both bad for battery life and also introduces a race condition where rapidly suspending and resuming application may get it into the state where application is resumed while some or most GPU objects are not recreated.