### PR TITLE
Make doxygen catch global enums

### DIFF
--- a/Source/Urho3D/AngelScript/Script.h
+++ b/Source/Urho3D/AngelScript/Script.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Core/Mutex.h"

--- a/Source/Urho3D/AngelScript/ScriptInstance.h
+++ b/Source/Urho3D/AngelScript/ScriptInstance.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../AngelScript/ScriptEventListener.h"

--- a/Source/Urho3D/Core/Attribute.h
+++ b/Source/Urho3D/Core/Attribute.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Container/FlagSet.h"

--- a/Source/Urho3D/Core/Spline.h
+++ b/Source/Urho3D/Core/Spline.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Core/Variant.h"

--- a/Source/Urho3D/Core/Variant.h
+++ b/Source/Urho3D/Core/Variant.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Container/HashMap.h"

--- a/Source/Urho3D/Database/Database.h
+++ b/Source/Urho3D/Database/Database.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Core/Object.h"

--- a/Source/Urho3D/Graphics/Animation.h
+++ b/Source/Urho3D/Graphics/Animation.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Container/FlagSet.h"

--- a/Source/Urho3D/Graphics/AnimationState.h
+++ b/Source/Urho3D/Graphics/AnimationState.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Container/HashMap.h"

--- a/Source/Urho3D/Graphics/Camera.h
+++ b/Source/Urho3D/Graphics/Camera.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Graphics/GraphicsDefs.h"

--- a/Source/Urho3D/Graphics/Drawable.h
+++ b/Source/Urho3D/Graphics/Drawable.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Graphics/GraphicsDefs.h"

--- a/Source/Urho3D/Graphics/GraphicsDefs.h
+++ b/Source/Urho3D/Graphics/GraphicsDefs.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Container/FlagSet.h"

--- a/Source/Urho3D/Graphics/Light.h
+++ b/Source/Urho3D/Graphics/Light.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Math/Color.h"

--- a/Source/Urho3D/Graphics/OcclusionBuffer.h
+++ b/Source/Urho3D/Graphics/OcclusionBuffer.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Core/Object.h"

--- a/Source/Urho3D/Graphics/OctreeQuery.h
+++ b/Source/Urho3D/Graphics/OctreeQuery.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Graphics/Drawable.h"

--- a/Source/Urho3D/Graphics/ParticleEffect.h
+++ b/Source/Urho3D/Graphics/ParticleEffect.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Graphics/GraphicsDefs.h"

--- a/Source/Urho3D/Graphics/RenderPath.h
+++ b/Source/Urho3D/Graphics/RenderPath.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Container/Ptr.h"

--- a/Source/Urho3D/Graphics/Renderer.h
+++ b/Source/Urho3D/Graphics/Renderer.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Container/HashSet.h"

--- a/Source/Urho3D/Graphics/RibbonTrail.h
+++ b/Source/Urho3D/Graphics/RibbonTrail.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Graphics/Drawable.h"

--- a/Source/Urho3D/Graphics/Skeleton.h
+++ b/Source/Urho3D/Graphics/Skeleton.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Math/BoundingBox.h"

--- a/Source/Urho3D/Graphics/Technique.h
+++ b/Source/Urho3D/Graphics/Technique.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Graphics/GraphicsDefs.h"

--- a/Source/Urho3D/IO/File.h
+++ b/Source/Urho3D/IO/File.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Container/ArrayPtr.h"

--- a/Source/Urho3D/Input/Input.h
+++ b/Source/Urho3D/Input/Input.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Container/FlagSet.h"

--- a/Source/Urho3D/Input/InputConstants.h
+++ b/Source/Urho3D/Input/InputConstants.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Container/FlagSet.h"

--- a/Source/Urho3D/LuaScript/LuaScriptInstance.h
+++ b/Source/Urho3D/LuaScript/LuaScriptInstance.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../LuaScript/LuaScriptEventListener.h"

--- a/Source/Urho3D/Math/Frustum.h
+++ b/Source/Urho3D/Math/Frustum.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Math/BoundingBox.h"

--- a/Source/Urho3D/Math/MathDefs.h
+++ b/Source/Urho3D/Math/MathDefs.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #ifdef _MSC_VER

--- a/Source/Urho3D/Navigation/CrowdAgent.h
+++ b/Source/Urho3D/Navigation/CrowdAgent.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Navigation/CrowdManager.h"

--- a/Source/Urho3D/Navigation/NavigationMesh.h
+++ b/Source/Urho3D/Navigation/NavigationMesh.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Container/ArrayPtr.h"

--- a/Source/Urho3D/Network/Connection.h
+++ b/Source/Urho3D/Network/Connection.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Container/HashSet.h"

--- a/Source/Urho3D/Network/HttpRequest.h
+++ b/Source/Urho3D/Network/HttpRequest.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Container/ArrayPtr.h"

