### PR TITLE
Make the 4 arguments vsnprintf_s() visible to FreeBSD

### DIFF
--- a/Source/ThirdParty/SLikeNet/Source/include/slikenet/linux_adapter.h
+++ b/Source/ThirdParty/SLikeNet/Source/include/slikenet/linux_adapter.h
@@ -42,7 +42,7 @@ typedef int errno_t;
 int vsnprintf_s(char *buffer, size_t sizeOfBuffer, size_t count, const char *format, va_list argptr);
 #endif
 
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
 template<size_t BufferSize> int vsnprintf_s(char (&buffer)[BufferSize], size_t count, const char *format, va_list argptr)
 {
     return vsnprintf_s(buffer, BufferSize, count, format, argptr);


### PR DESCRIPTION
Compilation fails on FreeBSD 12.0 with the default compiler clang version 6.0.1:
```
[ 19%] Building CXX object Source/ThirdParty/SLikeNet/CMakeFiles/SLikeNet.dir/Source/src/RakString.cpp.o
/home/romain/Projects/Urho3D/Source/ThirdParty/SLikeNet/Source/src/RakString.cpp:1392:17: error: no matching function for call to 'vsnprintf_s'
        int numChars = vsnprintf_s(stackBuff, 511, str, ap);
                       ^~~~~~~~~~~
/home/romain/Projects/Urho3D/Source/ThirdParty/SLikeNet/Source/include/slikenet/linux_adapter.h:42:5: note: candidate function not viable: requires 5 arguments, but 4 were provided
int vsnprintf_s(char *buffer, size_t sizeOfBuffer, size_t count, const char *format, va_list argptr);
```

A template is conditionally defined but the condition did not include FreeBSD.