### PR TITLE
Add result support to angelscript function call

### DIFF
--- a/Source/Urho3D/AngelScript/ScriptFile.cpp
+++ b/Source/Urho3D/AngelScript/ScriptFile.cpp
@@ -292,6 +292,13 @@ bool ScriptFile::HasEventHandler(Object* sender, StringHash eventType) const
 
 bool ScriptFile::Execute(const String& declaration, const VariantVector& parameters, bool unprepare)
 {
+    Variant result;
+    VariantType resultType = VariantType::VAR_NONE;
+    return Execute(declaration, parameters, resultType, result, unprepare);
+}
+
+bool ScriptFile::Execute(const String& declaration, const VariantVector& parameters, VariantType resultType, Variant&result, bool unprepare)
+{
     asIScriptFunction* function = GetFunction(declaration);
     if (!function)
     {
@@ -299,10 +306,17 @@ bool ScriptFile::Execute(const String& declaration, const VariantVector& paramet
         return false;
     }
 
-    return Execute(function, parameters, unprepare);
+    return Execute(function, parameters, resultType, result, unprepare);
 }
 
 bool ScriptFile::Execute(asIScriptFunction* function, const VariantVector& parameters, bool unprepare)
+{
+    Variant result;
+    VariantType resultType = VariantType::VAR_NONE;
+    return Execute(function, parameters, resultType, result, unprepare);
+}
+
+bool ScriptFile::Execute(asIScriptFunction* function, const VariantVector& parameters, VariantType resultType, Variant & result, bool unprepare)
 {
     URHO3D_PROFILE(ExecuteFunction);
 
@@ -321,6 +335,78 @@ bool ScriptFile::Execute(asIScriptFunction* function, const VariantVector& param
 
     scriptSystem->IncScriptNestingLevel();
     bool success = context->Execute() >= 0;
+    if(success)
+    {
+        switch(resultType)
+        {
+        case VariantType::VAR_NONE:
+            break;
+
+        case VariantType::VAR_INT:
+            result = Variant(static_cast<int>(context->GetReturnDWord())); 
+            break;
+
+        case VariantType::VAR_INT64:
+            result = Variant(static_cast<long long>(context->GetReturnQWord())); 
+            break;
+
+        case VariantType::VAR_BOOL:
+            result = Variant(context->GetReturnByte()>0); 
+            break;
+
+        case VariantType::VAR_FLOAT:
+            result = Variant(context->GetReturnFloat()); 
+            break;
+
+        case VariantType::VAR_DOUBLE:
+            result = Variant(context->GetReturnDouble()); 
+            break;
+
+        case VariantType::VAR_RECT:
+            result = Variant(*(static_cast<Rect*>(context->GetReturnObject()))); 
+            break;
+
+        case VariantType::VAR_VECTOR2:
+            result = Variant(*(static_cast<Vector2*>(context->GetReturnObject()))); 
+            break;
+
+        case VariantType::VAR_VECTOR3:
+            result = Variant(*(static_cast<Vector3*>( context->GetReturnObject()))); 
+            break;
+
+        case VariantType::VAR_VECTOR4:     
+            result = Variant(*(static_cast<Vector4*>( context->GetReturnObject()))); 
+            break;
+
+        case VariantType::VAR_QUATERNION:  
+            result = Variant(*(static_cast<Quaternion*>( context->GetReturnObject()))); 
+            break;
+
+        case VariantType::VAR_INTRECT:     
+            result = Variant(*(static_cast<IntRect*>( context->GetReturnObject()))); 
+            break;
+
+        case VariantType::VAR_INTVECTOR2:  
+            result = Variant(*(static_cast<IntVector2*>( context->GetReturnObject()))); 
+            break;
+
+        case VariantType::VAR_INTVECTOR3:  
+            result = Variant(*(static_cast<IntVector3*>(context->GetReturnObject()))); 
+            break;
+
+        case VariantType::VAR_STRING:      
+            result = Variant(*(static_cast<String*>(context->GetReturnObject()))); 
+            break;
+
+        case VariantType::VAR_PTR:
+            result = Variant(static_cast<RefCounted*>(context->GetReturnObject()));
+            break;
+
+        default:
+            URHO3D_LOGERRORF("Result type is not supported");
+            break;
+        }
+    }
     if (unprepare)
         context->Unprepare();
     scriptSystem->DecScriptNestingLevel();
@@ -344,6 +430,13 @@ bool ScriptFile::Execute(asIScriptObject* object, const String& declaration, con
 }
 
 bool ScriptFile::Execute(asIScriptObject* object, asIScriptFunction* method, const VariantVector& parameters, bool unprepare)
+{
+    Variant result;
+    VariantType resultType = VariantType::VAR_NONE;
+    return Execute(object, method, parameters, resultType, result, unprepare);
+}
+
+bool ScriptFile::Execute(asIScriptObject* object, asIScriptFunction* method, const VariantVector& parameters, VariantType resultType, Variant&result, bool unprepare)
 {
     URHO3D_PROFILE(ExecuteMethod);
 

--- a/Source/Urho3D/AngelScript/ScriptFile.h
+++ b/Source/Urho3D/AngelScript/ScriptFile.h
@@ -81,14 +81,24 @@ public:
 
     /// Query for a function by declaration and execute if found.
     bool Execute(const String& declaration, const VariantVector& parameters = Variant::emptyVariantVector, bool unprepare = true);
+    /// Query for a function by declaration and execute and return result if found.
+    bool Execute(const String& declaration, const VariantVector& parameters, VariantType resultType, Variant&result, 
+        bool unprepare = true);
     /// Execute a function.
     bool Execute(asIScriptFunction* function, const VariantVector& parameters = Variant::emptyVariantVector, bool unprepare = true);
+    /// Execute a function and return result.
+    bool Execute(asIScriptFunction* function, const VariantVector& parameters, VariantType resultType, Variant & result, 
+        bool unprepare = true);
     /// Query for an object method by declaration and execute if found.
     bool Execute(asIScriptObject* object, const String& declaration, const VariantVector& parameters = Variant::emptyVariantVector,
         bool unprepare = true);
     /// Execute an object method.
     bool Execute(asIScriptObject* object, asIScriptFunction* method, const VariantVector& parameters = Variant::emptyVariantVector,
         bool unprepare = true);
+    /// Execute an object method and return result.
+    bool Execute(asIScriptObject* object, asIScriptFunction* method, const VariantVector& parameters, VariantType resultType, 
+        Variant&result, bool unprepare = true);
+
     /// Add a delay-executed function call, optionally repeating.
     void DelayedExecute
         (float delay, bool repeat, const String& declaration, const VariantVector& parameters = Variant::emptyVariantVector);

--- a/Source/Urho3D/AngelScript/ScriptFile.h
+++ b/Source/Urho3D/AngelScript/ScriptFile.h
@@ -80,24 +80,13 @@ public:
     bool HasEventHandler(Object* sender, StringHash eventType) const override;
 
     /// Query for a function by declaration and execute if found.
-    bool Execute(const String& declaration, const VariantVector& parameters = Variant::emptyVariantVector, bool unprepare = true);
-    /// Query for a function by declaration and execute and return result if found.
-    bool Execute(const String& declaration, const VariantVector& parameters, VariantType resultType, Variant&result, 
-        bool unprepare = true);
+    bool Execute(const String& declaration, const VariantVector& parameters = Variant::emptyVariantVector, Variant* functionReturn=nullptr, bool unprepare = true);
     /// Execute a function.
-    bool Execute(asIScriptFunction* function, const VariantVector& parameters = Variant::emptyVariantVector, bool unprepare = true);
-    /// Execute a function and return result.
-    bool Execute(asIScriptFunction* function, const VariantVector& parameters, VariantType resultType, Variant & result, 
-        bool unprepare = true);
+    bool Execute(asIScriptFunction* function, const VariantVector& parameters = Variant::emptyVariantVector, Variant* functionReturn=nullptr, bool unprepare = true);
     /// Query for an object method by declaration and execute if found.
-    bool Execute(asIScriptObject* object, const String& declaration, const VariantVector& parameters = Variant::emptyVariantVector,
-        bool unprepare = true);
+    bool Execute(asIScriptObject* object, const String& declaration, const VariantVector& parameters = Variant::emptyVariantVector, Variant* functionReturn=nullptr, bool unprepare = true);
     /// Execute an object method.
-    bool Execute(asIScriptObject* object, asIScriptFunction* method, const VariantVector& parameters = Variant::emptyVariantVector,
-        bool unprepare = true);
-    /// Execute an object method and return result.
-    bool Execute(asIScriptObject* object, asIScriptFunction* method, const VariantVector& parameters, VariantType resultType, 
-        Variant&result, bool unprepare = true);
+    bool Execute(asIScriptObject* object, asIScriptFunction* method, const VariantVector& parameters = Variant::emptyVariantVector, Variant* functionReturn=nullptr, bool unprepare = true);
 
     /// Add a delay-executed function call, optionally repeating.
     void DelayedExecute


### PR DESCRIPTION
Hi Urho team

It's very usefull to call an angelscript function and get the return of the function

Per exemple in my game, I call this AS function to get player node

```
URHO::Variant Result;
ScriptFile->Execute("Node @ CreatePlayer(Scene @ scene)", Parameters, URHO::VariantType::VAR_PTR, Result);
URHO::Node * Node = (URHO::Node*) Result.GetPtr();
```

So I propose to add 3 new functions to scriptfile with 2 new parameters

**VariantType resultType**: to specify the type of result expected
**Variant & result**: contains the result of function
