### PR TITLE
Added check for setting cursor to current

### DIFF
--- a/Source/Urho3D/UI/UI.cpp
+++ b/Source/Urho3D/UI/UI.cpp
@@ -153,6 +153,9 @@ UI::~UI() = default;
 
 void UI::SetCursor(Cursor* cursor)
 {
+    if (cursor_ == cursor)
+        return;
+
     // Remove old cursor (if any) and set new
     if (cursor_)
     {


### PR DESCRIPTION
This change prevents the following code from resulting in a segmentation fault:

```
UI* ui{ GetSubsystem<UI>() };
ui->SetCursor(new Cursor(context_));
ui->SetCursor(ui->GetCursor());
```

Thanks to @TIG3R99 for [locating](https://discourse.urho3d.io/t/changing-cursors/5581) this bug.