### PR TITLE
Serialization additions

### DIFF
--- a/Source/Urho3D/Scene/Animatable.h
+++ b/Source/Urho3D/Scene/Animatable.h
@@ -72,6 +72,10 @@ public:
     /// Register object factory.
     static void RegisterObject(Context* context);
 
+    /// Load from binary data. Return true if successful.
+    bool Load(Deserializer& source) override;
+    /// Save as binary data. Return true if successful.
+    bool Save(Serializer& dest) const override;
     /// Load from XML data. Return true if successful.
     bool LoadXML(const XMLElement& source) override;
     /// Save as XML data. Return true if successful.

--- a/Source/Urho3D/Scene/Serializable.cpp
+++ b/Source/Urho3D/Scene/Serializable.cpp
@@ -326,7 +326,7 @@ bool Serializable::Save(Serializer& dest) const
     for (unsigned i = 0; i < attributes->Size(); ++i)
     {
         const AttributeInfo& attr = attributes->At(i);
-        if (!(attr.mode_ & AM_FILE) || (attr.mode_ & AM_FILEREADONLY) == AM_FILEREADONLY)
+        if (!(attr.mode_ & AM_FILE))
             continue;
 
         OnGetAttribute(attr, value);

--- a/Source/Urho3D/UI/UIElement.h
+++ b/Source/Urho3D/UI/UIElement.h
@@ -133,6 +133,10 @@ public:
 
     /// Apply attribute changes that can not be applied immediately.
     void ApplyAttributes() override;
+    /// Load from binary data. Return true if successful.
+    bool Load(Deserializer& source) override;
+    /// Save as binary data. Return true if successful.
+    bool Save(Serializer& dest) const override;
     /// Load from XML data. Return true if successful.
     bool LoadXML(const XMLElement& source) override;
     /// Load from XML data with style. Return true if successful.

--- a/Source/Urho3D/UI/UIElement.h
+++ b/Source/Urho3D/UI/UIElement.h
@@ -141,6 +141,14 @@ public:
     virtual UIElement* LoadChildXML(const XMLElement& childElem, XMLFile* styleFile);
     /// Save as XML data. Return true if successful.
     bool SaveXML(XMLElement& dest) const override;
+    /// Load from JSON data. Return true if successful.
+    bool LoadJSON(const JSONValue& source) override;
+    /// Load from JSON data with style. Return true if successful.
+    virtual bool LoadJSON(const JSONValue& source, XMLFile* styleFile);
+    /// Create a child by loading from JSON data with style. Returns the child element if successful, null if otherwise.
+    virtual UIElement* LoadChildJSON(const JSONValue& childElem, XMLFile* styleFile);
+    /// Save as JSON data. Return true if successful.
+    bool SaveJSON(JSONValue& dest) const override;
 
     /// Perform UI element update.
     virtual void Update(float timeStep);
@@ -212,8 +220,14 @@ public:
     bool LoadXML(Deserializer& source);
     /// Save to an XML file. Return true if successful.
     bool SaveXML(Serializer& dest, const String& indentation = "\t") const;
+    /// Load from a JSON file. Return true if successful.
+    bool LoadJSON(Deserializer& source);
+    /// Save to a JSON file. Return true if successful.
+    bool SaveJSON(Serializer& dest, const String& indentation = "\t") const;
     /// Filter attributes in serialization process.
     bool FilterAttributes(XMLElement& dest) const;
+    /// Filter attributes in serialization process.
+    bool FilterAttributes(JSONValue& dest) const;
 
     /// Set name.
     void SetName(const String& name);
@@ -668,6 +682,10 @@ protected:
     bool FilterUIStyleAttributes(XMLElement& dest, const XMLElement& styleElem) const;
     /// Filter implicit attributes in serialization process.
     virtual bool FilterImplicitAttributes(XMLElement& dest) const;
+    /// Filter UI-style attributes in serialization process.
+    bool FilterUIStyleAttributes(JSONValue& dest, const XMLElement& styleElem) const;
+    /// Filter implicit attributes in serialization process.
+    virtual bool FilterImplicitAttributes(JSONValue& dest) const;
     /// Update anchored size & position. Only called when anchoring is enabled.
     void UpdateAnchoring();
 


### PR DESCRIPTION
Saving to binary for UIElement ends up working not quite like the others, because they rely on going through the data that's been written and removing values that are defined by the set style, which you can't really do with the binary serialization. I could add so that UIElement overrides the saving from Animatable and Serializable in order to make it do this, but it seemed like a lot of work for something that probably won't be used. In practice, the difference is that when saving to binary it saves all attributes, while the other formats remove ones that are defined by the style while leaving ones set in addition to those (if I understand it right).

I wanted the binary writing in the first place just because I didn't really want to write and read from XML to copy UI in app, it just felt wrong. Animatable came as a side thing to that since it's the parent to UIElement. The JSON implementation was also an aside, it just made no sense to me to not have all the implementations (JSON should work the same as XML load and save does).

Also as a last note, Menu has a custom save function as well, but I left it out for now.