### PR TITLE
Fix build using FreeBSD clang version 6.0.1

### DIFF
--- a/Source/ThirdParty/SLikeNet/CMakeLists.txt
+++ b/Source/ThirdParty/SLikeNet/CMakeLists.txt
@@ -24,7 +24,7 @@ add_definitions (-D_RAKNET_SUPPORT_Rackspace=0 -D_RAKNET_SUPPORT_PacketizedTCP=0
 add_definitions (-D_RAKNET_SUPPORT_ReadyEvent=0 -D_RAKNET_SUPPORT_MessageFilter=0 -D_RAKNET_SUPPORT_FileListTransfer=0)
 
 # Check specific function availability which may be missing from different MinGW versions
-check_cxx_source_compiles ("#include <arpa/inet.h>\nint main() {\n    struct sockaddr_in sa;\n    char str[INET_ADDRSTRLEN];\n    inet_pton(AF_INET, \"192.0.2.33\", &(sa.sin_addr));\n    inet_ntop(AF_INET, &(sa.sin_addr), str, INET_ADDRSTRLEN);\n}" INET_FUNCTIONS_EXISTS_1)
+check_cxx_source_compiles ("#include <sys/types.h>\n#include <sys/socket.h>\n#include <netinet/in.h>\n#include <arpa/inet.h>\nint main() {\n    struct sockaddr_in sa;\n    char str[INET_ADDRSTRLEN];\n    inet_pton(AF_INET, \"192.0.2.33\", &(sa.sin_addr));\n    inet_ntop(AF_INET, &(sa.sin_addr), str, INET_ADDRSTRLEN);\n}" INET_FUNCTIONS_EXISTS_1)
 
 set (ORIG_CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES})
 set (CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} ws2_32)


### PR DESCRIPTION
[ 19%] Building CXX object Source/ThirdParty/SLikeNet/CMakeFiles/SLikeNet.dir/Source/src/BitStream.cpp.o
In file included from /home/romain/Projects/Urho3D/Source/ThirdParty/SLikeNet/Source/src/BitStream.cpp:48:
/home/romain/Projects/Urho3D/Source/ThirdParty/SLikeNet/Source/include/slikenet/linux_adapter.h:17:10: fatal error: 'winsock2.h' file not found
#include "winsock2.h"
         ^~~~~~~~~~~~
1 error generated.