### PR TITLE
Files patched for Issue# 2352 (unordered network replication of node hierarchies)

### DIFF
--- a/Source/Urho3D/AngelScript/GraphicsAPI.cpp
+++ b/Source/Urho3D/AngelScript/GraphicsAPI.cpp
@@ -2081,7 +2081,7 @@ static void RegisterDebugRenderer(asIScriptEngine* engine)
     engine->RegisterObjectMethod("DebugRenderer", "void AddSphereSector(const Sphere&in, const Quaternion&in, float, bool, const Color&in, bool depthTest = true)", asMETHOD(DebugRenderer, AddSphereSector), asCALL_THISCALL);
     engine->RegisterObjectMethod("DebugRenderer", "void AddSkeleton(Skeleton@+, const Color&in, bool depthTest = true)", asMETHOD(DebugRenderer, AddSkeleton), asCALL_THISCALL);
     engine->RegisterObjectMethod("DebugRenderer", "void AddCircle(const Vector3&in, const Vector3&in, float, const Color&in, int steps = 64, bool depthTest = true)", asMETHOD(DebugRenderer, AddCircle), asCALL_THISCALL);
-    engine->RegisterObjectMethod("DebugRenderer", "void AddCross(const Vector3&in, float size, const Color&in, bool depthTest = true)", asMETHOD(DebugRenderer, AddCross), asCALL_THISCALL);
+    engine->RegisterObjectMethod("DebugRenderer", "void AddCross(const Vector3&in, const Quaternion&in, float size, const Color&in, bool depthTest = true)", asMETHOD(DebugRenderer, AddCross), asCALL_THISCALL);
     engine->RegisterObjectMethod("DebugRenderer", "void AddQuad(const Vector3&in, float, float, const Color&in, bool depthTest = true)", asMETHOD(DebugRenderer, AddQuad), asCALL_THISCALL);
     engine->RegisterObjectMethod("Scene", "DebugRenderer@+ get_debugRenderer() const", asFUNCTION(SceneGetDebugRenderer), asCALL_CDECL_OBJLAST);
     engine->RegisterGlobalFunction("DebugRenderer@+ get_debugRenderer()", asFUNCTION(GetDebugRenderer), asCALL_CDECL);

--- a/Source/Urho3D/Graphics/DebugRenderer.h
+++ b/Source/Urho3D/Graphics/DebugRenderer.h
@@ -131,8 +131,13 @@ public:
     /// Add a sphere sector.
     void AddSphereSector(const Sphere& sphere, const Quaternion& rotation, float angle,
         bool drawLines, const Color& color, bool depthTest = true);
+    void AddArc(const Sphere& sphere, const Vector3& from, const Vector3& to, const Color& color, int steps=16, bool depthTest=true);
     /// Add a cylinder
-    void AddCylinder(const Vector3& position, float radius, float height, const Color& color, bool depthTest = true);
+    void AddCylinder(     const Vector3& position, float radius, float height, const Color& color, bool depthTest = true);
+    void AddSolidCylinder(const Vector3& position, const Vector3& normal, float radius, float height, const Color& color, int steps=64, bool drawCaps=true, bool depthTest = true);
+    /// Add a solid arrow    
+    void AddSolidArrow(const Vector3& position, const Vector3& normal, float radius, float height, Color color, int steps=64, bool depthTest=true);
+
     /// Add a skeleton.
     void AddSkeleton(const Skeleton& skeleton, const Color& color, bool depthTest = true);
     /// Add a triangle mesh.
@@ -144,9 +149,14 @@ public:
     /// Add a circle.
     void AddCircle(const Vector3& center, const Vector3& normal, float radius, const Color& color, int steps = 64, bool depthTest = true);
     /// Add a cross.
-    void AddCross(const Vector3& center, float size, const Color& color, bool depthTest = true);
+    void AddCross(const Vector3& center,  const Quaternion& orient, float size, const Color& color, bool depthTest = true);
     /// Add a quad on the XZ plane.
     void AddQuad(const Vector3& center, float width, float height, const Color& color, bool depthTest = true);
+
+    void AddLabel(const Vector3& position, const String& name, const String& text, bool dynamicText=true);
+
+    void AddSolidCone(const Vector3& center, const Vector3& normal, float radius, const Color& color, int steps = 64, bool depthTest = true);
+    void AddWireCone(const Vector3& center, const Vector3& normal, float radius, const Color& color, int steps = 64, bool depthTest = true);
 
     /// Update vertex buffer and render all debug lines. The viewport and rendertarget should be set before.
     void Render();

--- a/Source/Urho3D/LuaScript/pkgs/Graphics/DebugRenderer.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Graphics/DebugRenderer.pkg
@@ -21,7 +21,7 @@ class DebugRenderer : public Component
     void AddTriangleMesh(const void* vertexData, unsigned vertexSize, const void* indexData, unsigned indexSize, unsigned indexStart, unsigned indexCount, const Matrix3x4& transform, const Color& color, bool depthTest = true);
     void AddTriangleMesh(const void* vertexData, unsigned vertexSize, unsigned vertexStart, const void* indexData, unsigned indexSize, unsigned indexStart, unsigned indexCount, const Matrix3x4& transform, const Color& color, bool depthTest = true);
     void AddCircle(const Vector3& center, const Vector3& normal, float radius, const Color& color, int steps = 64, bool depthTest = true);
-    void AddCross(const Vector3& center, float size, const Color& color, bool depthTest = true);
+    void AddCross(const Vector3& center, const Quaternion& orient, float size, const Color& color, bool depthTest = true);
     void AddQuad(const Vector3& center, float width, float height, const Color& color, bool depthTest = true);
     void Render();
 

--- a/Source/Urho3D/Network/Connection.cpp
+++ b/Source/Urho3D/Network/Connection.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2008-2017 the Urho3D project.
+// Copyright (c) 2008-2019 the Urho3D project.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -38,9 +38,16 @@
 #include "../Scene/SceneEvents.h"
 #include "../Scene/SmoothedTransform.h"
 
-#include <kNet/kNet.h>
+#include <SLikeNet/peerinterface.h>
+#include <SLikeNet/statistics.h>
+
+#ifdef SendMessage
+#undef SendMessage
+#endif
 
 #include "../DebugNew.h"
