### PR TITLE
Fixed a bug where using CScriptDictionary can lead to crash on arm64.

### DIFF
--- a/Source/ThirdParty/AngelScript/include/wrapmacros.h
+++ b/Source/ThirdParty/AngelScript/include/wrapmacros.h
@@ -75,7 +75,7 @@
 #define RegisterObjectMethodFasCALL_CDECL_OBJFIRST(clsdcl,decl,fun) RegisterObjectMethod(clsdcl,decl, WRAP_OBJ_FIRST(fun), asCALL_GENERIC); //assert(r >= 0);
 //#define RegisterObjectMethodMasCALL_CDECL_OBJECTFIRST(decl,cls,fun) RegisterObjectMethodMasCALL_THISCALL_ASGLOBAL_2(decl,UNWRAP fun)
 //#define RegisterObjectMethodMasCALL_THISCALL_ASGLOBAL_2(decl, ...) RegisterObjectMethod(decl, WRAP_MFN(__VA_ARGS__), asCALL_GENERIC); //assert(r >= 0);
-#define RegisterObjectMethodFasCALL_GENERIC(clsdcl,decl,fun) RegisterObjectMethod(clsdcl,decl, asMethodPtr(fun), asCALL_GENERIC); //assert(r >= 0);
+#define RegisterObjectMethodFasCALL_GENERIC(clsdcl,decl,fun) RegisterObjectMethod(clsdcl,decl, asFunctionPtr(fun), asCALL_GENERIC); //assert(r >= 0);
 
 ////note:unfortunately, the WrapCon methods are for creating the constructor wrapper, which typically seems to be done anyways, so we should just handle it like Register Object Method with 1 extra parameter
 //#define RegisterObjectBehaviour(...) RegObjectBehaviorIndirect(__VA__ARGS__)

--- a/Source/Urho3D/AngelScript/Addons.cpp
+++ b/Source/Urho3D/AngelScript/Addons.cpp
@@ -2043,7 +2043,25 @@ void ScriptDictionaryListFactory_Generic(asIScriptGeneric *gen)
     *(CScriptDictionary**)gen->GetAddressOfReturnLocation() = CScriptDictionary::Create(buffer);
 }
 
-CScriptDictValue::CScriptDictValue()    // NOLINT(hicpp-member-init)
+void ScriptDictionarySet_Generic(asIScriptGeneric *gen)
+{
+    CScriptDictionary* dict = (CScriptDictionary*)gen->GetObject();
+    String* key = *(String**)gen->GetAddressOfArg(0);
+    void* ref = *(void**)gen->GetAddressOfArg(1);
+    int type_id = gen->GetArgTypeId(1);
+    dict->Set(*key, ref, type_id);
+}
+
+void ScriptDictionaryGet_Generic(asIScriptGeneric *gen)
+{
+    CScriptDictionary* dict = (CScriptDictionary*)gen->GetObject();
+    String* key = *(String**)gen->GetAddressOfArg(0);
+    void* ref = *(void**)gen->GetAddressOfArg(1);
+    int type_id = gen->GetArgTypeId(1);
+    *(bool*)gen->GetAddressOfReturnLocation() = dict->Get(*key, ref, type_id);
+}
+
+CScriptDictValue::CScriptDictValue()
 {
     m_valueObj = nullptr;
     m_typeId   = 0;
@@ -2273,8 +2291,8 @@ void RegisterDictionary(asIScriptEngine *engine)
     engine->RegisterObjectBehaviour("Dictionary", asBEHAVE_ADDREF, "void f()", asMETHOD(CScriptDictionary,AddRef), asCALL_THISCALL);
     engine->RegisterObjectBehaviour("Dictionary", asBEHAVE_RELEASE, "void f()", asMETHOD(CScriptDictionary,Release), asCALL_THISCALL);
     engine->RegisterObjectMethod("Dictionary", "Dictionary &opAssign(const Dictionary &in)", asMETHODPR(CScriptDictionary, operator=, (const CScriptDictionary &), CScriptDictionary&), asCALL_THISCALL);
-    engine->RegisterObjectMethod("Dictionary", "void Set(const String &in, const ?&in)", asMETHODPR(CScriptDictionary,Set,(const String&,void*,int),void), asCALL_THISCALL);
-    engine->RegisterObjectMethod("Dictionary", "bool Get(const String &in, ?&out) const", asMETHODPR(CScriptDictionary,Get,(const String&,void*,int) const,bool), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Dictionary", "void Set(const String &in, const ?&in)", asFUNCTION(ScriptDictionarySet_Generic), asCALL_GENERIC);
+    engine->RegisterObjectMethod("Dictionary", "bool Get(const String &in, ?&out) const", asFUNCTION(ScriptDictionaryGet_Generic), asCALL_GENERIC);
     engine->RegisterObjectMethod("Dictionary", "void Set(const String &in, const int64&in)", asMETHODPR(CScriptDictionary,Set,(const String&,const asINT64&),void), asCALL_THISCALL);
     engine->RegisterObjectMethod("Dictionary", "bool Get(const String &in, int64&out) const", asMETHODPR(CScriptDictionary,Get,(const String&,asINT64&) const,bool), asCALL_THISCALL);
     engine->RegisterObjectMethod("Dictionary", "void Set(const String &in, const double&in)", asMETHODPR(CScriptDictionary,Set,(const String&,const double&),void), asCALL_THISCALL);


### PR DESCRIPTION
The script Dictionary will lead to nullptr access on arm64. The macro wrappers don't support asGeneric when using  a ? type(like the ?&out parameter in "void Set(const String &in, const ?&in)").