--- a/Source/Urho3D/Physics/CollisionShape.h
+++ b/Source/Urho3D/Physics/CollisionShape.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Container/ArrayPtr.h"

--- a/Source/Urho3D/Physics/Constraint.h
+++ b/Source/Urho3D/Physics/Constraint.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Math/Vector3.h"

--- a/Source/Urho3D/Physics/RigidBody.h
+++ b/Source/Urho3D/Physics/RigidBody.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../IO/VectorBuffer.h"

--- a/Source/Urho3D/Resource/Image.h
+++ b/Source/Urho3D/Resource/Image.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Container/ArrayPtr.h"

--- a/Source/Urho3D/Resource/JSONValue.h
+++ b/Source/Urho3D/Resource/JSONValue.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Core/Variant.h"

--- a/Source/Urho3D/Resource/PListFile.h
+++ b/Source/Urho3D/Resource/PListFile.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Resource/Resource.h"

--- a/Source/Urho3D/Resource/Resource.h
+++ b/Source/Urho3D/Resource/Resource.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Core/Object.h"

--- a/Source/Urho3D/Resource/ResourceCache.h
+++ b/Source/Urho3D/Resource/ResourceCache.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Container/HashSet.h"

--- a/Source/Urho3D/Scene/AnimationDefs.h
+++ b/Source/Urho3D/Scene/AnimationDefs.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 namespace Urho3D

--- a/Source/Urho3D/Scene/Component.h
+++ b/Source/Urho3D/Scene/Component.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Scene/Animatable.h"

--- a/Source/Urho3D/Scene/LogicComponent.h
+++ b/Source/Urho3D/Scene/LogicComponent.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Container/FlagSet.h"

--- a/Source/Urho3D/Scene/Node.h
+++ b/Source/Urho3D/Scene/Node.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../IO/VectorBuffer.h"

--- a/Source/Urho3D/Scene/Scene.h
+++ b/Source/Urho3D/Scene/Scene.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Container/HashSet.h"

--- a/Source/Urho3D/Scene/SmoothedTransform.h
+++ b/Source/Urho3D/Scene/SmoothedTransform.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Scene/Component.h"

--- a/Source/Urho3D/Scene/ValueAnimation.h
+++ b/Source/Urho3D/Scene/ValueAnimation.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Core/Variant.h"

--- a/Source/Urho3D/UI/Cursor.h
+++ b/Source/Urho3D/UI/Cursor.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Graphics/Texture.h"

--- a/Source/Urho3D/UI/Font.h
+++ b/Source/Urho3D/UI/Font.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Container/ArrayPtr.h"

--- a/Source/Urho3D/UI/ListView.h
+++ b/Source/Urho3D/UI/ListView.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Input/InputConstants.h"

--- a/Source/Urho3D/UI/Text.h
+++ b/Source/Urho3D/UI/Text.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../UI/UISelectable.h"

--- a/Source/Urho3D/UI/UI.h
+++ b/Source/Urho3D/UI/UI.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Core/Object.h"

--- a/Source/Urho3D/UI/UIElement.h
+++ b/Source/Urho3D/UI/UIElement.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Math/Vector2.h"

--- a/Source/Urho3D/UI/Window.h
+++ b/Source/Urho3D/UI/Window.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../UI/BorderImage.h"

--- a/Source/Urho3D/Urho2D/AnimatedSprite2D.h
+++ b/Source/Urho3D/Urho2D/AnimatedSprite2D.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Urho2D/StaticSprite2D.h"

--- a/Source/Urho3D/Urho2D/ParticleEffect2D.h
+++ b/Source/Urho3D/Urho2D/ParticleEffect2D.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Graphics/GraphicsDefs.h"

--- a/Source/Urho3D/Urho2D/RigidBody2D.h
+++ b/Source/Urho3D/Urho2D/RigidBody2D.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Scene/Component.h"

--- a/Source/Urho3D/Urho2D/SpriterData2D.h
+++ b/Source/Urho3D/Urho2D/SpriterData2D.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 namespace pugi

--- a/Source/Urho3D/Urho2D/SpriterInstance2D.h
+++ b/Source/Urho3D/Urho2D/SpriterInstance2D.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Urho2D/SpriterData2D.h"

--- a/Source/Urho3D/Urho2D/TileMapDefs2D.h
+++ b/Source/Urho3D/Urho2D/TileMapDefs2D.h
@@ -20,6 +20,8 @@
 // THE SOFTWARE.
 //
 
+/// \file
+
 #pragma once
 
 #include "../Container/RefCounted.h"


### PR DESCRIPTION
Already posted issue about it https://github.com/urho3d/Urho3D/issues/2469 (tldr: global enums are skipped by doxygen unless you put \file element into corresponding header or source file).

The reason for it is so that nobody has to grep through documentation in order to figure out which values can given enum have. Yay.