### PR TITLE
Fix missing bit shift in BatchQueue::SortFrontToBack2Pass(). Thanks t…

### DIFF
--- a/Source/Urho3D/Graphics/Batch.cpp
+++ b/Source/Urho3D/Graphics/Batch.cpp
@@ -807,7 +807,7 @@ void BatchQueue::SortFrontToBack2Pass(PODVector<Batch*>& batches)
             ++freeShaderID;
         }
 
-        auto materialID = (unsigned short)(batch->sortKey_ & 0xffff0000);
+        auto materialID = (unsigned short)((batch->sortKey_ & 0xffff0000) >> 16u);
         HashMap<unsigned short, unsigned short>::ConstIterator k = materialRemapping_.Find(materialID);
         if (k != materialRemapping_.End())
             materialID = k->second_;


### PR DESCRIPTION
Fixes a long-standing bug which would cause all material ID's to be zero in the sorting, making it ineffective in regard to different materials. See https://discourse.urho3d.io/t/the-doubt-in-batchqueue-sortfronttoback2pass/4807