### PR TITLE
added missing 'Apply' function for AnimationState

### DIFF
--- a/Source/Urho3D/LuaScript/pkgs/Graphics/AnimationState.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Graphics/AnimationState.pkg
@@ -23,7 +23,8 @@ class AnimationState
     void AddTime(float delta);
     void SetLayer(unsigned char layer);
     void SetBlendMode(AnimationBlendMode mode);
-
+    void Apply();
+    
     Animation* GetAnimation() const;
     Bone* GetStartBone() const;
     float GetBoneWeight(const String name) const;


### PR DESCRIPTION
AnimationState needs to have the Apply function binding for lua. Needed for bone-less animation playback without animation controller. Not sure why it was missing in the first place, I assume it got forgotten.  For reference I followed 'Node animations' instructions in the documentation, which explicitly mentions the method. 

Works as intended in my project.
 