### PR TITLE
fix bug for SpritePacker in Tools

### DIFF
--- a/Source/Tools/SpritePacker/SpritePacker.cpp
+++ b/Source/Tools/SpritePacker/SpritePacker.cpp
@@ -289,19 +289,13 @@ void Run(Vector<String>& arguments)
 
             stbrp_context packerContext;
             stbrp_node packerMemory[PACKER_NUM_NODES];
-            stbrp_init_target(&packerContext, textureWidth, textureHeight, packerMemory, packerInfos.Size());
-            stbrp_pack_rects(&packerContext, packerRects, packerInfos.Size());
-
-            // check to see if everything fit
-            for (unsigned i = 0; i < packerInfos.Size(); ++i)
+            stbrp_init_target(&packerContext, textureWidth, textureHeight, packerMemory, PACKER_NUM_NODES);
+            if (!stbrp_pack_rects(&packerContext, packerRects, packerInfos.Size()))
             {
-                stbrp_rect* packerRect = &packerRects[i];
-                if (!packerRect->was_packed)
-                {
-                    fit = false;
-                    break;
-                }
+                // check to see if everything fit
+                fit = false;
             }
+
             if (fit)
             {
                 success = true;


### PR DESCRIPTION
If the forth parameter is "packerInfos.Size()" in "stbrp_init_target", I cannot pack three image(1920 * 1080、355 * 2 and 2 * 774) into a big image（2048 * 2048）.
In nothing/stb/stb_rect_pack.h comments, note that to guarantee best results, either:
1. make sure 'num_nodes' >= 'width'
or  2. call stbrp_allow_out_of_mem() defined below with 'allow_out_of_mem = 1'

See it in [](https://github.com/nothings/stb/blob/master/stb_rect_pack.h) line 124 to 143

:( bad on English