### PR TITLE
Fixed resource reloading failure caused by load resource as `XMLFile`…

### DIFF
--- a/bin/Data/Scripts/Editor/EditorResourceBrowser.as
+++ b/bin/Data/Scripts/Editor/EditorResourceBrowser.as
@@ -1334,29 +1334,30 @@ bool GetXmlType(String path, StringHash &out fileType, bool useCache = false)
         return false;
 
     String name;
+    File@ file;
+    XMLFile@ xml;
+
     if (useCache)
     {
-        XMLFile@ xml = cache.GetResource("XMLFile", path);
-        if (xml is null)
+        file = cache.GetFile(path);
+        if (file is null)
             return false;
-
-        name = xml.root.name;
     }
     else
     {
-        File@ file = File();
+        file = File();
         if (!file.Open(path))
             return false;
-
-        if (file.size == 0)
-            return false;
-
-        XMLFile@ xml = XMLFile();
-        if (xml.Load(file))
-            name = xml.root.name;
-        else
-            return false;
     }
+
+    if (file.size == 0)
+        return false;
+
+    xml = XMLFile();
+    if (xml.Load(file))
+        name = xml.root.name;
+    else
+        return false;
 
     bool found = false;
     if (!name.empty)


### PR DESCRIPTION
`ResourceCache::GetResource` will keep the resource type the first time it is called.

If we once called 
```angelscript
XMLFile@ xml = cache.GetResource("XMLFile", path);
``` 
or 
```c++
XMLFile* xml = cache->GetResource<XMLFile>(path);
```

even though the xml file is a `Material` e.g., the type will always be `XMLFile`. This causes resource reloading failed since only `XMLFile`'s `BeginLoad` or `EndLoad` will be called, instead of `Material`'s.

However, currently, in the editor, this code path is not called (`useCache` is a false), it is still a bug. And this `ResourceCache` characteristic should be taken seriously. 