### PR TITLE
Fix compiler warning:

### DIFF
--- a/Source/Urho3D/AngelScript/ResourceAPI.cpp
+++ b/Source/Urho3D/AngelScript/ResourceAPI.cpp
@@ -401,7 +401,7 @@ static void RegisterJSONValue(asIScriptEngine* engine)
     engine->RegisterObjectMethod("JSONValue", "uint GetUInt(uint defaultValue = 0) const", asMETHOD(JSONValue, GetUInt), asCALL_THISCALL);
     engine->RegisterObjectMethod("JSONValue", "float GetFloat(float defaultValue = 0) const", asMETHOD(JSONValue, GetFloat), asCALL_THISCALL);
     engine->RegisterObjectMethod("JSONValue", "double GetDouble(double defaultValue = 0) const", asMETHOD(JSONValue, GetDouble), asCALL_THISCALL);
-    engine->RegisterObjectMethod("JSONValue", "const String& GetString(const String& defaultValue = String(\"\")) const", asMETHOD(JSONValue, GetString), asCALL_THISCALL);
+    engine->RegisterObjectMethod("JSONValue", "const String& GetString(const String& defaultValue) const", asMETHOD(JSONValue, GetStringWithDefault), asCALL_THISCALL);
     engine->RegisterObjectMethod("JSONValue", "Variant GetVariant(Variant defaultValue = Variant()) const", asMETHOD(JSONValue, GetVariant), asCALL_THISCALL);
     engine->RegisterObjectMethod("JSONValue", "VariantMap GetVariantMap(VariantMap defaultValue = VariantMap()) const", asMETHOD(JSONValue, GetVariantMap), asCALL_THISCALL);
 

--- a/Source/Urho3D/Resource/JSONValue.h
+++ b/Source/Urho3D/Resource/JSONValue.h
@@ -197,7 +197,7 @@ public:
     /// Return double value.
     double GetDouble(double defaultValue = 0.0) const { return IsNumber() ? numberValue_ : defaultValue; }
     /// Return string value.
-    const String& GetString(const String& defaultValue = String::EMPTY) const { return IsString() ? *stringValue_ : defaultValue;}
+    const String& GetString(String& defaultValue = String::EMPTY) const { return IsString() ? *stringValue_ : defaultValue;}
     /// Return C string value.
     const char* GetCString(const char* defaultValue = nullptr) const { return IsString() ? stringValue_->CString() : defaultValue;}
     /// Return JSON array value.

--- a/Source/Urho3D/Resource/JSONValue.h
+++ b/Source/Urho3D/Resource/JSONValue.h
@@ -197,7 +197,8 @@ public:
     /// Return double value.
     double GetDouble(double defaultValue = 0.0) const { return IsNumber() ? numberValue_ : defaultValue; }
     /// Return string value.
-    const String& GetString(String& defaultValue = String::EMPTY) const { return IsString() ? *stringValue_ : defaultValue;}
+    String GetString(String const& defaultValue) const { return IsString() ? *stringValue_ : defaultValue;}
+    const String& GetString() const { return IsString() ? *stringValue_ : String::EMPTY;}
     /// Return C string value.
     const char* GetCString(const char* defaultValue = nullptr) const { return IsString() ? stringValue_->CString() : defaultValue;}
     /// Return JSON array value.

--- a/Source/Urho3D/Resource/JSONValue.h
+++ b/Source/Urho3D/Resource/JSONValue.h
@@ -197,8 +197,9 @@ public:
     /// Return double value.
     double GetDouble(double defaultValue = 0.0) const { return IsNumber() ? numberValue_ : defaultValue; }
     /// Return string value.
-    String GetString(String const& defaultValue) const { return IsString() ? *stringValue_ : defaultValue;}
+    String GetString(String const& defaultValue) const { return GetStringWithDefault(defaultValue);}
     const String& GetString() const { return IsString() ? *stringValue_ : String::EMPTY;}
+    String GetStringWithDefault(const String& defaultValue) const { return IsString() ? *stringValue_ : String::EMPTY;}
     /// Return C string value.
     const char* GetCString(const char* defaultValue = nullptr) const { return IsString() ? stringValue_->CString() : defaultValue;}
     /// Return JSON array value.

--- a/Source/Urho3D/Resource/JSONValue.h
+++ b/Source/Urho3D/Resource/JSONValue.h
@@ -197,7 +197,7 @@ public:
     /// Return double value.
     double GetDouble(double defaultValue = 0.0) const { return IsNumber() ? numberValue_ : defaultValue; }
     /// Return string value.
-    const String& GetString(String defaultValue = String::EMPTY) const { return IsString() ? *stringValue_ : defaultValue;}
+    const String& GetString(const String& defaultValue = String::EMPTY) const { return IsString() ? *stringValue_ : defaultValue;}
     /// Return C string value.
     const char* GetCString(const char* defaultValue = nullptr) const { return IsString() ? stringValue_->CString() : defaultValue;}
     /// Return JSON array value.


### PR DESCRIPTION
Compiler Warning was:

````
        Resource/JSONValue.h:200:110: warning: reference to stack memory associated with parameter 'defaultValue' returned [-Wreturn-stack-address]
        const String& GetString(String defaultValue = String::EMPTY) const { return IsString() ? *stringValue_ : defaultValue;}
````

Note: This is also a series problem as the parameter is a stack variable and will be destroyed on
the function return. This returning a reference to this value is returning a reference to a value
that has been destroyed.

Changing the parameter to also be a `const String&` does not change the meaning or usage of the
function.