### PR TITLE
Fix compiler warning:

### DIFF
--- a/Source/Urho3D/AngelScript/ResourceAPI.cpp
+++ b/Source/Urho3D/AngelScript/ResourceAPI.cpp
@@ -401,7 +401,7 @@ static void RegisterJSONValue(asIScriptEngine* engine)
     engine->RegisterObjectMethod("JSONValue", "uint GetUInt(uint defaultValue = 0) const", asMETHOD(JSONValue, GetUInt), asCALL_THISCALL);
     engine->RegisterObjectMethod("JSONValue", "float GetFloat(float defaultValue = 0) const", asMETHOD(JSONValue, GetFloat), asCALL_THISCALL);
     engine->RegisterObjectMethod("JSONValue", "double GetDouble(double defaultValue = 0) const", asMETHOD(JSONValue, GetDouble), asCALL_THISCALL);
-    engine->RegisterObjectMethod("JSONValue", "const String& GetString(const String& defaultValue = String(\"\")) const", asMETHOD(JSONValue, GetString), asCALL_THISCALL);
+    engine->RegisterObjectMethod("JSONValue", "String GetStringWithDefault(const String& defaultValue) const", asMETHOD(JSONValue, GetStringWithDefault), asCALL_THISCALL);
     engine->RegisterObjectMethod("JSONValue", "Variant GetVariant(Variant defaultValue = Variant()) const", asMETHOD(JSONValue, GetVariant), asCALL_THISCALL);
     engine->RegisterObjectMethod("JSONValue", "VariantMap GetVariantMap(VariantMap defaultValue = VariantMap()) const", asMETHOD(JSONValue, GetVariantMap), asCALL_THISCALL);
 

--- a/Source/Urho3D/Resource/JSONValue.h
+++ b/Source/Urho3D/Resource/JSONValue.h
@@ -197,7 +197,16 @@ public:
     /// Return double value.
     double GetDouble(double defaultValue = 0.0) const { return IsNumber() ? numberValue_ : defaultValue; }
     /// Return string value.
-    const String& GetString(String defaultValue = String::EMPTY) const { return IsString() ? *stringValue_ : defaultValue;}
+    /// Need two version because.
+    ///     Can not pass by value (as undefined to return a reference)
+    ///     or reference (as String::EMPTY is const)
+    ///     or const reference (as you can pass temporary and undefined to return a reference to this).
+    /// So we need to return by value.
+    /// To make it more efficient we don't provide a default parameter version so we can return by reference.
+    /// We also need a version to be compatable with the script system (GetStringWithDefault()) that has unique name.
+    String GetString(String const& defaultValue) const { return GetStringWithDefault(defaultValue);}
+    const String& GetString() const { return IsString() ? *stringValue_ : String::EMPTY;}
+    String GetStringWithDefault(String const& defaultValue) const { return IsString() ? *stringValue_ : defaultValue;}
     /// Return C string value.
     const char* GetCString(const char* defaultValue = nullptr) const { return IsString() ? stringValue_->CString() : defaultValue;}
     /// Return JSON array value.


### PR DESCRIPTION
Compiler Warning was:

````
    Resource/JSONValue.h:200:110: warning: reference to stack memory associated with parameter 'defaultValue' returned [-Wreturn-stack-address]
    const String& GetString(String defaultValue = String::EMPTY) const { return IsString() ? *stringValue_ : defaultValue;}
````

Now the trouble here is that `String::EMPTY` is a constant value. So we can't just use a reference.

Possible Solutions:

* Pass defaultValue as const reference.
* Pass defaultValue as reference.
* Pass defaultValue by value.
* Pass a type of reference but value keep local copy
* Return by value


### Pass defaultValue as const reference.
As pointed out by `iSLC` is not usable as this allows temporary variables, which may have been destroyed.

### Pass defaultValue as reference.
The problem here is that `String::EMPTY` has a type `const reference` and thus can not be used as a default value.

### Pass defaultValue by value.
This was the original bug. The problem here is that we are returning a reference and if we have a default value then you are returning a reference to a parameter that will be destroyed on function exit.

### Pass a type of reference but value keep local copy
We could potentially keep a local copy in the function .

1. by using a static function variable. We can return a reference to this variable as it will live an appropriate amount of time. The problem here is that the default value only lives until the next call to `GetString()` at which point it will be over-riden. Not all objects will share the same variable so a call to any `GetString()` will change the value. If a user kept a reference to the value this effectively causes the value to change behind the scenes.

2. by using a member variable. Again it only last until the `GetString()` might be slightly longer as the `GetString()` would have to be called on the same object. But this alters the state of the object which long term is undesirable.

### Return by value
This will allow the parameter to be passed by constant reference. It has the same affect as returning by const reference. The trouble is that it will require a copy to return the value so it becomes less efficient.

## Conclusion
The only way to solve the problem is to return by value. This will be less efficient but it will be correct.

````
String GetString(String const& defaultValue = String::EMPTY) const { return IsString() ? *stringValue_ : defaultValue;}
````

## Optimization
There are situations where we can still return by `const reference` if we know both alternatives can still be maintained. So in the situation where no defaultValue is provided by the user we know that String::Empty is always available so we can return that or the original value by const reference.

````
String GetString(String const& defaultValue) const { return IsString() ? *stringValue_ : defaultValue;}
const String& GetString() const { return IsString() ? *stringValue_ : String::EMPTY;}
````

## Why not pass by reference and cast away const on String::EMPTY
Since GetString() returns a const reference why can we simply not use "Pass defaultValue as reference" as defined above but cast away the `const` for the default value.

````
    const String& GetString(String& defaultValue = const_cast< String & >(String::EMPTY)) const { return IsString() ? *stringValue_ : defaultValue; }
````

The problem here is that we can not use temporary object or pass as default values a const String.

````
    const String  myDefault = "a";
    object.GetString(myDefault);        // Fail
    object.GetString(String("Temp"));   // Fail
````