### PR TITLE
Added new EmitterTypes

### DIFF
--- a/Source/Urho3D/AngelScript/GraphicsAPI.cpp
+++ b/Source/Urho3D/AngelScript/GraphicsAPI.cpp
@@ -1556,6 +1556,9 @@ static void RegisterParticleEffect(asIScriptEngine* engine)
     engine->RegisterEnum("EmitterType");
     engine->RegisterEnumValue("EmitterType", "EMITTER_SPHERE", EMITTER_SPHERE);
     engine->RegisterEnumValue("EmitterType", "EMITTER_BOX", EMITTER_BOX);
+    engine->RegisterEnumValue("EmitterType", "EMITTER_SPHEREVOLUME", EMITTER_SPHEREVOLUME);
+    engine->RegisterEnumValue("EmitterType", "EMITTER_CYLINDER", EMITTER_CYLINDER);
+    engine->RegisterEnumValue("EmitterType", "EMITTER_RING", EMITTER_RING);
 
     engine->RegisterObjectType("ColorFrame", 0, asOBJ_REF);
     engine->RegisterObjectBehaviour("ColorFrame", asBEHAVE_ADDREF, "void f()", asFUNCTION(FakeAddRef), asCALL_CDECL_OBJLAST);

--- a/Source/Urho3D/Graphics/ParticleEffect.cpp
+++ b/Source/Urho3D/Graphics/ParticleEffect.cpp
@@ -42,6 +42,9 @@ static const char* emitterTypeNames[] =
 {
     "Sphere",
     "Box",
+    "SphereVolume",
+    "Cylinder",
+    "Ring",
     nullptr
 };
 

--- a/Source/Urho3D/Graphics/ParticleEffect.h
+++ b/Source/Urho3D/Graphics/ParticleEffect.h
@@ -32,7 +32,10 @@ namespace Urho3D
 enum EmitterType
 {
     EMITTER_SPHERE = 0,
-    EMITTER_BOX
+    EMITTER_BOX,
+    EMITTER_SPHEREVOLUME,
+    EMITTER_CYLINDER,
+    EMITTER_RING
 };
 
 /// %Color animation frame definition.

--- a/Source/Urho3D/Graphics/ParticleEmitter.cpp
+++ b/Source/Urho3D/Graphics/ParticleEmitter.cpp
@@ -471,6 +471,7 @@ bool ParticleEmitter::EmitNewParticle()
             );
             dir.Normalize();
             startPos = effect_->GetEmitterSize() * dir * 0.5f;
+            
         }
         break;
 
@@ -484,6 +485,36 @@ bool ParticleEmitter::EmitNewParticle()
             );
         }
         break;
+
+    case EMITTER_SPHEREVOLUME:
+        {
+            Vector3 dir(
+                Random(2.0f) - 1.0f,
+                Random(2.0f) - 1.0f,
+                Random(2.0f) - 1.0f
+            );
+            dir.Normalize();
+            startPos = effect_->GetEmitterSize() * dir * Pow(Random(), 1.0f / 3.0f) * 0.5f;
+            
+        }
+        break;
+
+    case EMITTER_CYLINDER:
+        {
+            float angle = Random(360.0f);
+            float radius = Sqrt(Random()) * 0.5f;
+            startPos = Vector3(Cos(angle) * radius, Random() - 0.5f, Sin(angle) * radius) * effect_->GetEmitterSize();
+        }
+        break;
+
+    case EMITTER_RING:
+        {
+            float angle = Random(360.0f);
+            startPos = Vector3(Cos(angle), Random(2.0f) - 1.0f, Sin(angle)) * effect_->GetEmitterSize() * 0.5f;
+        }
+        break;
+
+
     }
 
     particle.size_ = effect_->GetRandomSize();

--- a/bin/Data/Scripts/Editor/EditorParticleEffect.as
+++ b/bin/Data/Scripts/Editor/EditorParticleEffect.as
@@ -693,6 +693,19 @@ void EditParticleEffectEmitterShape(StringHash eventType, VariantMap& eventData)
         case 1:
             editParticleEffect.emitterType = EMITTER_BOX;
             break;
+
+        case 2:
+            editParticleEffect.emitterType = EMITTER_SPHEREVOLUME;
+            break;
+
+        case 3:
+            editParticleEffect.emitterType = EMITTER_CYLINDER;
+            break;
+
+        case 4:
+            editParticleEffect.emitterType = EMITTER_RING;
+            break;
+
     }
 
     EndParticleEffectEdit();
@@ -1474,6 +1487,15 @@ void RefreshParticleEffectBasicAttributes()
             break;
         case EMITTER_BOX:
             cast<DropDownList>(particleEffectWindow.GetChild("EmitterShape", true)).selection = 1;
+            break;
+        case EMITTER_SPHEREVOLUME:
+            cast<DropDownList>(particleEffectWindow.GetChild("EmitterShape", true)).selection = 2;
+            break;
+        case EMITTER_CYLINDER:
+            cast<DropDownList>(particleEffectWindow.GetChild("EmitterShape", true)).selection = 3;
+            break;
+        case EMITTER_RING:
+            cast<DropDownList>(particleEffectWindow.GetChild("EmitterShape", true)).selection = 4;
             break;
     }
 

--- a/bin/Data/UI/EditorParticleEffectWindow.xml
+++ b/bin/Data/UI/EditorParticleEffectWindow.xml
@@ -623,6 +623,15 @@
                                                 <element type="Text" style="FileSelectorFilterText">
                                                     <attribute name="Text" value="Box" />
                                                 </element>
+                                                <element type="Text" style="FileSelectorFilterText">
+                                                    <attribute name="Text" value="Sphere Volume" />
+                                                </element>
+                                                <element type="Text" style="FileSelectorFilterText">
+                                                    <attribute name="Text" value="Cylinder" />
+                                                </element>
+                                                <element type="Text" style="FileSelectorFilterText">
+                                                    <attribute name="Text" value="Ring" />
+                                                </element>
                                             </element>
                                         </element>
                                     </element>


### PR DESCRIPTION
 * Added SphereVolume, Cylinder, and Ring enum with calculations
 * Modified EditorParticle to incorporate new emitter shapes

The options for emitter shapes is quite small, and I thought I should add to it. Sphere volume emits particles in a random point inside a sphere instead of the surface. Cylinder is a random point in a cylinder, which can be flattened to make a circle that emits in evenly distributed points. Ring emits particles on the edges of a circle, but becomes a tube shape when sized vertically (image below).

![image](https://user-images.githubusercontent.com/14708882/48973949-86fa0a80-f000-11e8-9b8c-c59c4020b0ca.png)
