### PR TITLE
Return 0, not NULL, in function returning an int

### DIFF
--- a/Source/ThirdParty/StanHull/hull.cpp
+++ b/Source/ThirdParty/StanHull/hull.cpp
@@ -34,7 +34,7 @@
 		THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -----------------------------------------------------------------------*/
 
-// Modified by Lasse Oorni for Urho3D
+// Modified by Lasse Oorni and Romain Tartière for Urho3D
 
 // Urho3D: use a namespace to not clash with Urho3D's inbuilt math types
 namespace StanHull
@@ -2587,7 +2587,8 @@ int overhull(Plane *planes,int planes_count,float3 *verts, int verts_count,int m
 			 float3 *&verts_out, int &verts_count_out,  int *&faces_out, int &faces_count_out ,float inflate)
 {
 	int i,j;
-	if(verts_count <4) return NULL;
+	// Urho3D: Return 0, not NULL, in function returning an int
+	if(verts_count <4) return 0;
 	maxplanes = Min(maxplanes,planes_count);
 	float3 bmin(verts[0]),bmax(verts[0]);
 	for(i=0;i<verts_count;i++) 


### PR DESCRIPTION
Compilation fails on FreeBSD 12.0 with the default compiler clang version 6.0.1:
```
[ 12%] Building CXX object Source/ThirdParty/StanHull/CMakeFiles/StanHull.dir/hull.cpp.o
/home/romain/Projects/Urho3D/Source/ThirdParty/StanHull/hull.cpp:2590:28: error: cannot initialize return object of type 'int' with an rvalue of type 'nullptr_t'
        if(verts_count <4) return NULL;
                                  ^~~~
/usr/include/sys/_null.h:37:14: note: expanded from macro 'NULL'
#define NULL    nullptr
                ^~~~~~~
1 error generated.
```

The function `overhull()` is supposed to return an `int`, but `NULL` is defined as a nullptr, which the compiler does not allow you to store as an int.

The fix consist in replacing `NULL` with the raw value `0`.