### PR TITLE
Fix HiresTimer overflow bug.

### DIFF
--- a/Source/Urho3D/Core/Timer.cpp
+++ b/Source/Urho3D/Core/Timer.cpp
@@ -94,7 +94,7 @@ static long long HiresTick()
     else
         return timeGetTime();
 #elif __EMSCRIPTEN__
-    return (unsigned)(emscripten_get_now()*1000.0);
+    return (long long)(emscripten_get_now()*1000.0);
 #else
     struct timeval time{};
     gettimeofday(&time, nullptr);


### PR DESCRIPTION
When the application is running for a long time in a browser environment,  emscripten_get_now()*1000.0 may larger than 2^32-1, so HiresTick() may return wrong value, which causes timeStep_ is always 0.0f.