### PR TITLE
Fix chat sample [Samples/16_Chat]

### DIFF
--- a/Source/Samples/16_Chat/Chat.cpp
+++ b/Source/Samples/16_Chat/Chat.cpp
@@ -181,14 +181,14 @@ void Chat::UpdateButtons()
     startServerButton_->SetVisible(!serverConnection && !serverRunning);
 }
 
-void Chat::HandleLogMessage(StringHash eventType, VariantMap& eventData)
+void Chat::HandleLogMessage(StringHash /*eventType*/, VariantMap& eventData)
 {
     using namespace LogMessage;
 
     ShowChatText(eventData[P_MESSAGE].GetString());
 }
 
-void Chat::HandleSend(StringHash eventType, VariantMap& eventData)
+void Chat::HandleSend(StringHash /*eventType*/, VariantMap& eventData)
 {
     String text = textEdit_->GetText();
     if (text.Empty())
@@ -209,7 +209,7 @@ void Chat::HandleSend(StringHash eventType, VariantMap& eventData)
     }
 }
 
-void Chat::HandleConnect(StringHash eventType, VariantMap& eventData)
+void Chat::HandleConnect(StringHash /*eventType*/, VariantMap& eventData)
 {
     auto* network = GetSubsystem<Network>();
     String address = textEdit_->GetText().Trimmed();
@@ -226,7 +226,7 @@ void Chat::HandleConnect(StringHash eventType, VariantMap& eventData)
     UpdateButtons();
 }
 
-void Chat::HandleDisconnect(StringHash eventType, VariantMap& eventData)
+void Chat::HandleDisconnect(StringHash /*eventType*/, VariantMap& eventData)
 {
     auto* network = GetSubsystem<Network>();
     Connection* serverConnection = network->GetServerConnection();
@@ -240,7 +240,7 @@ void Chat::HandleDisconnect(StringHash eventType, VariantMap& eventData)
     UpdateButtons();
 }
 
-void Chat::HandleStartServer(StringHash eventType, VariantMap& eventData)
+void Chat::HandleStartServer(StringHash /*eventType*/, VariantMap& eventData)
 {
     auto* network = GetSubsystem<Network>();
     network->StartServer(CHAT_SERVER_PORT);
@@ -248,7 +248,7 @@ void Chat::HandleStartServer(StringHash eventType, VariantMap& eventData)
     UpdateButtons();
 }
 
-void Chat::HandleNetworkMessage(StringHash eventType, VariantMap& eventData)
+void Chat::HandleNetworkMessage(StringHash /*eventType*/, VariantMap& eventData)
 {
     auto* network = GetSubsystem<Network>();
 
@@ -280,7 +280,7 @@ void Chat::HandleNetworkMessage(StringHash eventType, VariantMap& eventData)
     }
 }
 
-void Chat::HandleConnectionStatus(StringHash eventType, VariantMap& eventData)
+void Chat::HandleConnectionStatus(StringHash /*eventType*/, VariantMap& eventData)
 {
     UpdateButtons();
 }

--- a/Source/Samples/16_Chat/Chat.cpp
+++ b/Source/Samples/16_Chat/Chat.cpp
@@ -110,10 +110,13 @@ void Chat::CreateUI()
 
     UpdateButtons();
 
-    int rowHeight = chatHistoryText_->GetRowHeight();
+    float rowHeight = chatHistoryText_->GetRowHeight();
     // Row height would be zero if the font failed to load
     if (rowHeight)
-        chatHistory_.Resize((graphics->GetHeight() - 20) / rowHeight);
+    {
+        float numberOfRows = (graphics->GetHeight() - 20) / rowHeight;
+        chatHistory_.Resize(static_cast<unsigned int>(numberOfRows));
+    }
 
     // No viewports or scene is defined. However, the default zone's fog color controls the fill color
     GetSubsystem<Renderer>()->GetDefaultZone()->SetFogColor(Color(0.0f, 0.0f, 0.1f));


### PR DESCRIPTION
Issue: due to a round-off error of an implicit conversion from float to int, the number of lines of the chat history was wrongly computed.

This PR contains a commit (45793b8) that fixes this, by doing the conversion only at the end of the calculation.

The commit dd9532d is just to remove declaration of unused parameters. They were commented out as per other samples.
