### PR TITLE
Fix conflicting types for int64_t and uint64_t on FreeBSD

### DIFF
--- a/Source/Urho3D/CMakeLists.txt
+++ b/Source/Urho3D/CMakeLists.txt
@@ -31,6 +31,11 @@ if (MINGW AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9.1 AND NOT URHO3D_64BIT
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mpreferred-stack-boundary=2")
 endif ()
 
+check_include_files (stdint.h HAVE_STDINT_H)
+if (HAVE_STDINT_H)
+  add_definitions (-DHAVE_STDINT_H)
+endif ()
+
 # Generate JSON compilation database format specification
 if (URHO3D_CLANG_TOOLS OR URHO3D_BINDINGS)
     set (CMAKE_EXPORT_COMPILE_COMMANDS 1)


### PR DESCRIPTION
Compilation fails on FreeBSD 12.0 with the default compiler clang version 6.0.1:
```
[ 53%] Building CXX object Source/Urho3D/CMakeFiles/Urho3D.dir/Core/ProcessUtils.cpp.o
In file included from /home/romain/Projects/Urho3D/Source/Urho3D/Core/ProcessUtils.cpp:41:
In file included from /home/romain/Projects/Urho3D/build/include/Urho3D/ThirdParty/LibCpuId/libcpuid.h:88:
/home/romain/Projects/Urho3D/build/include/Urho3D/ThirdParty/LibCpuId/libcpuid_types.h:61:29: error: typedef redefinition with different types ('long long' vs '__int64_t' (aka 'long'))
        typedef signed long long   int64_t;
                                   ^
/usr/include/sys/_stdint.h:51:20: note: previous definition is here
typedef __int64_t               int64_t;
                                ^
In file included from /home/romain/Projects/Urho3D/Source/Urho3D/Core/ProcessUtils.cpp:41:
In file included from /home/romain/Projects/Urho3D/build/include/Urho3D/ThirdParty/LibCpuId/libcpuid.h:88:
/home/romain/Projects/Urho3D/build/include/Urho3D/ThirdParty/LibCpuId/libcpuid_types.h:62:29: error: typedef redefinition with different types
      ('unsigned long long' vs '__uint64_t' (aka 'unsigned long'))
        typedef unsigned long long uint64_t;
                                   ^
/usr/include/sys/endian.h:54:20: note: previous definition is here
typedef __uint64_t      uint64_t;
                        ^
2 errors generated.
```

Including `stdint.h` prevents these headers from (re)declaring these types.  `stdint.h` is included if `HAVE_STDINT_H` is set, so ensure CMake look for this header and defines the appropriate macro.