### PR TITLE
Included default material definition in the documentation.

### DIFF
--- a/Docs/CreateDefaultMaterial.as
+++ b/Docs/CreateDefaultMaterial.as
@@ -1,0 +1,7 @@
+void Start()
+{
+Material@ mat = Material();
+mat.Save("DefaultMat.xml");
+Print("Saved default material to DefaultMat.xml");
+engine.Exit();
+}

--- a/Docs/DefaultMaterial.xml
+++ b/Docs/DefaultMaterial.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<material>
+	<technique name="Techniques/NoTexture.xml" quality="0" loddistance="0" />
+	<parameter name="UOffset" value="1 0 0 0" />
+	<parameter name="VOffset" value="0 1 0 0" />
+	<parameter name="MatDiffColor" value="1 1 1 1" />
+	<parameter name="MatEmissiveColor" value="0 0 0" />
+	<parameter name="MatEnvMapColor" value="1 1 1" />
+	<parameter name="MatSpecColor" value="0 0 0 1" />
+	<parameter name="Roughness" value="0.5" />
+	<parameter name="Metallic" value="0" />
+	<cull value="ccw" />
+	<shadowcull value="ccw" />
+	<fill value="solid" />
+	<depthbias constant="0" slopescaled="0" />
+	<alphatocoverage enable="false" />
+	<lineantialias enable="false" />
+	<renderorder value="128" />
+	<occlusion enable="true" />
+</material>

--- a/Docs/Doxyfile.in
+++ b/Docs/Doxyfile.in
@@ -873,7 +873,7 @@ EXCLUDE_SYMBOLS        =
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH           =
+EXAMPLE_PATH           = "@CMAKE_SOURCE_DIR@/Docs/"
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and

--- a/Docs/Reference.dox
+++ b/Docs/Reference.dox
@@ -1216,6 +1216,10 @@ A material definition looks like this:
 </material>
 \endcode
 
+The default values for a material are set by \ref Material::ResetToDefaults() and are as follows:
+
+\include DefaultMaterial.xml
+
 Several techniques can be defined for different quality levels and LOD distances. %Technique quality levels are specified from 0 (low) to 2 (high). When rendering, the highest available technique that does not exceed the Renderer's material quality setting will be chosen, see \ref Renderer::SetMaterialQuality "SetMaterialQuality()".
 
 The techniques for different LOD levels and quality settings must appear in a specific order:


### PR DESCRIPTION
My initial solution to #2501

I added a Docs/CreateDefaultMaterial.as script to save the default material values and included the default material in the documentation. Note that this script is not called anywhere by the build system, the Docs/DefaultMaterial.xml will require manual updates (the script is there to make those easier). 

I'm open to other approaches, for example we could leave out the Docs/DefaultMaterial.xml file and just past the contents in a \code block in Docs/Reference.dox instead. Depending on the version of doxygen we're using, this might be better: for my local version (1.8.11) the \include command seems to erroneously add line numbers to the block, which make copying and pasting the contents difficult and clutters it up unnecessarily for such a short file, as well as simply looking different than the code block above it. We could also go with some of the other proposed options from the issue, but I felt this was one of the simplest to implement and easiest to maintain approaches.