+
+#include <cstdio>
 
 namespace Urho3D
 {
@@ -60,30 +67,29 @@ PackageUpload::PackageUpload() :
 {
 }
 
-Connection::Connection(Context* context, bool isClient, kNet::SharedPtr<kNet::MessageConnection> connection) :
+Connection::Connection(Context* context, bool isClient, const SLNet::AddressOrGUID& address, SLNet::RakPeerInterface* peer) :
     Object(context),
     timeStamp_(0),
-    connection_(connection),
+    peer_(peer),
     sendMode_(OPSM_NONE),
     isClient_(isClient),
     connectPending_(false),
     sceneLoaded_(false),
-    logStatistics_(false)
+    logStatistics_(false),
+    address_(nullptr)
 {
     sceneState_.connection_ = this;
-
-    // Store address and port now for accurate logging (kNet may already have destroyed the socket on disconnection,
-    // in which case we would log a zero address:port on disconnect)
-    kNet::EndPoint endPoint = connection_->RemoteEndPoint();
-    ///\todo Not IPv6-capable.
-    address_ = Urho3D::ToString("%d.%d.%d.%d", endPoint.ip[0], endPoint.ip[1], endPoint.ip[2], endPoint.ip[3]);
-    port_ = endPoint.port;
+    port_ = address.systemAddress.GetPort();
+    SetAddressOrGUID(address);
 }
 
 Connection::~Connection()
 {
     // Reset scene (remove possible owner references), as this connection is about to be destroyed
-    SetScene(0);
+    SetScene(nullptr);
+
+    delete address_;
+    address_ = nullptr;
 }
 
 void Connection::SendMessage(int msgID, bool reliable, bool inOrder, const VectorBuffer& msg, unsigned contentID)
@@ -94,8 +100,9 @@ void Connection::SendMessage(int msgID, bool reliable, bool inOrder, const Vecto
 void Connection::SendMessage(int msgID, bool reliable, bool inOrder, const unsigned char* data, unsigned numBytes,
     unsigned contentID)
 {
-    // Make sure not to use kNet internal message ID's
-    if (msgID <= 0x4 || msgID >= 0x3ffffffe)
+    /* Make sure not to use SLikeNet(RakNet) internal message ID's
+     and since RakNet uses 1 byte message ID's, they cannot exceed 255 limit */
+    if (msgID <= 0x4 || msgID >= 255)
     {
         URHO3D_LOGERROR("Can not send message with reserved ID");
         return;
@@ -107,21 +114,14 @@ void Connection::SendMessage(int msgID, bool reliable, bool inOrder, const unsig
         return;
     }
 
-    kNet::NetworkMessage* msg = connection_->StartNewMessage((unsigned long)msgID, numBytes);
-    if (!msg)
-    {
-        URHO3D_LOGERROR("Can not start new network message");
-        return;
+    VectorBuffer buffer;
+    buffer.WriteUByte((unsigned char)msgID);
+    buffer.Write(data, numBytes);
+    PacketReliability reliability = reliable ? (inOrder ? RELIABLE_ORDERED : RELIABLE) : (inOrder ? UNRELIABLE_SEQUENCED : UNRELIABLE);
+    if (peer_) {
+        peer_->Send((const char *) buffer.GetData(), (int) buffer.GetSize(), HIGH_PRIORITY, reliability, (char) 0, *address_, false);
+        tempPacketCounter_.y_++;
     }
-
-    msg->reliable = reliable;
-    msg->inOrder = inOrder;
-    msg->priority = 0;
-    msg->contentID = contentID;
-    if (numBytes)
-        memcpy(msg->data, data, numBytes);
-
-    connection_->EndAndQueueMessage(msg);
 }
 
 void Connection::SendRemoteEvent(StringHash eventType, bool inOrder, const VariantMap& eventData)
@@ -146,7 +146,7 @@ void Connection::SendRemoteEvent(Node* node, StringHash eventType, bool inOrder,
         URHO3D_LOGERROR("Sender node is not in the connection's scene, can not send remote node event");
         return;
     }
-    if (node->GetID() >= FIRST_LOCAL_ID)
+    if (!node->IsReplicated())
     {
         URHO3D_LOGERROR("Sender node has a local ID, can not send remote node event");
         return;
@@ -238,7 +238,7 @@ void Connection::SetLogStatistics(bool enable)
 
 void Connection::Disconnect(int waitMSec)
 {
-    connection_->Disconnect(waitMSec);
+    peer_->CloseConnection(*address_, true);
 }
 
 void Connection::SendServerUpdate()
@@ -253,8 +253,10 @@ void Connection::SendServerUpdate()
     ProcessNode(sceneID);
 
     // Then go through all dirtied nodes
-    nodesToProcess_.Insert(0, sceneState_.dirtyNodes_);
-    nodesToProcess_.Erase(nodesToProcess_.Find(sceneID)); // Do not process the root node twice
+    nodesToProcess_.Insert(0,sceneState_.dirtyNodes_);
+    auto it=nodesToProcess_.Find(sceneID);
+    if(it!=nodesToProcess_.End())
+        nodesToProcess_.Erase(it); // Do not process the root node twice
 
     while (nodesToProcess_.Size())
     {
@@ -290,12 +292,22 @@ void Connection::SendRemoteEvents()
     {
         statsTimer_.Reset();
         char statsBuffer[256];
-        sprintf(statsBuffer, "RTT %.3f ms Pkt in %d Pkt out %d Data in %.3f KB/s Data out %.3f KB/s", connection_->RoundTripTime(),
-            (int)connection_->PacketsInPerSec(),
-            (int)connection_->PacketsOutPerSec(), connection_->BytesInPerSec() / 1000.0f, connection_->BytesOutPerSec() / 1000.0f);
+        sprintf(statsBuffer, "RTT %.3f ms Pkt in %i Pkt out %i Data in %.3f KB/s Data out %.3f KB/s, Last heard %u", GetRoundTripTime(),
+            GetPacketsInPerSec(),
+            GetPacketsOutPerSec(),
+            GetBytesInPerSec(),
+            GetBytesOutPerSec(),
+            GetLastHeardTime());
         URHO3D_LOGINFO(statsBuffer);
     }
 #endif
+
+    if (packetCounterTimer_.GetMSec(false) > 1000)
+    {
+        packetCounterTimer_.Reset();
+        packetCounter_ = tempPacketCounter_;
+        tempPacketCounter_ = IntVector2::ZERO;
+    }
 
     if (remoteEvents_.Empty())
         return;
@@ -325,7 +337,7 @@ void Connection::SendRemoteEvents()
 
 void Connection::SendPackages()
 {
-    while (!uploads_.Empty() && connection_->NumOutboundMessagesPending() < 1000)
+    while (!uploads_.Empty())
     {
         unsigned char buffer[PACKAGE_FRAGMENT_SIZE];
 
@@ -333,8 +345,8 @@ void Connection::SendPackages()
         {
             HashMap<StringHash, PackageUpload>::Iterator current = i++;
             PackageUpload& upload = current->second_;
-            unsigned fragmentSize =
-                Min((upload.file_->GetSize() - upload.file_->GetPosition()), PACKAGE_FRAGMENT_SIZE);
+            auto fragmentSize =
+                (unsigned)Min((int)(upload.file_->GetSize() - upload.file_->GetPosition()), (int)PACKAGE_FRAGMENT_SIZE);
             upload.file_->Read(buffer, fragmentSize);
 
             msg_.Clear();
@@ -389,6 +401,9 @@ void Connection::ProcessPendingLatestData()
 
 bool Connection::ProcessMessage(int msgID, MemoryBuffer& msg)
 {
+    // New incomming message, reset last heard timer
+    lastHeardTimer_.Reset();
+    tempPacketCounter_.x_++;
     bool processed = true;
 
     switch (msgID)
@@ -446,6 +461,14 @@ bool Connection::ProcessMessage(int msgID, MemoryBuffer& msg)
     return processed;
 }
 
+void Connection::Ban()
+{
+    if (peer_)
+    {
+        peer_->AddToBanList(address_->ToString(false), 0);
+    }
+}
+
 void Connection::ProcessLoadScene(int msgID, MemoryBuffer& msg)
 {
     if (IsClient())
@@ -470,7 +493,7 @@ void Connection::ProcessLoadScene(int msgID, MemoryBuffer& msg)
 
     // In case we have joined other scenes in this session, remove first all downloaded package files from the resource system
     // to prevent resource conflicts
-    ResourceCache* cache = GetSubsystem<ResourceCache>();
+    auto* cache = GetSubsystem<ResourceCache>();
     const String& packageCacheDir = GetSubsystem<Network>()->GetPackageCacheDir();
 
     Vector<SharedPtr<PackageFile> > packages = cache->GetPackageFiles();
@@ -536,7 +559,7 @@ void Connection::ProcessSceneUpdate(int msgID, MemoryBuffer& msg)
 
             // Read initial attributes, then snap the motion smoothing immediately to the end
             node->ReadDeltaUpdate(msg);
-            SmoothedTransform* transform = node->GetComponent<SmoothedTransform>();
+            auto* transform = node->GetComponent<SmoothedTransform>();
             if (transform)
                 transform->Update(1.0f, 0.0f);
 
@@ -739,7 +762,7 @@ void Connection::ProcessPackageDownload(int msgID, MemoryBuffer& msg)
             for (unsigned i = 0; i < packages.Size(); ++i)
             {
                 PackageFile* package = packages[i];
-                String packageFullName = package->GetName();
+                const String& packageFullName = package->GetName();
                 if (!GetFileNameAndExtension(packageFullName).Compare(name, false))
                 {
                     StringHash nameHash(name);
@@ -981,11 +1004,6 @@ void Connection::ProcessRemoteEvent(int msgID, MemoryBuffer& msg)
     }
 }
 
-kNet::MessageConnection* Connection::GetMessageConnection() const
-{
-    return const_cast<kNet::MessageConnection*>(connection_.ptr());
-}
-
 Scene* Connection::GetScene() const
 {
     return scene_;
@@ -993,37 +1011,55 @@ Scene* Connection::GetScene() const
 
 bool Connection::IsConnected() const
 {
-    return connection_->GetConnectionState() == kNet::ConnectionOK;
+    return peer_ && peer_->IsActive();
 }
 
 float Connection::GetRoundTripTime() const
 {
-    return connection_->RoundTripTime();
+    if (peer_)
+    {
+        SLNet::RakNetStatistics stats{};
+        if (peer_->GetStatistics(address_->systemAddress, &stats))
+            return (float)peer_->GetAveragePing(*address_);
+    }
+    return 0.0f;
 }
 
-float Connection::GetLastHeardTime() const
+unsigned Connection::GetLastHeardTime() const
 {
-    return connection_->LastHeardTime();
+    return const_cast<Timer&>(lastHeardTimer_).GetMSec(false);
 }
 
 float Connection::GetBytesInPerSec() const
 {
-    return connection_->BytesInPerSec();
+    if (peer_)
+    {
+        SLNet::RakNetStatistics stats{};
+        if (peer_->GetStatistics(address_->systemAddress, &stats))
+            return (float)stats.valueOverLastSecond[SLNet::ACTUAL_BYTES_RECEIVED];
+    }
+    return 0.0f;
 }
 
 float Connection::GetBytesOutPerSec() const
 {
-    return connection_->BytesOutPerSec();
+    if (peer_)
+    {
+        SLNet::RakNetStatistics stats{};
+        if (peer_->GetStatistics(address_->systemAddress, &stats))
+            return (float)stats.valueOverLastSecond[SLNet::ACTUAL_BYTES_SENT];
+    }
+    return 0.0f;
 }
 
-float Connection::GetPacketsInPerSec() const
+int Connection::GetPacketsInPerSec() const
 {
-    return connection_->PacketsInPerSec();
+    return packetCounter_.x_;
 }
 
-float Connection::GetPacketsOutPerSec() const
+int Connection::GetPacketsOutPerSec() const
 {
-    return connection_->PacketsOutPerSec();
+    return packetCounter_.y_;
 }
 
 String Connection::ToString() const
@@ -1083,18 +1119,16 @@ void Connection::SendPackageToClient(PackageFile* package)
 
 void Connection::ConfigureNetworkSimulator(int latencyMs, float packetLoss)
 {
-    if (connection_)
-    {
-        kNet::NetworkSimulator& simulator = connection_->NetworkSendSimulator();
-        simulator.enabled = latencyMs > 0 || packetLoss > 0.0f;
-        simulator.constantPacketSendDelay = (float)latencyMs;
-        simulator.packetLossRate = packetLoss;
-    }
+    if (peer_)
+        peer_->ApplyNetworkSimulator(packetLoss, latencyMs, 0);
 }
 
 void Connection::HandleAsyncLoadFinished(StringHash eventType, VariantMap& eventData)
 {
     sceneLoaded_ = true;
+
+    // Clear all replicated nodes
+    scene_->Clear(true, false);
 
     msg_.Clear();
     msg_.WriteUInt(scene_->GetChecksum());
@@ -1104,13 +1138,10 @@ void Connection::HandleAsyncLoadFinished(StringHash eventType, VariantMap& event
 void Connection::ProcessNode(unsigned nodeID)
 {
     // Check that we have not already processed this due to dependency recursion
-    auto meh = nodesToProcess_.Find(nodeID);
-
-    //if (!nodesToProcess_.Erase(nodeID))
-    if(meh==nodesToProcess_.End())
+    auto it=nodesToProcess_.Find(nodeID);
+    if (it==nodesToProcess_.End())
         return;
-
-    nodesToProcess_.Erase(meh);
+    nodesToProcess_.Erase(it);
 
     // Find replication state for the node
     HashMap<unsigned, NodeReplicationState>::Iterator i = sceneState_.nodeStates_.Find(nodeID);
@@ -1185,7 +1216,7 @@ void Connection::ProcessNewNode(Node* node)
     {
         Component* component = components[i];
         // Check if component is not to be replicated
-        if (component->GetID() >= FIRST_LOCAL_ID)
+        if (!component->IsReplicated())
             continue;
 
         ComponentReplicationState& componentState = nodeState.componentStates_[component->GetID()];
@@ -1218,7 +1249,7 @@ void Connection::ProcessExistingNode(Node* node, NodeReplicationState& nodeState
 
     // Check from the interest management component, if exists, whether should update
     /// \todo Searching for the component is a potential CPU hotspot. It should be cached
-    NetworkPriority* priority = node->GetComponent<NetworkPriority>();
+    auto* priority = node->GetComponent<NetworkPriority>();
     if (priority && (!priority->GetAlwaysUpdateOwner() || node->GetOwner() != this))
     {
         float distance = (node->GetWorldPosition() - position_).Length();
@@ -1353,7 +1384,7 @@ void Connection::ProcessExistingNode(Node* node, NodeReplicationState& nodeState
         {
             Component* component = components[i];
             // Check if component is not to be replicated
-            if (component->GetID() >= FIRST_LOCAL_ID)
+            if (!component->IsReplicated())
                 continue;
 
             HashMap<unsigned, ComponentReplicationState>::Iterator j = nodeState.componentStates_.Find(component->GetID());
@@ -1383,7 +1414,7 @@ void Connection::ProcessExistingNode(Node* node, NodeReplicationState& nodeState
 
 bool Connection::RequestNeededPackages(unsigned numPackages, MemoryBuffer& msg)
 {
-    ResourceCache* cache = GetSubsystem<ResourceCache>();
+    auto* cache = GetSubsystem<ResourceCache>();
     const String& packageCacheDir = GetSubsystem<Network>()->GetPackageCacheDir();
 
     Vector<SharedPtr<PackageFile> > packages = cache->GetPackageFiles();
@@ -1549,6 +1580,17 @@ void Connection::ProcessPackageInfo(int msgID, MemoryBuffer& msg)
     }
 
     RequestNeededPackages(1, msg);
+}
+
+String Connection::GetAddress() const {
+    return String(address_->ToString(false /*write port*/));
+}
+
+void Connection::SetAddressOrGUID(const SLNet::AddressOrGUID& addr)
+{
+    delete address_;
+    address_ = nullptr;
+    address_ = new SLNet::AddressOrGUID(addr);
 }
 
 }

--- a/Source/Urho3D/Network/Connection.h
+++ b/Source/Urho3D/Network/Connection.h
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2008-2017 the Urho3D project.
+// Copyright (c) 2008-2019 the Urho3D project.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -29,12 +29,15 @@
 #include "../IO/VectorBuffer.h"
 #include "../Scene/ReplicationState.h"
 
-#include <kNet/kNetFwd.h>
-#include <kNet/SharedPtr.h>
-
-#ifdef SendMessage
-#undef SendMessage
-#endif
+namespace SLNet
+{
+    class SystemAddress;
+    struct AddressOrGUID;
+    struct RakNetGUID;
+    struct Packet;
+    class NatPunchthroughClient;
+    class RakPeerInterface;
+}
 
 namespace Urho3D
 {
@@ -107,10 +110,10 @@ class URHO3D_API Connection : public Object
     URHO3D_OBJECT(Connection, Object);
 
 public:
-    /// Construct with context and kNet message connection pointers.
-    Connection(Context* context, bool isClient, kNet::SharedPtr<kNet::MessageConnection> connection);
+    /// Construct with context, RakNet connection address and Raknet peer pointer.
+    Connection(Context* context, bool isClient, const SLNet::AddressOrGUID& address, SLNet::RakPeerInterface* peer);
     /// Destruct.
-    ~Connection();
+    ~Connection() override;
 
     /// Send a message.
     void SendMessage(int msgID, bool reliable, bool inOrder, const VectorBuffer& msg, unsigned contentID = 0);
@@ -148,9 +151,12 @@ public:
     void ProcessPendingLatestData();
     /// Process a message from the server or client. Called by Network.
     bool ProcessMessage(int msgID, MemoryBuffer& msg);
-
-    /// Return the kNet message connection.
-    kNet::MessageConnection* GetMessageConnection() const;
+    /// Ban this connections IP address.
+    void Ban();
+    /// Return the RakNet address/guid.
+    const SLNet::AddressOrGUID& GetAddressOrGUID() const { return *address_; }
+    /// Set the the RakNet address/guid.
+    void SetAddressOrGUID(const SLNet::AddressOrGUID& addr);
 
     /// Return client identity.
     VariantMap& GetIdentity() { return identity_; }
@@ -186,7 +192,7 @@ public:
     bool GetLogStatistics() const { return logStatistics_; }
 
     /// Return remote address.
-    String GetAddress() const { return address_; }
+    String GetAddress() const;
 
     /// Return remote port.
     unsigned short GetPort() const { return port_; }
@@ -195,7 +201,7 @@ public:
     float GetRoundTripTime() const;
 
     /// Return the time since last received data from the remote host in milliseconds.
-    float GetLastHeardTime() const;
+    unsigned GetLastHeardTime() const;
 
     /// Return bytes received per second.
     float GetBytesInPerSec() const;
@@ -204,10 +210,10 @@ public:
     float GetBytesOutPerSec() const;
 
     /// Return packets received per second.
-    float GetPacketsInPerSec() const;
+    int GetPacketsInPerSec() const;
 
     /// Return packets sent per second.
-    float GetPacketsOutPerSec() const;
+    int GetPacketsOutPerSec() const;
 
     /// Return an address:port string.
     String ToString() const;
@@ -270,8 +276,6 @@ private:
     /// Handle all packages loaded successfully. Also called directly on MSG_LOADSCENE if there are none.
     void OnPackagesReady();
 
-    /// kNet message connection.
-    kNet::SharedPtr<kNet::MessageConnection> connection_;
     /// Scene.
     WeakPtr<Scene> scene_;
     /// Network replication state of the scene.
@@ -294,8 +298,6 @@ private:
     String sceneFileName_;
     /// Statistics timer.
     Timer statsTimer_;
-    /// Remote endpoint address.
-    String address_;
     /// Remote endpoint port.
     unsigned short port_;
     /// Observer position for interest management.
@@ -312,6 +314,18 @@ private:
     bool sceneLoaded_;
     /// Show statistics flag.
     bool logStatistics_;
+    /// Address of this connection.
+    SLNet::AddressOrGUID* address_;
+    /// Raknet peer object.
+    SLNet::RakPeerInterface* peer_;
+    /// Temporary variable to hold packet count in the next second, x - packets in, y - packets out
+    IntVector2 tempPacketCounter_;
+    /// Packet count in the last second, x - packets in, y - packets out
+    IntVector2 packetCounter_;
+    /// Packet count timer which resets every 1s
+    Timer packetCounterTimer_;
+    /// Last heard timer, resets when new packet is incoming
+    Timer lastHeardTimer_;
 };
 
 }

--- a/Source/Urho3D/Scene/Component.cpp
+++ b/Source/Urho3D/Scene/Component.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2008-2017 the Urho3D project.
+// Copyright (c) 2008-2019 the Urho3D project.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -48,21 +48,19 @@ const char* autoRemoveModeNames[] = {
     "Disabled",
     "Component",
     "Node",
-    0
+    nullptr
 };
 
 Component::Component(Context* context) :
     Animatable(context),
-    node_(0),
+    node_(nullptr),
     id_(0),
     networkUpdate_(false),
     enabled_(true)
 {
 }
 
-Component::~Component()
-{
-}
+Component::~Component() = default;
 
 bool Component::Save(Serializer& dest) const
 {
@@ -100,7 +98,7 @@ bool Component::SaveJSON(JSONValue& dest) const
 
 void Component::MarkNetworkUpdate()
 {
-    if (!networkUpdate_ && id_ < FIRST_LOCAL_ID)
+    if (!networkUpdate_ && IsReplicated())
     {
         Scene* scene = GetScene();
         if (scene)
@@ -149,9 +147,14 @@ void Component::Remove()
         node_->RemoveComponent(this);
 }
 
+bool Component::IsReplicated() const
+{
+    return Scene::IsReplicatedID(id_);
+}
+
 Scene* Component::GetScene() const
 {
-    return node_ ? node_->GetScene() : 0;
+    return node_ ? node_->GetScene() : nullptr;
 }
 
 void Component::AddReplicationState(ComponentReplicationState* state)
@@ -191,7 +194,7 @@ void Component::PrepareNetworkUpdate()
             for (PODVector<ReplicationState*>::Iterator j = networkState_->replicationStates_.Begin();
                  j != networkState_->replicationStates_.End(); ++j)
             {
-                ComponentReplicationState* compState = static_cast<ComponentReplicationState*>(*j);
+                auto* compState = static_cast<ComponentReplicationState*>(*j);
                 compState->dirtyAttributes_.Set(i);
 
                 // Add component's parent node to the dirty set if not added yet
@@ -261,7 +264,7 @@ void Component::SetNode(Node* node)
 
 Component* Component::GetComponent(StringHash type) const
 {
-    return node_ ? node_->GetComponent(type) : 0;
+    return node_ ? node_->GetComponent(type) : nullptr;
 }
 
 bool Component::IsEnabledEffective() const
@@ -286,7 +289,7 @@ void Component::HandleAttributeAnimationUpdate(StringHash eventType, VariantMap&
 
 Component* Component::GetFixedUpdateSource()
 {
-    Component* ret = 0;
+    Component* ret = nullptr;
     Scene* scene = GetScene();
 
     if (scene)

--- a/Source/Urho3D/Scene/Node.cpp
+++ b/Source/Urho3D/Scene/Node.cpp
@@ -1,5 +1,5 @@
 ﻿//
-// Copyright (c) 2008-2017 the Urho3D project.
+// Copyright (c) 2008-2019 the Urho3D project.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -52,8 +52,8 @@ Node::Node(Context* context) :
     enabled_(true),
     enabledPrev_(true),
     networkUpdate_(false),
-    parent_(0),
-    scene_(0),
+    parent_(nullptr),
+    scene_(nullptr),
     id_(0),
     position_(Vector3::ZERO),
     rotation_(Quaternion::IDENTITY),
@@ -61,7 +61,7 @@ Node::Node(Context* context) :
     worldRotation_(Quaternion::IDENTITY)
 {
     impl_ = new NodeImpl();
-    impl_->owner_ = 0;
+    impl_->owner_ = nullptr;
 }
 
 Node::~Node()
@@ -93,7 +93,7 @@ void Node::RegisterObject(Context* context)
         AM_NET | AM_NOEDIT);
 }
 
-bool Node::Load(Deserializer& source, bool setInstanceDefault)
+bool Node::Load(Deserializer& source)
 {
     SceneResolver resolver;
 
@@ -153,7 +153,7 @@ bool Node::Save(Serializer& dest) const
     return true;
 }
 
-bool Node::LoadXML(const XMLElement& source, bool setInstanceDefault)
+bool Node::LoadXML(const XMLElement& source)
 {
     SceneResolver resolver;
 
@@ -172,7 +172,7 @@ bool Node::LoadXML(const XMLElement& source, bool setInstanceDefault)
     return success;
 }
 
-bool Node::LoadJSON(const JSONValue& source, bool setInstanceDefault)
+bool Node::LoadJSON(const JSONValue& source)
 {
     SceneResolver resolver;
 
@@ -283,7 +283,7 @@ void Node::ApplyAttributes()
 
 void Node::MarkNetworkUpdate()
 {
-    if (!networkUpdate_ && scene_ && id_ < FIRST_LOCAL_ID)
+    if (!networkUpdate_ && scene_ && IsReplicated())
     {
         scene_->MarkNetworkUpdate(this);
         networkUpdate_ = true;
@@ -887,9 +887,9 @@ void Node::RemoveChildren(bool removeReplicated, bool removeLocal, bool recursiv
 
         if (recursive)
             childNode->RemoveChildren(removeReplicated, removeLocal, true);
-        if (childNode->GetID() < FIRST_LOCAL_ID && removeReplicated)
+        if (childNode->IsReplicated() && removeReplicated)
             remove = true;
-        else if (childNode->GetID() >= FIRST_LOCAL_ID && removeLocal)
+        else if (!childNode->IsReplicated() && removeLocal)
             remove = true;
 
         if (remove)
@@ -908,7 +908,7 @@ Component* Node::CreateComponent(StringHash type, CreateMode mode, unsigned id)
 {
     // Do not attempt to create replicated components to local nodes, as that may lead to component ID overwrite
     // as replicated components are synced over
-    if (id_ >= FIRST_LOCAL_ID && mode == REPLICATED)
+    if (mode == REPLICATED && !IsReplicated())
         mode = LOCAL;
 
     // Check that creation succeeds and that the object in fact is a component
@@ -916,7 +916,7 @@ Component* Node::CreateComponent(StringHash type, CreateMode mode, unsigned id)
     if (!newComponent)
     {
         URHO3D_LOGERROR("Could not create unknown component type " + type.ToString());
-        return 0;
+        return nullptr;
     }
 
     AddComponent(newComponent, id, mode);
@@ -937,10 +937,10 @@ Component* Node::CloneComponent(Component* component, unsigned id)
     if (!component)
     {
         URHO3D_LOGERROR("Null source component given for CloneComponent");
-        return 0;
+        return nullptr;
     }
 
-    return CloneComponent(component, component->GetID() < FIRST_LOCAL_ID ? REPLICATED : LOCAL, id);
+    return CloneComponent(component, component->IsReplicated() ? REPLICATED : LOCAL, id);
 }
 
 Component* Node::CloneComponent(Component* component, CreateMode mode, unsigned id)
@@ -948,14 +948,14 @@ Component* Node::CloneComponent(Component* component, CreateMode mode, unsigned 
     if (!component)
     {
         URHO3D_LOGERROR("Null source component given for CloneComponent");
-        return 0;
+        return nullptr;
     }
 
     Component* cloneComponent = SafeCreateComponent(component->GetTypeName(), component->GetType(), mode, 0);
     if (!cloneComponent)
     {
         URHO3D_LOGERROR("Could not clone component " + component->GetTypeName());
-        return 0;
+        return nullptr;
     }
 
     const Vector<AttributeInfo>* compAttributes = component->GetAttributes();
@@ -979,6 +979,7 @@ Component* Node::CloneComponent(Component* component, CreateMode mode, unsigned 
         cloneComponent->ApplyAttributes();
     }
 
+    if (scene_)
     {
         using namespace ComponentCloned;
 
@@ -1032,9 +1033,9 @@ void Node::RemoveComponents(bool removeReplicated, bool removeLocal)
         bool remove = false;
         Component* component = components_[i];
 
-        if (component->GetID() < FIRST_LOCAL_ID && removeReplicated)
+        if (component->IsReplicated() && removeReplicated)
             remove = true;
-        else if (component->GetID() >= FIRST_LOCAL_ID && removeLocal)
+        else if (!component->IsReplicated() && removeLocal)
             remove = true;
 
         if (remove)
@@ -1096,7 +1097,7 @@ Node* Node::Clone(CreateMode mode)
     if (this == scene_ || !parent_)
     {
         URHO3D_LOGERROR("Can not clone node without a parent");
-        return 0;
+        return nullptr;
     }
 
     URHO3D_PROFILE(CloneNode);
@@ -1293,7 +1294,7 @@ PODVector<Node*> Node::GetChildrenWithTag(const String& tag, bool recursive) con
 
 Node* Node::GetChild(unsigned index) const
 {
-    return index < children_.Size() ? children_[index].Get() : 0;
+    return index < children_.Size() ? children_[index].Get() : nullptr;
 }
 
 Node* Node::GetChild(const String& name, bool recursive) const
@@ -1321,7 +1322,7 @@ Node* Node::GetChild(StringHash nameHash, bool recursive) const
         }
     }
 
-    return 0;
+    return nullptr;
 }
 
 unsigned Node::GetNumNetworkComponents() const
@@ -1329,7 +1330,7 @@ unsigned Node::GetNumNetworkComponents() const
     unsigned num = 0;
     for (Vector<SharedPtr<Component> >::ConstIterator i = components_.Begin(); i != components_.End(); ++i)
     {
-        if ((*i)->GetID() < FIRST_LOCAL_ID)
+        if ((*i)->IsReplicated())
             ++num;
     }
 
@@ -1360,6 +1361,11 @@ bool Node::HasComponent(StringHash type) const
             return true;
     }
     return false;
+}
+
+bool Node::IsReplicated() const
+{
+    return Scene::IsReplicatedID(id_);
 }
 
 bool Node::HasTag(const String& tag) const
@@ -1403,7 +1409,7 @@ Component* Node::GetComponent(StringHash type, bool recursive) const
         }
     }
 
-    return 0;
+    return nullptr;
 }
 
 Component* Node::GetParentComponent(StringHash type, bool fullTraversal) const
@@ -1420,7 +1426,7 @@ Component* Node::GetParentComponent(StringHash type, bool fullTraversal) const
         else
             break;
     }
-    return 0;
+    return nullptr;
 }
 
 void Node::SetID(unsigned id)
@@ -1436,13 +1442,13 @@ void Node::SetScene(Scene* scene)
 void Node::ResetScene()
 {
     SetID(0);
-    SetScene(0);
-    SetOwner(0);
+    SetScene(nullptr);
+    SetOwner(nullptr);
 }
 
 void Node::SetNetPositionAttr(const Vector3& value)
 {
-    SmoothedTransform* transform = GetComponent<SmoothedTransform>();
+    auto* transform = GetComponent<SmoothedTransform>();
     if (transform)
         transform->SetTargetPosition(value);
     else
@@ -1452,7 +1458,7 @@ void Node::SetNetPositionAttr(const Vector3& value)
 void Node::SetNetRotationAttr(const PODVector<unsigned char>& value)
 {
     MemoryBuffer buf(value);
-    SmoothedTransform* transform = GetComponent<SmoothedTransform>();
+    auto* transform = GetComponent<SmoothedTransform>();
     if (transform)
         transform->SetTargetRotation(buf.ReadPackedQuaternion());
     else
@@ -1516,14 +1522,14 @@ const PODVector<unsigned char>& Node::GetNetParentAttr() const
     {
         // If parent is replicated, can write the ID directly
         unsigned parentID = parent_->GetID();
-        if (parentID < FIRST_LOCAL_ID)
+        if (Scene::IsReplicatedID(parentID))
             impl_->attrBuffer_.WriteNetID(parentID);
         else
         {
             // Parent is local: traverse hierarchy to find a non-local base node
             // This iteration always stops due to the scene (root) being non-local
             Node* current = parent_;
-            while (current->GetID() >= FIRST_LOCAL_ID)
+            while (!current->IsReplicated())
                 current = current->GetParent();
 
             // Then write the base node ID and the parent's name hash
@@ -1535,7 +1541,7 @@ const PODVector<unsigned char>& Node::GetNetParentAttr() const
     return impl_->attrBuffer_.GetBuffer();
 }
 
-bool Node::Load(Deserializer& source, SceneResolver& resolver, bool readChildren, bool rewriteIDs, CreateMode mode)
+bool Node::Load(Deserializer& source, SceneResolver& resolver, bool loadChildren, bool rewriteIDs, CreateMode mode)
 {
     // Remove all children and components first in case this is not a fresh load
     RemoveAllChildren();
@@ -1553,7 +1559,7 @@ bool Node::Load(Deserializer& source, SceneResolver& resolver, bool readChildren
         unsigned compID = compBuffer.ReadUInt();
 
         Component* newComponent = SafeCreateComponent(String::EMPTY, compType,
-            (mode == REPLICATED && compID < FIRST_LOCAL_ID) ? REPLICATED : LOCAL, rewriteIDs ? 0 : compID);
+            (mode == REPLICATED && Scene::IsReplicatedID(compID)) ? REPLICATED : LOCAL, rewriteIDs ? 0 : compID);
         if (newComponent)
         {
             resolver.AddComponent(compID, newComponent);
@@ -1562,24 +1568,24 @@ bool Node::Load(Deserializer& source, SceneResolver& resolver, bool readChildren
         }
     }
 
-    if (!readChildren)
+    if (!loadChildren)
         return true;
 
     unsigned numChildren = source.ReadVLE();
     for (unsigned i = 0; i < numChildren; ++i)
     {
         unsigned nodeID = source.ReadUInt();
-        Node* newNode = CreateChild(rewriteIDs ? 0 : nodeID, (mode == REPLICATED && nodeID < FIRST_LOCAL_ID) ? REPLICATED :
+        Node* newNode = CreateChild(rewriteIDs ? 0 : nodeID, (mode == REPLICATED && Scene::IsReplicatedID(nodeID)) ? REPLICATED :
             LOCAL);
         resolver.AddNode(nodeID, newNode);
-        if (!newNode->Load(source, resolver, readChildren, rewriteIDs, mode))
+        if (!newNode->Load(source, resolver, loadChildren, rewriteIDs, mode))
             return false;
     }
 
     return true;
 }
 
-bool Node::LoadXML(const XMLElement& source, SceneResolver& resolver, bool readChildren, bool rewriteIDs, CreateMode mode)
+bool Node::LoadXML(const XMLElement& source, SceneResolver& resolver, bool loadChildren, bool rewriteIDs, CreateMode mode)
 {
     // Remove all children and components first in case this is not a fresh load
     RemoveAllChildren();
@@ -1594,7 +1600,7 @@ bool Node::LoadXML(const XMLElement& source, SceneResolver& resolver, bool readC
         String typeName = compElem.GetAttribute("type");
         unsigned compID = compElem.GetUInt("id");
         Component* newComponent = SafeCreateComponent(typeName, StringHash(typeName),
-            (mode == REPLICATED && compID < FIRST_LOCAL_ID) ? REPLICATED : LOCAL, rewriteIDs ? 0 : compID);
+            (mode == REPLICATED && Scene::IsReplicatedID(compID)) ? REPLICATED : LOCAL, rewriteIDs ? 0 : compID);
         if (newComponent)
         {
             resolver.AddComponent(compID, newComponent);
@@ -1605,17 +1611,17 @@ bool Node::LoadXML(const XMLElement& source, SceneResolver& resolver, bool readC
         compElem = compElem.GetNext("component");
     }
 
-    if (!readChildren)
+    if (!loadChildren)
         return true;
 
     XMLElement childElem = source.GetChild("node");
     while (childElem)
     {
         unsigned nodeID = childElem.GetUInt("id");
-        Node* newNode = CreateChild(rewriteIDs ? 0 : nodeID, (mode == REPLICATED && nodeID < FIRST_LOCAL_ID) ? REPLICATED :
+        Node* newNode = CreateChild(rewriteIDs ? 0 : nodeID, (mode == REPLICATED && Scene::IsReplicatedID(nodeID)) ? REPLICATED :
             LOCAL);
         resolver.AddNode(nodeID, newNode);
-        if (!newNode->LoadXML(childElem, resolver, readChildren, rewriteIDs, mode))
+        if (!newNode->LoadXML(childElem, resolver, loadChildren, rewriteIDs, mode))
             return false;
 
         childElem = childElem.GetNext("node");
@@ -1624,7 +1630,7 @@ bool Node::LoadXML(const XMLElement& source, SceneResolver& resolver, bool readC
     return true;
 }
 
-bool Node::LoadJSON(const JSONValue& source, SceneResolver& resolver, bool readChildren, bool rewriteIDs, CreateMode mode)
+bool Node::LoadJSON(const JSONValue& source, SceneResolver& resolver, bool loadChildren, bool rewriteIDs, CreateMode mode)
 {
     // Remove all children and components first in case this is not a fresh load
     RemoveAllChildren();
@@ -1641,7 +1647,7 @@ bool Node::LoadJSON(const JSONValue& source, SceneResolver& resolver, bool readC
         String typeName = compVal.Get("type").GetString();
         unsigned compID = compVal.Get("id").GetUInt();
         Component* newComponent = SafeCreateComponent(typeName, StringHash(typeName),
-            (mode == REPLICATED && compID < FIRST_LOCAL_ID) ? REPLICATED : LOCAL, rewriteIDs ? 0 : compID);
+            (mode == REPLICATED && Scene::IsReplicatedID(compID)) ? REPLICATED : LOCAL, rewriteIDs ? 0 : compID);
         if (newComponent)
         {
             resolver.AddComponent(compID, newComponent);
@@ -1650,7 +1656,7 @@ bool Node::LoadJSON(const JSONValue& source, SceneResolver& resolver, bool readC
         }
     }
 
-    if (!readChildren)
+    if (!loadChildren)
         return true;
 
     const JSONArray& childrenArray = source.Get("children").GetArray();
@@ -1659,10 +1665,10 @@ bool Node::LoadJSON(const JSONValue& source, SceneResolver& resolver, bool readC
         const JSONValue& childVal = childrenArray.At(i);
 
         unsigned nodeID = childVal.Get("id").GetUInt();
-        Node* newNode = CreateChild(rewriteIDs ? 0 : nodeID, (mode == REPLICATED && nodeID < FIRST_LOCAL_ID) ? REPLICATED :
+        Node* newNode = CreateChild(rewriteIDs ? 0 : nodeID, (mode == REPLICATED && Scene::IsReplicatedID(nodeID)) ? REPLICATED :
             LOCAL);
         resolver.AddNode(nodeID, newNode);
-        if (!newNode->LoadJSON(childVal, resolver, readChildren, rewriteIDs, mode))
+        if (!newNode->LoadJSON(childVal, resolver, loadChildren, rewriteIDs, mode))
             return false;
     }
 
@@ -1678,7 +1684,7 @@ void Node::PrepareNetworkUpdate()
     if (parent_ && parent_ != scene_)
     {
         Node* current = parent_;
-        while (current->id_ >= FIRST_LOCAL_ID)
+        while (!current->IsReplicated())
             current = current->parent_;
         if (current && current != scene_)
             impl_->dependencyNodes_.Push(current);
@@ -1688,7 +1694,7 @@ void Node::PrepareNetworkUpdate()
     for (Vector<SharedPtr<Component> >::ConstIterator i = components_.Begin(); i != components_.End(); ++i)
     {
         Component* component = *i;
-        if (component->GetID() < FIRST_LOCAL_ID)
+        if (component->IsReplicated())
             component->GetDependencyNodes(impl_->dependencyNodes_);
     }
 
@@ -1717,7 +1723,7 @@ void Node::PrepareNetworkUpdate()
             for (PODVector<ReplicationState*>::Iterator j = networkState_->replicationStates_.Begin();
                  j != networkState_->replicationStates_.End(); ++j)
             {
-                NodeReplicationState* nodeState = static_cast<NodeReplicationState*>(*j);
+                auto* nodeState = static_cast<NodeReplicationState*>(*j);
                 nodeState->dirtyAttributes_.Set(i);
 
                 // Add node to the dirty set if not added yet
@@ -1742,7 +1748,7 @@ void Node::PrepareNetworkUpdate()
             for (PODVector<ReplicationState*>::Iterator j = networkState_->replicationStates_.Begin();
                  j != networkState_->replicationStates_.End(); ++j)
             {
-                NodeReplicationState* nodeState = static_cast<NodeReplicationState*>(*j);
+                auto* nodeState = static_cast<NodeReplicationState*>(*j);
                 nodeState->dirtyVars_.Insert(i->first_);
 
                 if (!nodeState->markedDirty_)
@@ -1760,7 +1766,7 @@ void Node::PrepareNetworkUpdate()
 void Node::CleanupConnection(Connection* connection)
 {
     if (impl_->owner_ == connection)
-        impl_->owner_ = 0;
+        impl_->owner_ = nullptr;
 
     if (networkState_)
     {
@@ -1779,7 +1785,7 @@ void Node::MarkReplicationDirty()
         for (PODVector<ReplicationState*>::Iterator j = networkState_->replicationStates_.Begin();
              j != networkState_->replicationStates_.End(); ++j)
         {
-            NodeReplicationState* nodeState = static_cast<NodeReplicationState*>(*j);
+            auto* nodeState = static_cast<NodeReplicationState*>(*j);
             if (!nodeState->markedDirty_)
             {
                 nodeState->markedDirty_ = true;
@@ -1931,7 +1937,7 @@ Animatable* Node::FindAttributeAnimationTarget(const String& name, String& outNa
             if (!node)
             {
                 URHO3D_LOGERROR("Could not find node by name " + name);
-                return 0;
+                return nullptr;
             }
         }
 
@@ -1944,7 +1950,7 @@ Animatable* Node::FindAttributeAnimationTarget(const String& name, String& outNa
         if (i != names.Size() - 2 || names[i].Front() != '@')
         {
             URHO3D_LOGERROR("Invalid name " + name);
-            return 0;
+            return nullptr;
         }
 
         String componentName = names[i].Substring(1, names[i].Length() - 1);
@@ -1955,7 +1961,7 @@ Animatable* Node::FindAttributeAnimationTarget(const String& name, String& outNa
             if (!component)
             {
                 URHO3D_LOGERROR("Could not find component by name " + name);
-                return 0;
+                return nullptr;
             }
 
             outName = names.Back();
@@ -1969,7 +1975,7 @@ Animatable* Node::FindAttributeAnimationTarget(const String& name, String& outNa
             if (index >= components.Size())
             {
                 URHO3D_LOGERROR("Could not find component by name " + name);
-                return 0;
+                return nullptr;
             }
 
             outName = names.Back();
@@ -2050,7 +2056,7 @@ Component* Node::SafeCreateComponent(const String& typeName, StringHash type, Cr
 {
     // Do not attempt to create replicated components to local nodes, as that may lead to component ID overwrite
     // as replicated components are synced over
-    if (id_ >= FIRST_LOCAL_ID && mode == REPLICATED)
+    if (mode == REPLICATED && !IsReplicated())
         mode = LOCAL;
 
     // First check if factory for type exists
@@ -2110,7 +2116,7 @@ void Node::RemoveChild(Vector<SharedPtr<Node> >::Iterator i)
         scene_->SendEvent(E_NODEREMOVED, eventData);
     }
 
-    child->parent_ = 0;
+    child->parent_ = nullptr;
     child->MarkDirty();
     child->MarkNetworkUpdate();
     if (scene_)
@@ -2168,7 +2174,7 @@ void Node::GetChildrenWithTagRecursive(PODVector<Node*>& dest, const String& tag
 Node* Node::CloneRecursive(Node* parent, SceneResolver& resolver, CreateMode mode)
 {
     // Create clone node
-    Node* cloneNode = parent->CreateChild(0, (mode == REPLICATED && id_ < FIRST_LOCAL_ID) ? REPLICATED : LOCAL);
+    Node* cloneNode = parent->CreateChild(0, (mode == REPLICATED && IsReplicated()) ? REPLICATED : LOCAL);
     resolver.AddNode(id_, cloneNode);
 
     // Copy attributes
@@ -2193,7 +2199,7 @@ Node* Node::CloneRecursive(Node* parent, SceneResolver& resolver, CreateMode mod
             continue;
 
         Component* cloneComponent = cloneNode->CloneComponent(component,
-            (mode == REPLICATED && component->GetID() < FIRST_LOCAL_ID) ? REPLICATED : LOCAL, 0);
+            (mode == REPLICATED && component->IsReplicated()) ? REPLICATED : LOCAL, 0);
         if (cloneComponent)
             resolver.AddComponent(component->GetID(), cloneComponent);
     }
@@ -2208,6 +2214,7 @@ Node* Node::CloneRecursive(Node* parent, SceneResolver& resolver, CreateMode mod
         node->CloneRecursive(cloneNode, resolver, mode);
     }
 
+    if (scene_)
     {
         using namespace NodeCloned;
 
@@ -2240,7 +2247,7 @@ void Node::RemoveComponent(Vector<SharedPtr<Component> >::Iterator i)
     RemoveListener(*i);
     if (scene_)
         scene_->ComponentRemoved(*i);
-    (*i)->SetNode(0);
+    (*i)->SetNode(nullptr);
     components_.Erase(i);
 }
 

--- a/Source/Urho3D/Scene/ReplicationState.h
+++ b/Source/Urho3D/Scene/ReplicationState.h
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2008-2017 the Urho3D project.
+// Copyright (c) 2008-2019 the Urho3D project.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -25,7 +25,6 @@
 #include "../Core/Attribute.h"
 #include "../Container/HashMap.h"
 #include "../Container/HashSet.h"
-#include "../Container/Vector.h"
 #include "../Container/Ptr.h"
 #include "../Math/StringHash.h"
 
@@ -50,11 +49,7 @@ struct SceneReplicationState;
 struct URHO3D_API DirtyBits
 {
     /// Construct empty.
-    DirtyBits() :
-        count_(0)
-    {
-        memset(data_, 0, MAX_NETWORK_ATTRIBUTES / 8);
-    }
+    DirtyBits() = default;
 
     /// Copy-construct.
     DirtyBits(const DirtyBits& bits) :
@@ -68,8 +63,8 @@ struct URHO3D_API DirtyBits
     {
         if (index < MAX_NETWORK_ATTRIBUTES)
         {
-            unsigned byteIndex = index >> 3;
-            unsigned bit = (unsigned)(1 << (index & 7));
+            unsigned byteIndex = index >> 3u;
+            auto bit = (unsigned)(1u << (index & 7u));
             if ((data_[byteIndex] & bit) == 0)
             {
                 data_[byteIndex] |= bit;
@@ -83,8 +78,8 @@ struct URHO3D_API DirtyBits
     {
         if (index < MAX_NETWORK_ATTRIBUTES)
         {
-            unsigned byteIndex = index >> 3;
-            unsigned bit = (unsigned)(1 << (index & 7));
+            unsigned byteIndex = index >> 3u;
+            auto bit = (unsigned)(1u << (index & 7u));
             if ((data_[byteIndex] & bit) != 0)
             {
                 data_[byteIndex] &= ~bit;
@@ -105,8 +100,8 @@ struct URHO3D_API DirtyBits
     {
         if (index < MAX_NETWORK_ATTRIBUTES)
         {
-            unsigned byteIndex = index >> 3;
-            unsigned bit = (unsigned)(1 << (index & 7));
+            unsigned byteIndex = index >> 3u;
+            auto bit = (unsigned)(1u << (index & 7u));
             return (data_[byteIndex] & bit) != 0;
         }
         else
@@ -117,22 +112,16 @@ struct URHO3D_API DirtyBits
     unsigned Count() const { return count_; }
 
     /// Bit data.
-    unsigned char data_[MAX_NETWORK_ATTRIBUTES / 8];
+    unsigned char data_[MAX_NETWORK_ATTRIBUTES / 8]{};
     /// Number of set bits.
-    unsigned char count_;
+    unsigned char count_{};
 };
 
 /// Per-object attribute state for network replication, allocated on demand.
 struct URHO3D_API NetworkState
 {
-    /// Construct with defaults.
-    NetworkState() :
-        interceptMask_(0)
-    {
-    }
-
     /// Cached network attribute infos.
-    const Vector<AttributeInfo>* attributes_;
+    const Vector<AttributeInfo>* attributes_{};
     /// Current network attribute values.
     Vector<Variant> currentValues_;
     /// Previous network attribute values.
@@ -142,7 +131,7 @@ struct URHO3D_API NetworkState
     /// Previous user variables.
     VariantMap previousVars_;
     /// Bitmask for intercepting network messages. Used on the client only.
-    unsigned long long interceptMask_;
+    unsigned long long interceptMask_{};
 };
 
 /// Base class for per-user network replication states.
@@ -156,7 +145,7 @@ struct URHO3D_API ReplicationState
 struct URHO3D_API ComponentReplicationState : public ReplicationState
 {
     /// Parent node replication state.
-    NodeReplicationState* nodeState_;
+    NodeReplicationState* nodeState_{};
     /// Link to the actual component.
     WeakPtr<Component> component_;
     /// Dirty attribute bits.
@@ -166,14 +155,6 @@ struct URHO3D_API ComponentReplicationState : public ReplicationState
 /// Per-user node network replication state.
 struct URHO3D_API NodeReplicationState : public ReplicationState
 {
-    /// Construct.
-    NodeReplicationState() :
-        ReplicationState(),
-        priorityAcc_(0.0f),
-        markedDirty_(false)
-    {
-    }
-
     /// Parent scene replication state.
     SceneReplicationState* sceneState_;
     /// Link to the actual node.
@@ -185,9 +166,9 @@ struct URHO3D_API NodeReplicationState : public ReplicationState
     /// Components by ID.
     HashMap<unsigned, ComponentReplicationState> componentStates_;
     /// Interest management priority accumulator.
-    float priorityAcc_;
+    float priorityAcc_{};
     /// Whether exists in the SceneState's dirty set.
-    bool markedDirty_;
+    bool markedDirty_{};
 };
 
 /// Per-user scene network replication state.

--- a/Source/Urho3D/Scene/Scene.cpp
+++ b/Source/Urho3D/Scene/Scene.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2008-2017 the Urho3D project.
+// Copyright (c) 2008-2019 the Urho3D project.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -111,7 +111,7 @@ void Scene::RegisterObject(Context* context)
     URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Variable Names", GetVarNamesAttr, SetVarNamesAttr, String, String::EMPTY, AM_FILE | AM_NOEDIT);
 }
 
-bool Scene::Load(Deserializer& source, bool setInstanceDefault)
+bool Scene::Load(Deserializer& source)
 {
     URHO3D_PROFILE(LoadScene);
 
@@ -129,7 +129,7 @@ bool Scene::Load(Deserializer& source, bool setInstanceDefault)
     Clear();
 
     // Load the whole scene, then perform post-load if successfully loaded
-    if (Node::Load(source, setInstanceDefault))
+    if (Node::Load(source))
     {
         FinishLoading(&source);
         return true;
@@ -149,7 +149,7 @@ bool Scene::Save(Serializer& dest) const
         return false;
     }
 
-    Deserializer* ptr = dynamic_cast<Deserializer*>(&dest);
+    auto* ptr = dynamic_cast<Deserializer*>(&dest);
     if (ptr)
         URHO3D_LOGINFO("Saving scene to " + ptr->GetName());
 
@@ -162,7 +162,7 @@ bool Scene::Save(Serializer& dest) const
         return false;
 }
 
-bool Scene::LoadXML(const XMLElement& source, bool setInstanceDefault)
+bool Scene::LoadXML(const XMLElement& source)
 {
     URHO3D_PROFILE(LoadSceneXML);
 
@@ -170,16 +170,16 @@ bool Scene::LoadXML(const XMLElement& source, bool setInstanceDefault)
 
     // Load the whole scene, then perform post-load if successfully loaded
     // Note: the scene filename and checksum can not be set, as we only used an XML element
-    if (Node::LoadXML(source, setInstanceDefault))
+    if (Node::LoadXML(source))
     {
-        FinishLoading(0);
+        FinishLoading(nullptr);
         return true;
     }
     else
         return false;
 }
 
-bool Scene::LoadJSON(const JSONValue& source, bool setInstanceDefault)
+bool Scene::LoadJSON(const JSONValue& source)
 {
     URHO3D_PROFILE(LoadSceneJSON);
 
@@ -187,9 +187,9 @@ bool Scene::LoadJSON(const JSONValue& source, bool setInstanceDefault)
 
     // Load the whole scene, then perform post-load if successfully loaded
     // Note: the scene filename and checksum can not be set, as we only used an XML element
-    if (Node::LoadJSON(source, setInstanceDefault))
+    if (Node::LoadJSON(source))
     {
-        FinishLoading(0);
+        FinishLoading(nullptr);
         return true;
     }
     else
@@ -269,7 +269,7 @@ bool Scene::SaveXML(Serializer& dest, const String& indentation) const
     if (!SaveXML(rootElem))
         return false;
 
-    Deserializer* ptr = dynamic_cast<Deserializer*>(&dest);
+    auto* ptr = dynamic_cast<Deserializer*>(&dest);
     if (ptr)
         URHO3D_LOGINFO("Saving scene to " + ptr->GetName());
 
@@ -291,7 +291,7 @@ bool Scene::SaveJSON(Serializer& dest, const String& indentation) const
     if (!SaveJSON(rootVal))
         return false;
 
-    Deserializer* ptr = dynamic_cast<Deserializer*>(&dest);
+    auto* ptr = dynamic_cast<Deserializer*>(&dest);
     if (ptr)
         URHO3D_LOGINFO("Saving scene to " + ptr->GetName());
 
@@ -544,7 +544,7 @@ Node* Scene::Instantiate(Deserializer& source, const Vector3& position, const Qu
     else
     {
         node->Remove();
-        return 0;
+        return nullptr;
     }
 }
 
@@ -567,7 +567,7 @@ Node* Scene::InstantiateXML(const XMLElement& source, const Vector3& position, c
     else
     {
         node->Remove();
-        return 0;
+        return nullptr;
     }
 }
 
@@ -590,7 +590,7 @@ Node* Scene::InstantiateJSON(const JSONValue& source, const Vector3& position, c
     else
     {
         node->Remove();
-        return 0;
+        return nullptr;
     }
 }
 
@@ -598,7 +598,7 @@ Node* Scene::InstantiateXML(Deserializer& source, const Vector3& position, const
 {
     SharedPtr<XMLFile> xml(new XMLFile(context_));
     if (!xml->Load(source))
-        return 0;
+        return nullptr;
 
     return InstantiateXML(xml->GetRoot(), position, rotation, mode);
 }
@@ -607,7 +607,7 @@ Node* Scene::InstantiateJSON(Deserializer& source, const Vector3& position, cons
 {
     SharedPtr<JSONFile> json(new JSONFile(context_));
     if (!json->Load(source))
-        return 0;
+        return nullptr;
 
     return InstantiateJSON(json->GetRoot(), position, rotation, mode);
 }
@@ -705,15 +705,15 @@ void Scene::UnregisterAllVars()
 
 Node* Scene::GetNode(unsigned id) const
 {
-    if (id < FIRST_LOCAL_ID)
+    if (IsReplicatedID(id))
     {
         HashMap<unsigned, Node*>::ConstIterator i = replicatedNodes_.Find(id);
-        return i != replicatedNodes_.End() ? i->second_ : 0;
+        return i != replicatedNodes_.End() ? i->second_ : nullptr;
     }
     else
     {
         HashMap<unsigned, Node*>::ConstIterator i = localNodes_.Find(id);
-        return i != localNodes_.End() ? i->second_ : 0;
+        return i != localNodes_.End() ? i->second_ : nullptr;
     }
 }
 
@@ -732,15 +732,15 @@ bool Scene::GetNodesWithTag(PODVector<Node*>& dest, const String& tag) const
 
 Component* Scene::GetComponent(unsigned id) const
 {
-    if (id < FIRST_LOCAL_ID)
+    if (IsReplicatedID(id))
     {
         HashMap<unsigned, Component*>::ConstIterator i = replicatedComponents_.Find(id);
-        return i != replicatedComponents_.End() ? i->second_ : 0;
+        return i != replicatedComponents_.End() ? i->second_ : nullptr;
     }
     else
     {
         HashMap<unsigned, Component*>::ConstIterator i = localComponents_.Find(id);
-        return i != localComponents_.End() ? i->second_ : 0;
+        return i != localComponents_.End() ? i->second_ : nullptr;
     }
 }
 
@@ -924,7 +924,7 @@ void Scene::NodeAdded(Node* node)
     }
 
     // If node with same ID exists, remove the scene reference from it and overwrite with the new node
-    if (id < FIRST_LOCAL_ID)
+    if (IsReplicatedID(id))
     {
         HashMap<unsigned, Node*>::Iterator i = replicatedNodes_.Find(id);
         if (i != replicatedNodes_.End() && i->second_ != node)
@@ -982,7 +982,7 @@ void Scene::NodeRemoved(Node* node)
         return;
 
     unsigned id = node->GetID();
-    if (id < FIRST_LOCAL_ID)
+    if (Scene::IsReplicatedID(id))
     {
         replicatedNodes_.Erase(id);
         MarkReplicationDirty(node);
@@ -1023,7 +1023,7 @@ void Scene::ComponentAdded(Component* component)
         component->SetID(id);
     }
 
-    if (id < FIRST_LOCAL_ID)
+    if (IsReplicatedID(id))
     {
         HashMap<unsigned, Component*>::Iterator i = replicatedComponents_.Find(id);
         if (i != replicatedComponents_.End() && i->second_ != component)
@@ -1055,13 +1055,13 @@ void Scene::ComponentRemoved(Component* component)
         return;
 
     unsigned id = component->GetID();
-    if (id < FIRST_LOCAL_ID)
+    if (Scene::IsReplicatedID(id))
         replicatedComponents_.Erase(id);
     else
         localComponents_.Erase(id);
 
     component->SetID(0);
-    component->OnSceneSet(0);
+    component->OnSceneSet(nullptr);
 }
 
 void Scene::SetVarNamesAttr(const String& value)
@@ -1149,14 +1149,13 @@ void Scene::MarkNetworkUpdate(Component* component)
 
 void Scene::MarkReplicationDirty(Node* node)
 {
-    unsigned id = node->GetID();
-
-    if (id < FIRST_LOCAL_ID && networkState_)
+    if (networkState_ && node->IsReplicated())
     {
+        unsigned id = node->GetID();
         for (PODVector<ReplicationState*>::Iterator i = networkState_->replicationStates_.Begin();
              i != networkState_->replicationStates_.End(); ++i)
         {
-            NodeReplicationState* nodeState = static_cast<NodeReplicationState*>(*i);
+            auto* nodeState = static_cast<NodeReplicationState*>(*i);
             nodeState->sceneState_->dirtyNodes_.Push(id);
         }
     }
@@ -1177,7 +1176,7 @@ void Scene::HandleResourceBackgroundLoaded(StringHash eventType, VariantMap& eve
 
     if (asyncLoading_)
     {
-        Resource* resource = static_cast<Resource*>(eventData[P_RESOURCE].GetPtr());
+        auto* resource = static_cast<Resource*>(eventData[P_RESOURCE].GetPtr());
         if (asyncProgress_.resources_.Contains(resource->GetNameHash()))
         {
             asyncProgress_.resources_.Erase(resource->GetNameHash());
@@ -1210,7 +1209,7 @@ void Scene::UpdateAsyncLoading()
         if (asyncProgress_.xmlFile_)
         {
             unsigned nodeID = asyncProgress_.xmlElement_.GetUInt("id");
-            Node* newNode = CreateChild(nodeID, nodeID < FIRST_LOCAL_ID ? REPLICATED : LOCAL);
+            Node* newNode = CreateChild(nodeID, IsReplicatedID(nodeID) ? REPLICATED : LOCAL);
             resolver_.AddNode(nodeID, newNode);
             newNode->LoadXML(asyncProgress_.xmlElement_, resolver_);
             asyncProgress_.xmlElement_ = asyncProgress_.xmlElement_.GetNext("node");
@@ -1220,7 +1219,7 @@ void Scene::UpdateAsyncLoading()
             const JSONValue& childValue = asyncProgress_.jsonFile_->GetRoot().Get("children").GetArray().At(asyncProgress_.jsonIndex_);
 
             unsigned nodeID =childValue.Get("id").GetUInt();
-            Node* newNode = CreateChild(nodeID, nodeID < FIRST_LOCAL_ID ? REPLICATED : LOCAL);
+            Node* newNode = CreateChild(nodeID, IsReplicatedID(nodeID) ? REPLICATED : LOCAL);
             resolver_.AddNode(nodeID, newNode);
             newNode->LoadJSON(childValue, resolver_);
             ++asyncProgress_.jsonIndex_;
@@ -1228,7 +1227,7 @@ void Scene::UpdateAsyncLoading()
         else // Load from binary
         {
             unsigned nodeID = asyncProgress_.file_->ReadUInt();
-            Node* newNode = CreateChild(nodeID, nodeID < FIRST_LOCAL_ID ? REPLICATED : LOCAL);
+            Node* newNode = CreateChild(nodeID, IsReplicatedID(nodeID) ? REPLICATED : LOCAL);
             resolver_.AddNode(nodeID, newNode);
             newNode->Load(*asyncProgress_.file_, resolver_);
         }
@@ -1236,7 +1235,7 @@ void Scene::UpdateAsyncLoading()
         ++asyncProgress_.loadedNodes_;
 
         // Break if time limit exceeded, so that we keep sufficient FPS
-        if (asyncLoadTimer.GetUSec(false) >= asyncLoadingMs_ * 1000)
+        if (asyncLoadTimer.GetUSec(false) >= asyncLoadingMs_ * 1000LL)
             break;
     }
 
@@ -1281,7 +1280,7 @@ void Scene::FinishLoading(Deserializer* source)
 
 void Scene::FinishSaving(Serializer* dest) const
 {
-    Deserializer* ptr = dynamic_cast<Deserializer*>(dest);
+    auto* ptr = dynamic_cast<Deserializer*>(dest);
     if (ptr)
     {
         fileName_ = ptr->GetName();
@@ -1293,7 +1292,7 @@ void Scene::PreloadResources(File* file, bool isSceneFile)
 {
     // If not threaded, can not background load resources, so rather load synchronously later when needed
 #ifdef URHO3D_THREADING
-    ResourceCache* cache = GetSubsystem<ResourceCache>();
+    auto* cache = GetSubsystem<ResourceCache>();
 
     // Read node ID (not needed)
     /*unsigned nodeID = */file->ReadUInt();
@@ -1369,7 +1368,7 @@ void Scene::PreloadResourcesXML(const XMLElement& element)
 {
     // If not threaded, can not background load resources, so rather load synchronously later when needed
 #ifdef URHO3D_THREADING
-    ResourceCache* cache = GetSubsystem<ResourceCache>();
+    auto* cache = GetSubsystem<ResourceCache>();
 
     // Node or Scene attributes do not include any resources; therefore skip to the components
     XMLElement compElem = element.GetChild("component");
@@ -1449,7 +1448,7 @@ void Scene::PreloadResourcesJSON(const JSONValue& value)
 {
     // If not threaded, can not background load resources, so rather load synchronously later when needed
 #ifdef URHO3D_THREADING
-    ResourceCache* cache = GetSubsystem<ResourceCache>();
+    auto* cache = GetSubsystem<ResourceCache>();
 
     // Node or Scene attributes do not include any resources; therefore skip to the components
     JSONArray componentArray = value.Get("components").GetArray();


### PR DESCRIPTION
Connection class was gathering dirty node IDs in an unordered container (HashMap), which causes network Clients to process newly-replicated nodes in an arbitrary order.
Resolved by replacing the HashMap with a Vector (an ordered container).

Please disregard the initial commit as my project files were not up to date.
