### PR TITLE
Fixing typo on NavigationMesh API

### DIFF
--- a/Docs/AngelScriptAPI.h
+++ b/Docs/AngelScriptAPI.h
@@ -4971,7 +4971,7 @@ float GetDistanceToWall(const Vector3&, float, const Vector3& = Vector3 ( 1.0 , 
 bool GetInterceptNetworkUpdate(const String&) const;
 Vector3 GetRandomPoint();
 Vector3 GetRandomPointInCircle(const Vector3&, float, const Vector3& = Vector3 ( 1.0 , 1.0 , 1.0 ));
-BoundingBox GetTileBoudningBox(const IntVector2&) const;
+BoundingBox GetTileBoundingBox(const IntVector2&) const;
 VectorBuffer GetTileData(const IntVector2&) const;
 IntVector2 GetTileIndex(const Vector3&) const;
 bool HasSubscribedToEvent(Object, const String&);
@@ -7689,7 +7689,7 @@ float GetDistanceToWall(const Vector3&, float, const Vector3& = Vector3 ( 1.0 , 
 bool GetInterceptNetworkUpdate(const String&) const;
 Vector3 GetRandomPoint();
 Vector3 GetRandomPointInCircle(const Vector3&, float, const Vector3& = Vector3 ( 1.0 , 1.0 , 1.0 ));
-BoundingBox GetTileBoudningBox(const IntVector2&) const;
+BoundingBox GetTileBoundingBox(const IntVector2&) const;
 VectorBuffer GetTileData(const IntVector2&) const;
 IntVector2 GetTileIndex(const Vector3&) const;
 bool HasSubscribedToEvent(Object, const String&);

--- a/Docs/LuaScriptAPI.dox
+++ b/Docs/LuaScriptAPI.dox
@@ -3963,7 +3963,7 @@ Methods:
 - void RemoveTile(const IntVector2& tile)
 - void RemoveAllTiles()
 - bool HasTile(const IntVector2& tile) const
-- BoundingBox GetTileBoudningBox(const IntVector2& tile) const
+- BoundingBox GetTileBoundingBox(const IntVector2& tile) const
 - IntVector2 GetTileIndex(const Vector3& position) const
 - void SetPartitionType(NavmeshPartitionType aType)
 - void SetDrawOffMeshConnections(bool enable)

--- a/Docs/ScriptAPI.dox
+++ b/Docs/ScriptAPI.dox
@@ -7222,7 +7222,7 @@ Methods:
 - bool GetInterceptNetworkUpdate(const String&) const
 - Vector3 GetRandomPoint()
 - Vector3 GetRandomPointInCircle(const Vector3&, float, const Vector3& = Vector3 ( 1.0 , 1.0 , 1.0 ))
-- BoundingBox GetTileBoudningBox(const IntVector2&) const
+- BoundingBox GetTileBoundingBox(const IntVector2&) const
 - VectorBuffer GetTileData(const IntVector2&) const
 - IntVector2 GetTileIndex(const Vector3&) const
 - bool HasSubscribedToEvent(Object@, const String&)
@@ -9504,7 +9504,7 @@ Methods:
 - bool GetInterceptNetworkUpdate(const String&) const
 - Vector3 GetRandomPoint()
 - Vector3 GetRandomPointInCircle(const Vector3&, float, const Vector3& = Vector3 ( 1.0 , 1.0 , 1.0 ))
-- BoundingBox GetTileBoudningBox(const IntVector2&) const
+- BoundingBox GetTileBoundingBox(const IntVector2&) const
 - VectorBuffer GetTileData(const IntVector2&) const
 - IntVector2 GetTileIndex(const Vector3&) const
 - bool HasSubscribedToEvent(Object@, const String&)

--- a/Source/Urho3D/AngelScript/NavigationAPI.cpp
+++ b/Source/Urho3D/AngelScript/NavigationAPI.cpp
@@ -125,7 +125,7 @@ template<class T> static void RegisterNavMeshBase(asIScriptEngine* engine, const
     engine->RegisterObjectMethod(name, "void RemoveTile(const IntVector2&)", asMETHOD(T, RemoveTile), asCALL_THISCALL);
     engine->RegisterObjectMethod(name, "void RemoveAllTiles()", asMETHOD(T, RemoveAllTiles), asCALL_THISCALL);
     engine->RegisterObjectMethod(name, "bool HasTile(const IntVector2&) const", asMETHOD(T, HasTile), asCALL_THISCALL);
-    engine->RegisterObjectMethod(name, "BoundingBox GetTileBoudningBox(const IntVector2&) const", asMETHOD(T, GetTileBoudningBox), asCALL_THISCALL);
+    engine->RegisterObjectMethod(name, "BoundingBox GetTileBoundingBox(const IntVector2&) const", asMETHOD(T, GetTileBoundingBox), asCALL_THISCALL);
     engine->RegisterObjectMethod(name, "IntVector2 GetTileIndex(const Vector3&) const", asMETHOD(T, GetTileIndex), asCALL_THISCALL);
     engine->RegisterObjectMethod(name, "void SetAreaCost(uint, float)", asMETHOD(T, SetAreaCost), asCALL_THISCALL);
     engine->RegisterObjectMethod(name, "float GetAreaCost(uint) const", asMETHOD(T, GetAreaCost), asCALL_THISCALL);

--- a/Source/Urho3D/LuaScript/pkgs/Navigation/NavigationMesh.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Navigation/NavigationMesh.pkg
@@ -41,7 +41,7 @@ class NavigationMesh : public Component
     void RemoveTile(const IntVector2& tile);
     void RemoveAllTiles();
     bool HasTile(const IntVector2& tile) const;
-    BoundingBox GetTileBoudningBox(const IntVector2& tile) const;
+    BoundingBox GetTileBoundingBox(const IntVector2& tile) const;
     IntVector2 GetTileIndex(const Vector3& position) const;
     void SetPartitionType(NavmeshPartitionType aType);
     void SetDrawOffMeshConnections(bool enable);

--- a/Source/Urho3D/Navigation/CrowdAgent.cpp
+++ b/Source/Urho3D/Navigation/CrowdAgent.cpp
@@ -658,7 +658,7 @@ void CrowdAgent::HandleNavigationTileAdded(StringHash eventType, VariantMap& eve
 
     const IntVector2 tile = eventData[NavigationTileRemoved::P_TILE].GetIntVector2();
     const IntVector2 agentTile = mesh->GetTileIndex(node_->GetWorldPosition());
-    const BoundingBox boundingBox = mesh->GetTileBoudningBox(agentTile);
+    const BoundingBox boundingBox = mesh->GetTileBoundingBox(agentTile);
     if (tile == agentTile && IsInCrowd())
     {
         RemoveAgentFromCrowd();

--- a/Source/Urho3D/Navigation/DynamicNavigationMesh.cpp
+++ b/Source/Urho3D/Navigation/DynamicNavigationMesh.cpp
@@ -547,7 +547,7 @@ PODVector<unsigned char> DynamicNavigationMesh::GetTileData(const IntVector2& ti
 
 bool DynamicNavigationMesh::IsObstacleInTile(Obstacle* obstacle, const IntVector2& tile) const
 {
-    const BoundingBox tileBoundingBox = GetTileBoudningBox(tile);
+    const BoundingBox tileBoundingBox = GetTileBoundingBox(tile);
     const Vector3 obstaclePosition = obstacle->GetNode()->GetWorldPosition();
     return tileBoundingBox.DistanceToPoint(obstaclePosition) < obstacle->GetRadius();
 }
@@ -823,7 +823,7 @@ int DynamicNavigationMesh::BuildTile(Vector<NavigationGeometryInfo>& geometryLis
 
     tileCache_->removeTile(navMesh_->getTileRefAt(x, z, 0), nullptr, nullptr);
 
-    const BoundingBox tileBoundingBox = GetTileBoudningBox(IntVector2(x, z));
+    const BoundingBox tileBoundingBox = GetTileBoundingBox(IntVector2(x, z));
 
     DynamicNavBuildData build(allocator_.Get());
 

--- a/Source/Urho3D/Navigation/NavigationMesh.cpp
+++ b/Source/Urho3D/Navigation/NavigationMesh.cpp
@@ -541,7 +541,7 @@ bool NavigationMesh::HasTile(const IntVector2& tile) const
     return false;
 }
 
-BoundingBox NavigationMesh::GetTileBoudningBox(const IntVector2& tile) const
+BoundingBox NavigationMesh::GetTileBoundingBox(const IntVector2& tile) const
 {
     const float tileEdgeLength = (float)tileSize_ * cellSize_;
     return BoundingBox(
@@ -1306,7 +1306,7 @@ bool NavigationMesh::BuildTile(Vector<NavigationGeometryInfo>& geometryList, int
     // Remove previous tile (if any)
     navMesh_->removeTile(navMesh_->getTileRefAt(x, z, 0), nullptr, nullptr);
 
-    const BoundingBox tileBoundingBox = GetTileBoudningBox(IntVector2(x, z));
+    const BoundingBox tileBoundingBox = GetTileBoundingBox(IntVector2(x, z));
 
     SimpleNavBuildData build;
 

--- a/Source/Urho3D/Navigation/NavigationMesh.h
+++ b/Source/Urho3D/Navigation/NavigationMesh.h
@@ -153,7 +153,7 @@ public:
     /// Return whether the navigation mesh has tile.
     bool HasTile(const IntVector2& tile) const;
     /// Return bounding box of the tile in the node space.
-    BoundingBox GetTileBoudningBox(const IntVector2& tile) const;
+    BoundingBox GetTileBoundingBox(const IntVector2& tile) const;
     /// Return index of the tile at the position.
     IntVector2 GetTileIndex(const Vector3& position) const;
     /// Find the nearest point on the navigation mesh to a given point. Extents specifies how far out from the specified point to check along each axis.


### PR DESCRIPTION
Correcting a typo on Source/Urho3D/Navigation/NavigationMesh.h 's API. This patch also corrects all usages inside of the urho repo, and it builds. Might break client code for some users, so buyer's beware.