### PR TITLE
Fixed console styling to account for the addition of LOG_TRACE

### DIFF
--- a/Source/Urho3D/Engine/Console.cpp
+++ b/Source/Urho3D/Engine/Console.cpp
@@ -51,6 +51,7 @@ static const int DEFAULT_HISTORY_SIZE = 16;
 
 const char* logStyles[] =
 {
+    "ConsoleTraceText",
     "ConsoleDebugText",
     "ConsoleInfoText",
     "ConsoleWarningText",

--- a/bin/Data/UI/DefaultStyle.xml
+++ b/bin/Data/UI/DefaultStyle.xml
@@ -252,8 +252,8 @@
         <attribute name="Hover Color" value="0.3 0.4 0.32 1" />
         <attribute name="Selection Color" value="0.23 0.3 0.27 1" />
     </element>
-    <element type="ConsoleErrorText" style="ConsoleText" auto="false">
-        <attribute name="Color" value="1 0 0 1" />
+    <element type="ConsoleTraceText" style="ConsoleText" auto="false">
+        <attribute name="Color" value="0.85 0.85 0.6 1" />
     </element>
     <element type="ConsoleDebugText" style="ConsoleText" auto="false">
         <attribute name="Color" value="1 0.6 0 1" />
@@ -263,6 +263,9 @@
     </element>
     <element type="ConsoleWarningText" style="ConsoleText" auto="false">
         <attribute name="Color" value="1 1 0 1" />
+    </element>
+    <element type="ConsoleErrorText" style="ConsoleText" auto="false">
+        <attribute name="Color" value="1 0 0 1" />
     </element>
     <element type="ConsoleLineEdit" style="LineEdit" auto="false">
         <attribute name="Min Size" value="0 17" />


### PR DESCRIPTION
LOG_TRACE offset the log levels by 1 but the console styling did not add a
trace styling, so warnings were printed with error styling, etc.

I've not tested this much, but if you just open up the console in one of the samples it seems to print as expected. (To get an error you can run an invalid command through the FileSystem and to get regular text you can run echo hello or something like that)

I went with a sort of yellow-gray for the trace text styling. Feel free to change it as you see fit, I was more concerned with getting errors and warnings to be the right color than choosing the best color for the trace text, so I just went with something that seemed maybe reasonable (I haven't actually seen it as text, so that remains to be confirmed).