### PR TITLE
Fix Terrain Editor brush #2471

### DIFF
--- a/bin/Data/Scripts/Editor/EditorTerrain.as
+++ b/bin/Data/Scripts/Editor/EditorTerrain.as
@@ -123,6 +123,7 @@ class TerrainEditor
         //SubscribeToEvent(window.GetChild("PaintFoliage", true), "Toggled", "OnEditModeSelected");
         SubscribeToEvent(window.GetChild("CloseButton", true), "Released", "Hide");
         SubscribeToEvent(window.GetChild("CreateTerrainButton", true), "Released", "CreateTerrain");
+        SubscribeToEvent(window.GetChild("ResetButton", true), "Released", "ResetWindow");
         SubscribeToEvent(brushSizeSlider, "DragEnd", "UpdateScaledBrush");
 
         LoadBrushes();
@@ -131,9 +132,35 @@ class TerrainEditor
         brushVisualizer.Create();
     }
 
+    void ResetWindow()
+    {
+        // Reset edit mode to default
+        SetEditMode(TERRAIN_EDITMODE_RAISELOWERHEIGHT, "Raise or lower terrain");
+
+        // Clear selected brush
+        ClearSelectedBrush();
+    }
+
+    void ClearSelectedBrush()
+    {
+        selectedBrush = null;
+        selectedBrushImage = null;
+        scaledSelectedBrushImage = null;
+
+        ListView@ terrainBrushes = window.GetChild("BrushesContainer", true);
+
+        for (uint i = 0; i < terrainBrushes.numItems; ++i)
+        {
+            CheckBox@ checkbox = cast<CheckBox>(terrainBrushes.items[i]);
+            checkbox.checked = false;
+            checkbox.enabled = true;
+        }
+    }
+	
     // Hide the window
     void Hide()
     {
+        HideBrushVisualizer();
         window.visible = false;
     }
 
@@ -149,7 +176,9 @@ class TerrainEditor
             brushVisualizer.Hide();
             return;
         }
-        brushVisualizer.Update(terrainComponent, position, scaledSelectedBrushImage.width / 2);
+
+        if (window.visible == true)
+            brushVisualizer.Update(terrainComponent, position, scaledSelectedBrushImage.width / 2);
     }
 
     // Save all the terrains we have edited
@@ -238,7 +267,7 @@ class TerrainEditor
     void Work(Terrain@ terrainComponent, Vector3 position)
     {
         // Only work if a brush is selected
-        if (selectedBrushImage is null || scaledSelectedBrushImage is null)
+        if (selectedBrushImage is null || scaledSelectedBrushImage is null || window.visible == false)
             return;
 
         SetSceneModified();

--- a/bin/Data/Scripts/Editor/EditorTerrain.as
+++ b/bin/Data/Scripts/Editor/EditorTerrain.as
@@ -160,7 +160,7 @@ class TerrainEditor
     // Hide the window
     void Hide()
     {
-        HideBrushVisualizer();
+        ClearSelectedBrush();
         window.visible = false;
     }
 

--- a/bin/Data/UI/EditorTerrainWindow.xml
+++ b/bin/Data/UI/EditorTerrainWindow.xml
@@ -18,6 +18,21 @@
             <attribute name="Text" value="Terrain Editor" />
             <attribute name="Auto Localizable" value="false" />
         </element>
+        <element type="Button">
+            <attribute name="Name" value="ResetButton" />
+            <attribute name="Min Size" value="16 16" />
+            <attribute name="Max Size" value="16 16" />
+            <attribute name="Pivot" value="0 0" />
+            <attribute name="Layout Mode" value="Horizontal" />
+            <attribute name="Image Rect" value="16 0 32 16" />
+            <attribute name="Border" value="4 4 4 4" />
+            <attribute name="Hover Image Offset" value="0 16" />
+            <attribute name="Pressed Image Offset" value="16 0" />
+            <attribute name="Pressed Child Offset" value="-1 1" />
+            <element type="BorderImage">
+                <attribute name="Image Rect" value="128 32 144 48" />
+            </element>
+        </element>
         <element type="Button" style="CloseButton">
             <attribute name="Name" value="CloseButton" />
         </element>


### PR DESCRIPTION
Now is possible to leave from painting mode on Terrain Editor . You can simply press the button to reset window next to close button on title bar, or close/hide Terrain Editor window.

I added the reset button to Terrain Window, this is the only difference. Button will set edit mode to "Raise or lower terrain" and clear selected brush.

![image](https://user-images.githubusercontent.com/36571229/70394953-c3fd2900-19d8-11ea-94bd-a7b27d55b8b1.png)
