### PR TITLE
On OpenGL ES 2.0. npot textures don't support mipmaps.

### DIFF
--- a/Source/Urho3D/Graphics/OpenGL/OGLTexture2D.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLTexture2D.cpp
@@ -479,7 +479,14 @@ bool Texture2D::Create()
     }
 
     levels_ = CheckMaxLevels(width_, height_, requestedLevels_);
-#ifndef GL_ES_VERSION_2_0
+#ifdef GL_ES_VERSION_2_0
+    if (!IsPow2(width_) || !IsPow2(height_))
+    {
+        levels_ = 1;
+        addressModes_[COORD_U] = ADDRESS_CLAMP;
+        addressModes_[COORD_V] = ADDRESS_CLAMP;
+    }
+#else
     glTexParameteri(target_, GL_TEXTURE_BASE_LEVEL, 0);
     glTexParameteri(target_, GL_TEXTURE_MAX_LEVEL, levels_ - 1);
 #endif

--- a/Source/Urho3D/Graphics/Texture.cpp
+++ b/Source/Urho3D/Graphics/Texture.cpp
@@ -270,6 +270,11 @@ unsigned Texture::CheckMaxLevels(int width, int height, int depth, unsigned requ
         return requestedLevels;
 }
 
+bool Texture::IsPow2(int x)
+{
+    return (x & (x - 1)) == 0 && (x != 0);
+}
+
 void Texture::CheckTextureBudget(StringHash type)
 {
     auto* cache = GetSubsystem<ResourceCache>();

--- a/Source/Urho3D/Graphics/Texture.h
+++ b/Source/Urho3D/Graphics/Texture.h
@@ -188,6 +188,8 @@ public:
     static unsigned GetExternalFormat(unsigned format);
     /// Return the data type corresponding to an OpenGL internal format.
     static unsigned GetDataType(unsigned format);
+    /// Check whether texture's size is power of two
+    static bool IsPow2(int size);
 
 protected:
     /// Check whether texture memory budget has been exceeded. Free unused materials in that case to release the texture references.


### PR DESCRIPTION
I'm not sure if this pull request is useful. The 2d platform demo displays wrong graphics on WebGL & OpenGL ES 2.0 devices due to the use of non-power-of-two (npot) textures with mipmaps filter and repeat wrap mode.
By default, standard GLES 2.0 will display black color when using npot texture unless the min filter is set to linear or nearest, and wrap mode is set to clamp to edge.