### PR TITLE
Move Context subsystem removal to Engine class

### DIFF
--- a/Source/Urho3D/Core/Context.cpp
+++ b/Source/Urho3D/Core/Context.cpp
@@ -134,14 +134,6 @@ Context::Context() :
 
 Context::~Context()
 {
-    // Remove subsystems that use SDL in reverse order of construction, so that Graphics can shut down SDL last
-    /// \todo Context should not need to know about subsystems
-    RemoveSubsystem("Audio");
-    RemoveSubsystem("UI");
-    RemoveSubsystem("Input");
-    RemoveSubsystem("Renderer");
-    RemoveSubsystem("Graphics");
-
     subsystems_.Clear();
     factories_.Clear();
 

--- a/Source/Urho3D/Engine/Application.cpp
+++ b/Source/Urho3D/Engine/Application.cpp
@@ -54,7 +54,7 @@ Application::Application(Context* context) :
     engineParameters_ = Engine::ParseParameters(GetArguments());
 
     // Create the Engine, but do not initialize it yet. Subsystems except Graphics & Renderer are registered at this point
-    engine_ = new Engine(context);
+    engine_ = context->RegisterSubsystem<Engine>();
 
     // Subscribe to log messages so that can show errors if ErrorExit() is called with empty message
     SubscribeToEvent(E_LOGMESSAGE, URHO3D_HANDLER(Application, HandleLogMessage));
@@ -86,6 +86,9 @@ int Application::Run()
             engine_->RunFrame();
 
         Stop();
+
+		context_->RemoveSubsystem<Engine>();
+
         // iOS/tvOS will setup a timer for running animation frames so eg. Game Center can run. In this case we do not
         // support calling the Stop() function, as the application will never stop manually
 #else

--- a/Source/Urho3D/Engine/Engine.h
+++ b/Source/Urho3D/Engine/Engine.h
@@ -126,6 +126,48 @@ private:
     /// Actually perform the exit actions.
     void DoExit();
 
+private:
+	/// FileSystem subsystem.
+	SharedPtr<FileSystem> filesystem_;
+#ifdef URHO3D_LOGGING
+	/// Log subsystem.
+	SharedPtr<Log> log_;
+#endif
+#ifdef URHO3D_PROFILING
+	/// Profiler subsystem.
+	SharedPtr<Profiler> profiler_;
+	/// EventProfiler subsystem.
+	SharedPtr<EventProfiler> eventProfiler_;
+#endif
+
+	/// Graphics subsystem
+	SharedPtr<Graphics> graphics_;
+	/// Renderer subsystem.
+	SharedPtr<Renderer> renderer_;
+	/// Input subsystem
+	SharedPtr<Input> input_;
+	/// Audio subsystem
+	SharedPtr<Audio> audio_;
+	/// UI subsystem.
+	SharedPtr<UI> ui_;
+
+	// Time subsystem.
+	SharedPtr<Time> time_;
+	/// WorkQueue subsystem.
+	SharedPtr<WorkQueue> workQueue_;
+	/// ResourceCache subsystem.
+	SharedPtr<ResourceCache> resourceCache_;
+	/// Localization subsystem.
+	SharedPtr<Localization> localization_;
+#ifdef URHO3D_NETWORK
+	/// Network subsystem.
+	SharedPtr<Network> network_;
+#endif
+#ifdef URHO3D_DATABASE
+	/// Database subsystem.
+	SharedPtr<Database> database_;
+#endif
+
     /// Frame update timer.
     HiresTimer frameTimer_;
     /// Previous timesteps for smoothing.

--- a/Source/Urho3D/Engine/Engine.h
+++ b/Source/Urho3D/Engine/Engine.h
@@ -30,6 +30,21 @@ namespace Urho3D
 
 class Console;
 class DebugHud;
+class FileSystem;
+class Log;
+class Profiler;
+class EventProfiler;
+class Graphics;
+class Renderer;
+class Input;
+class Audio;
+class UI;
+class Time;
+class WorkQueue;
+class ResourceCache;
+class Localization;
+class Network;
+class Database;
 
 /// Urho3D engine. Creates the other subsystems.
 class URHO3D_API Engine : public Object


### PR DESCRIPTION
Context should not need to know about subsystems.
Also reduces the number of GetSubsystem() calls.
Does not work on non-blocking main function.