### PR TITLE
Tooltip improvements

### DIFF
--- a/Source/Urho3D/AngelScript/UIAPI.cpp
+++ b/Source/Urho3D/AngelScript/UIAPI.cpp
@@ -655,6 +655,7 @@ static void RegisterToolTip(asIScriptEngine* engine)
 {
     RegisterUIElement<ToolTip>(engine, "ToolTip");
     engine->RegisterObjectMethod("ToolTip", "void Reset()", asMETHOD(ToolTip, Reset), asCALL_THISCALL);
+    engine->RegisterObjectMethod("ToolTip", "void add_altTarget(UIElement@+)", asMETHOD(ToolTip, AddAltTarget), asCALL_THISCALL);
     engine->RegisterObjectMethod("ToolTip", "void set_delay(float)", asMETHOD(ToolTip, SetDelay), asCALL_THISCALL);
     engine->RegisterObjectMethod("ToolTip", "float get_delay() const", asMETHOD(ToolTip, GetDelay), asCALL_THISCALL);
 }

--- a/Source/Urho3D/AngelScript/UIAPI.cpp
+++ b/Source/Urho3D/AngelScript/UIAPI.cpp
@@ -654,6 +654,7 @@ static void RegisterFileSelector(asIScriptEngine* engine)
 static void RegisterToolTip(asIScriptEngine* engine)
 {
     RegisterUIElement<ToolTip>(engine, "ToolTip");
+    engine->RegisterObjectMethod("ToolTip", "void Reset()", asMETHOD(ToolTip, Reset), asCALL_THISCALL);
     engine->RegisterObjectMethod("ToolTip", "void set_delay(float)", asMETHOD(ToolTip, SetDelay), asCALL_THISCALL);
     engine->RegisterObjectMethod("ToolTip", "float get_delay() const", asMETHOD(ToolTip, GetDelay), asCALL_THISCALL);
 }

--- a/Source/Urho3D/LuaScript/pkgs/UI/ToolTip.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/UI/ToolTip.pkg
@@ -7,6 +7,8 @@ class ToolTip : public UIElement
 
     void Reset();
 
+    void AddAltTarget(UIElement* target);
+
     void SetDelay(float delay);
     
     float GetDelay() const;

--- a/Source/Urho3D/LuaScript/pkgs/UI/ToolTip.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/UI/ToolTip.pkg
@@ -5,6 +5,8 @@ class ToolTip : public UIElement
     ToolTip();
     virtual ~ToolTip();
 
+    void Reset();
+
     void SetDelay(float delay);
     
     float GetDelay() const;

--- a/Source/Urho3D/UI/ToolTip.cpp
+++ b/Source/Urho3D/UI/ToolTip.cpp
@@ -89,15 +89,20 @@ void ToolTip::Update(float timeStep)
     }
     else
     {
-        if (IsVisible() && parent_ == root)
-        {
-            SetParent(target_);
-            SetPosition(originalPosition_);
-            SetVisible(false);
-        }
-        parentHovered_ = false;
-        displayAt_.Reset();
+        Reset();
     }
+}
+
+void ToolTip::Reset()
+{
+    if (IsVisible() && parent_ == GetRoot())
+    {
+        SetParent(target_);
+        SetPosition(originalPosition_);
+        SetVisible(false);
+    }
+    parentHovered_ = false;
+    displayAt_.Reset();
 }
 
 void ToolTip::SetDelay(float delay)

--- a/Source/Urho3D/UI/ToolTip.cpp
+++ b/Source/Urho3D/UI/ToolTip.cpp
@@ -34,7 +34,7 @@ extern const char* UI_CATEGORY;
 ToolTip::ToolTip(Context* context) :
     UIElement(context),
     delay_(0.0f),
-    parentHovered_(false)
+    hovered_(false)
 {
     SetVisible(false);
 }
@@ -66,13 +66,28 @@ void ToolTip::Update(float timeStep)
         return;
     }
 
-    if (target_->IsHovering() && target_->IsVisibleEffective())
+    bool hovering = target_->IsHovering() && target_->IsVisibleEffective();
+    if (!hovering)
+    {
+        for (auto it = altTargets_.Begin(); it != altTargets_.End();)
+        {
+            SharedPtr<UIElement> target = it->Lock();
+            if (!target)
+                it = altTargets_.Erase(it);
+            else if (hovering = target->IsHovering() && target->IsVisibleEffective())
+                break;
+            else
+                ++it;
+        }
+    }
+
+    if (hovering)
     {
         float effectiveDelay = delay_ > 0.0f ? delay_ : GetSubsystem<UI>()->GetDefaultToolTipDelay();
 
-        if (!parentHovered_)
+        if (!hovered_)
         {
-            parentHovered_ = true;
+            hovered_ = true;
             displayAt_.Reset();
         }
         else if (displayAt_.GetMSec(false) >= (unsigned)(effectiveDelay * 1000.0f) && parent_ == target_)
@@ -101,8 +116,13 @@ void ToolTip::Reset()
         SetPosition(originalPosition_);
         SetVisible(false);
     }
-    parentHovered_ = false;
+    hovered_ = false;
     displayAt_.Reset();
+}
+
+void ToolTip::AddAltTarget(UIElement* target)
+{
+    altTargets_.Push(WeakPtr<UIElement>(target));
 }
 
 void ToolTip::SetDelay(float delay)

--- a/Source/Urho3D/UI/ToolTip.h
+++ b/Source/Urho3D/UI/ToolTip.h
@@ -44,6 +44,9 @@ public:
     /// Perform UI element update.
     void Update(float timeStep) override;
 
+    /// Hide tooltip if visible and reset parentage.
+    void Reset();
+
     /// Set the delay in seconds until the tooltip shows once hovering. Set zero to use the default from the UI subsystem.
     void SetDelay(float delay);
 

--- a/Source/Urho3D/UI/ToolTip.h
+++ b/Source/Urho3D/UI/ToolTip.h
@@ -47,6 +47,9 @@ public:
     /// Hide tooltip if visible and reset parentage.
     void Reset();
 
+    /// Add an alternative hover target.
+    void AddAltTarget(UIElement* target);
+
     /// Set the delay in seconds until the tooltip shows once hovering. Set zero to use the default from the UI subsystem.
     void SetDelay(float delay);
 
@@ -56,10 +59,12 @@ public:
 private:
     /// The element that is being tracked for hovering. Normally the parent element.
     WeakPtr<UIElement> target_;
+    /// Alternative targets. Primarily targets parent.
+    Vector<WeakPtr<UIElement> > altTargets_;
     /// Delay from hover start to displaying the tooltip.
     float delay_;
-    /// Point at which the parent was hovered.
-    bool parentHovered_;
+    /// Hover countdown has started.
+    bool hovered_;
     /// Point at which the tooltip was set visible.
     Timer displayAt_;
     /// Original offset position to the parent.


### PR DESCRIPTION
In working with ToolTips I've found that it's good to be able to hide them at will for stuff like repositioning, and alternative targets works well for setting a ToolTip for a layout or similar (say a row with a Text and a LineEdit) where normally the objects inside it would eat the input.