### PR TITLE
Event handler based on type-erasure.

### DIFF
--- a/Source/Urho3D/AngelScript/ScriptFile.cpp
+++ b/Source/Urho3D/AngelScript/ScriptFile.cpp
@@ -692,13 +692,13 @@ void ScriptFile::AddEventHandlerInternal(Object* sender, StringHash eventType, c
 
     if (!sender)
     {
-        i->second_->SubscribeToEvent(eventType, new EventHandlerImpl<ScriptEventInvoker>
-            (i->second_, &ScriptEventInvoker::HandleScriptEvent, (void*)function));
+        i->second_->SubscribeToEvent(eventType, new EventHandler
+            (i->second_, EventHandler::MemberFwd<ScriptEventInvoker, &ScriptEventInvoker::HandleScriptEvent>(), (void*)function));
     }
     else
     {
-        i->second_->SubscribeToEvent(sender, eventType, new EventHandlerImpl<ScriptEventInvoker>
-            (i->second_, &ScriptEventInvoker::HandleScriptEvent, (void*)function));
+        i->second_->SubscribeToEvent(sender, eventType, new EventHandler
+            (i->second_, EventHandler::MemberFwd<ScriptEventInvoker, &ScriptEventInvoker::HandleScriptEvent>(), (void*)function));
     }
 }
 

--- a/Source/Urho3D/AngelScript/ScriptFile.cpp
+++ b/Source/Urho3D/AngelScript/ScriptFile.cpp
@@ -693,12 +693,12 @@ void ScriptFile::AddEventHandlerInternal(Object* sender, StringHash eventType, c
     if (!sender)
     {
         i->second_->SubscribeToEvent(eventType, new EventHandler
-            (i->second_, EventHandler::MemberFwd<ScriptEventInvoker, &ScriptEventInvoker::HandleScriptEvent>(), (void*)function));
+            (i->second_, EventHandler::Forwarder<ScriptEventInvoker, &ScriptEventInvoker::HandleScriptEvent>(), (void*)function));
     }
     else
     {
         i->second_->SubscribeToEvent(sender, eventType, new EventHandler
-            (i->second_, EventHandler::MemberFwd<ScriptEventInvoker, &ScriptEventInvoker::HandleScriptEvent>(), (void*)function));
+            (i->second_, EventHandler::Forwarder<ScriptEventInvoker, &ScriptEventInvoker::HandleScriptEvent>(), (void*)function));
     }
 }
 

--- a/Source/Urho3D/Core/Object.cpp
+++ b/Source/Urho3D/Core/Object.cpp
@@ -182,16 +182,6 @@ void Object::SubscribeToEvent(Object* sender, StringHash eventType, EventHandler
     }
 }
 
-void Object::SubscribeToEvent(StringHash eventType, const std::function<void(StringHash, VariantMap&)>& function, void* userData/*=0*/)
-{
-    SubscribeToEvent(eventType, new EventHandler11Impl(function, userData));
-}
-
-void Object::SubscribeToEvent(Object* sender, StringHash eventType, const std::function<void(StringHash, VariantMap&)>& function, void* userData/*=0*/)
-{
-    SubscribeToEvent(sender, eventType, new EventHandler11Impl(function, userData));
-}
-
 void Object::UnsubscribeFromEvent(StringHash eventType)
 {
     for (;;)

--- a/Source/Urho3D/Core/Object.h
+++ b/Source/Urho3D/Core/Object.h
@@ -315,15 +315,6 @@ public:
             };
     }
 
-    /// Generate a forwarder for a lambda handler. Lambda must be stored separately and outlive this object!
-    template <class L>
-    static ForwarderType LambdaFwd()
-    {
-        return [](void* thisPtr, StringHash type, VariantMap& args) -> void {
-                (reinterpret_cast<L*>(thisPtr)->operator()(type, args));
-            };
-    }
-
 protected:
     /// Event receiver.
     Object* receiver_;

--- a/Source/Urho3D/Core/Object.h
+++ b/Source/Urho3D/Core/Object.h
@@ -290,7 +290,7 @@ public:
 
     /// Generate a forwarder for a function handler.
     template <void(*Fptr)(StringHash, VariantMap&)>
-    static ForwarderType FreeFwd()
+    static ForwarderType FreeForwarder()
     {
         return [](void* /* thisPtr */, StringHash type, VariantMap& args) -> void {
                 (*Fptr)(type, args);
@@ -299,7 +299,7 @@ public:
 
     /// Generate a forwarder for a member handler.
     template <class T, void(T::*Mptr)(StringHash, VariantMap&)>
-    static ForwarderType MemberFwd()
+    static ForwarderType Forwarder()
     {
         return [](Object* thisPtr, StringHash type, VariantMap& args) -> void {
                 (static_cast<T*>(thisPtr)->*Mptr)(type, args);
@@ -308,7 +308,7 @@ public:
 
     /// Generate a forwarder for a constant member handler.
     template <class T, void(T::*Mptr)(StringHash, VariantMap&)const>
-    static ForwarderType MemberFwd()
+    static ForwarderType Forwarder()
     {
         return [](Object* thisPtr, StringHash type, VariantMap& args) -> void {
                 (static_cast<const T*>(thisPtr)->*Mptr)(type, args);
@@ -336,8 +336,8 @@ URHO3D_API StringHashRegister& GetEventNameRegister();
 /// Describe an event's parameter hash ID. Should be used inside an event namespace.
 #define URHO3D_PARAM(paramID, paramName) static const Urho3D::StringHash paramID(#paramName)
 /// Convenience macro to construct an EventHandler that points to a receiver object and its member function.
-#define URHO3D_HANDLER(className, function) (new Urho3D::EventHandler(this, Urho3D::EventHandler::MemberFwd<className, &className::function>()))
+#define URHO3D_HANDLER(className, function) (new Urho3D::EventHandler(this, Urho3D::EventHandler::Forwarder<className, &className::function>()))
 /// Convenience macro to construct an EventHandler that points to a receiver object and its member function, and also defines a userdata pointer.
-#define URHO3D_HANDLER_USERDATA(className, function, userData) (new Urho3D::EventHandler(this, Urho3D::EventHandler::MemberFwd<className, &className::function>(), userData))
+#define URHO3D_HANDLER_USERDATA(className, function, userData) (new Urho3D::EventHandler(this, Urho3D::EventHandler::Forwarder<className, &className::function>(), userData))
 
 }


### PR DESCRIPTION
Removes the need for virtual methods in the event handler. I don't expect this to be merged due to the loss of `EventHandler11Impl`. But I still decided to make it available if the need is there.

Long story short: It uses lambdas to forward event calls instead of virtual methods. I'll detail the pros and cons bellow.

Cons:
- Things like `EventHandler11Impl` are no longer possible since `EventHandler` no longer has any virtual methods. So you can't use lambdas like your used to.

(Possible) Pros:
- The `EventHandler` structure is basically a POD now. It can be copied moved etc. Which opens other possibilities to how do you want to store it. Maybe like vector for cache friendliness. Might require extra work to avoid issues with un+subscribing during events but it is possible (_did it in a quite fast signals-and-slots implementation a while back_).

I won't masquerade this as being faster or something. Because I don't have a significant application to properly profile this. But it can be used to achieve a faster event system.