### PR TITLE
If disable Log module, URHO3D_LOGTRACEF(message) will cause parameters mismatch

### DIFF
--- a/Source/Urho3D/IO/Log.h
+++ b/Source/Urho3D/IO/Log.h
@@ -150,7 +150,7 @@ private:
 #define URHO3D_LOGWARNING(message) ((void)0)
 #define URHO3D_LOGERROR(message) ((void)0)
 #define URHO3D_LOGRAW(message) ((void)0)
-#define URHO3D_LOGTRACEF(message) ((void)0)
+#define URHO3D_LOGTRACEF(...) ((void)0)
 #define URHO3D_LOGDEBUGF(...) ((void)0)
 #define URHO3D_LOGINFOF(...) ((void)0)
 #define URHO3D_LOGWARNINGF(...) ((void)0)


### PR DESCRIPTION
Fixed URHO3D_LOGTRACEF(message) parameters mismatch when disable log module.