### PR TITLE
Fix clang argument outside range error

### DIFF
--- a/Source/ThirdParty/Bullet/src/LinearMath/btVector3.h
+++ b/Source/ThirdParty/Bullet/src/LinearMath/btVector3.h
@@ -40,7 +40,7 @@ subject to the following restrictions:
 #endif
 
 
-#define BT_SHUFFLE(x,y,z,w) ((w)<<6 | (z)<<4 | (y)<<2 | (x))
+#define BT_SHUFFLE(x,y,z,w) (((w)<<6 | (z)<<4 | (y)<<2 | (x)) & 0xff)
 //#define bt_pshufd_ps( _a, _mask ) (__m128) _mm_shuffle_epi32((__m128i)(_a), (_mask) )
 #define bt_pshufd_ps( _a, _mask ) _mm_shuffle_ps((_a), (_a), (_mask) )
 #define bt_splat3_ps( _a, _i ) bt_pshufd_ps((_a), BT_SHUFFLE(_i,_i,_i, 3) )


### PR DESCRIPTION
When building with a recent version of CLang, the following error is
reported:

> error: argument value 10880 is outside the valid range [0, 255]

The error has been fixed in the upstream project here:
https://github.com/bulletphysics/bullet3/pull/2232