### PR TITLE
Fix wrong pvrtc data size.

### DIFF
--- a/Source/Urho3D/Graphics/OpenGL/OGLTexture.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLTexture.cpp
@@ -237,11 +237,11 @@ unsigned Texture::GetRowDataSize(int width) const
 
     case COMPRESSED_RGB_PVRTC_4BPPV1_IMG:
     case COMPRESSED_RGBA_PVRTC_4BPPV1_IMG:
-        return (unsigned)(width * 4 + 7) >> 3u;
+        return ((unsigned)(width + 3) >> 2u) * 8;
 
     case COMPRESSED_RGB_PVRTC_2BPPV1_IMG:
     case COMPRESSED_RGBA_PVRTC_2BPPV1_IMG:
-        return (unsigned)(width * 2 + 7) >> 3u;
+        return ((unsigned)(width + 7) >> 3u) * 8;
 
     default:
         return 0;


### PR DESCRIPTION
This caused pvr textures can't display on iOS devices.

Texture for testing :  [https://tmpfiles.org/dl/28949/bj.pvr](url)