### PR TITLE
Fixed the depth test behavior of debug renderer sphere sectors.

### DIFF
--- a/Source/Urho3D/Graphics/DebugRenderer.cpp
+++ b/Source/Urho3D/Graphics/DebugRenderer.cpp
@@ -303,7 +303,7 @@ void DebugRenderer::AddSphereSector(const Sphere& sphere, const Quaternion& rota
         AddLine(
             sphere.center_ + rotation * sphere.GetLocalPoint(j * 360.0f / numCircleSegments, halfAngle),
             sphere.center_ + rotation * sphere.GetLocalPoint((j + 1) * 360.0f / numCircleSegments, halfAngle),
-            uintColor);
+            uintColor, depthTest);
     }
 
     // Draw arcs
@@ -316,7 +316,7 @@ void DebugRenderer::AddSphereSector(const Sphere& sphere, const Quaternion& rota
             AddLine(
                 sphere.center_ + rotation * sphere.GetLocalPoint(j * 360.0f / numCircleSegments, i * arcStep),
                 sphere.center_ + rotation * sphere.GetLocalPoint(j * 360.0f / numCircleSegments, nextPhi),
-                uintColor);
+                uintColor, depthTest);
         }
     }
 
@@ -327,7 +327,7 @@ void DebugRenderer::AddSphereSector(const Sphere& sphere, const Quaternion& rota
         {
             AddLine(sphere.center_,
                 sphere.center_ + rotation * sphere.GetLocalPoint(j * 360.0f / numCircleSegments, halfAngle),
-                uintColor);
+                uintColor, depthTest);
         }
     }
 }

--- a/Source/Urho3D/Graphics/DebugRenderer.h
+++ b/Source/Urho3D/Graphics/DebugRenderer.h
@@ -128,7 +128,7 @@ public:
     void AddPolyhedron(const Polyhedron& poly, const Color& color, bool depthTest = true);
     /// Add a sphere.
     void AddSphere(const Sphere& sphere, const Color& color, bool depthTest = true);
-    /// Add a sphere sector.
+    /// Add a sphere sector. Angle ranges from 0 to 360. Identity Quaternion yields the filled portion of the sector upwards.
     void AddSphereSector(const Sphere& sphere, const Quaternion& rotation, float angle,
         bool drawLines, const Color& color, bool depthTest = true);
     /// Add a cylinder


### PR DESCRIPTION
The `AddLine` calls were missing the `depthTest` flag, so it was impossible to actually get a sphere sector without depth test enabled.

Also added more details to the documentation for that function. Perhaps the documentation could be clarified differently, particularly regarding the angle. I initially expected the angle to range from 0 to 180 and be measured from the axis to the edge of the sector, but instead it ranges from 0 to 360 measuring the edge to the other edge of the sector.