### PR TITLE
Fix SLikeNet crash on android device.

### DIFF
--- a/Source/ThirdParty/SLikeNet/Source/src/linux_adapter.cpp
+++ b/Source/ThirdParty/SLikeNet/Source/src/linux_adapter.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  *  Copyright (c) 2016-2017, SLikeSoft UG (haftungsbeschränkt)
  *
  *  This source code is licensed under the MIT-style license found in the
@@ -989,7 +989,12 @@ static void interpretAddr(struct nlmsghdr *p_hdr, struct ifaddrs **p_links, stru
 		{
 			l_mask[i] = 0xff;
 		}
-		l_mask[i] = 0xff << (8 - (l_prefix % 8));
+
+		// Avoid stack check fail on android device, reference https://github.com/libuv/libuv/blob/e4087dedf837f415056a45a838f639a3d9dc3ced/src/unix/android-ifaddrs.c
+		if (l_prefix % 8)
+		{
+			l_mask[i] = 0xff << (8 - (l_prefix % 8));
+		}
 
 		makeSockaddr(l_entry->ifa_addr->sa_family, (struct sockaddr *)l_addr, l_mask, l_maxPrefix / 8);
 		l_entry->ifa_netmask = (struct sockaddr *)l_addr;


### PR DESCRIPTION
On Android device, the SLikeNet library crashes with a **__stack_chk_fail.** 
Because when the variable **l_prefix** is 128, the variable **i** is 16. The code line try to write l_mask[16] made the crash.

I fixed this bug with reference to libuv.

[https://github.com/libuv/libuv/blob/e4087dedf837f415056a45a838f639a3d9dc3ced/src/unix/android-ifaddrs.c](url)