### PR TITLE
Network Changes

### DIFF
--- a/Source/Urho3D/AngelScript/NetworkAPI.cpp
+++ b/Source/Urho3D/AngelScript/NetworkAPI.cpp
@@ -170,7 +170,7 @@ void RegisterNetwork(asIScriptEngine* engine)
     RegisterObject<Network>(engine, "Network");
     engine->RegisterObjectMethod("Network", "bool Connect(const String&in, uint16, Scene@+, const VariantMap&in identity = VariantMap())", asMETHOD(Network, Connect), asCALL_THISCALL);
     engine->RegisterObjectMethod("Network", "void Disconnect(int waitMSec = 0)", asMETHOD(Network, Disconnect), asCALL_THISCALL);
-    engine->RegisterObjectMethod("Network", "bool StartServer(uint16)", asMETHOD(Network, StartServer), asCALL_THISCALL);
+    engine->RegisterObjectMethod("Network", "bool StartServer(uint16, uint maxConnections = 128)", asMETHOD(Network, StartServer), asCALL_THISCALL);
     engine->RegisterObjectMethod("Network", "bool DiscoverHosts(uint16)", asMETHOD(Network, DiscoverHosts), asCALL_THISCALL);
 	engine->RegisterObjectMethod("Network", "bool SetDiscoveryBeacon(const VariantMap&in data = VariantMap())", asMETHOD(Network, SetDiscoveryBeacon), asCALL_THISCALL);
     engine->RegisterObjectMethod("Network", "bool SetPassword(const String&password)", asMETHOD(Network, SetPassword), asCALL_THISCALL);

--- a/Source/Urho3D/LuaScript/pkgs/Network/Network.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Network/Network.pkg
@@ -5,7 +5,7 @@ class Network
     bool Connect(const String address, unsigned short port, Scene* scene, const VariantMap& identity = Variant::emptyVariantMap);
     
     void Disconnect(int waitMSec = 0);
-    bool StartServer(unsigned short port);
+    bool StartServer(unsigned short port, unsigned int maxConnections = 128);
     void StopServer();
     
     void BroadcastMessage(int msgID, bool reliable, bool inOrder, const VectorBuffer& msg, unsigned contentID = 0);

--- a/Source/Urho3D/Network/Connection.cpp
+++ b/Source/Urho3D/Network/Connection.cpp
@@ -38,6 +38,7 @@
 #include "../Scene/SceneEvents.h"
 #include "../Scene/SmoothedTransform.h"
 
+#include <SLikeNet/MessageIdentifiers.h>
 #include <SLikeNet/peerinterface.h>
 #include <SLikeNet/statistics.h>
 
@@ -100,14 +101,6 @@ void Connection::SendMessage(int msgID, bool reliable, bool inOrder, const Vecto
 void Connection::SendMessage(int msgID, bool reliable, bool inOrder, const unsigned char* data, unsigned numBytes,
     unsigned contentID)
 {
-    /* Make sure not to use SLikeNet(RakNet) internal message ID's
-     and since RakNet uses 1 byte message ID's, they cannot exceed 255 limit */
-    if (msgID <= 0x4 || msgID >= 255)
-    {
-        URHO3D_LOGERROR("Can not send message with reserved ID");
-        return;
-    }
-
     if (numBytes && !data)
     {
         URHO3D_LOGERROR("Null pointer supplied for network message data");
@@ -115,7 +108,8 @@ void Connection::SendMessage(int msgID, bool reliable, bool inOrder, const unsig
     }
     
     VectorBuffer buffer;
-    buffer.WriteUByte((unsigned char)msgID);
+    buffer.WriteUByte((unsigned char)DefaultMessageIDTypes::ID_USER_PACKET_ENUM);
+    buffer.WriteUInt((unsigned int)msgID);
     buffer.Write(data, numBytes);
     PacketReliability reliability = reliable ? (inOrder ? RELIABLE_ORDERED : RELIABLE) : (inOrder ? UNRELIABLE_SEQUENCED : UNRELIABLE);
     if (peer_) {

--- a/Source/Urho3D/Network/Network.cpp
+++ b/Source/Urho3D/Network/Network.cpp
@@ -427,7 +427,7 @@ void Network::Disconnect(int waitMSec)
     serverConnection_->Disconnect(waitMSec);
 }
 
-bool Network::StartServer(unsigned short port)
+bool Network::StartServer(unsigned short port, unsigned int maxConnections)
 {
     if (IsServerRunning())
         return true;
@@ -438,11 +438,11 @@ bool Network::StartServer(unsigned short port)
     socket.port = port;
     socket.socketFamily = AF_INET;
     // Startup local connection with max 128 incoming connection(first param) and 1 socket description (third param)
-    SLNet::StartupResult startResult = rakPeer_->Startup(128, &socket, 1);
+    SLNet::StartupResult startResult = rakPeer_->Startup(maxConnections, &socket, 1);
     if (startResult == SLNet::RAKNET_STARTED)
     {
         URHO3D_LOGINFO("Started server on port " + String(port));
-        rakPeer_->SetMaximumIncomingConnections(128);
+        rakPeer_->SetMaximumIncomingConnections(maxConnections);
         isServer_ = true;
         rakPeer_->SetOccasionalPing(true);
         rakPeer_->SetUnreliableTimeout(1000);

--- a/Source/Urho3D/Network/Network.h
+++ b/Source/Urho3D/Network/Network.h
@@ -65,7 +65,7 @@ public:
     /// Disconnect the connection to the server. If wait time is non-zero, will block while waiting for disconnect to finish.
     void Disconnect(int waitMSec = 0);
     /// Start a server on a port using UDP protocol. Return true if successful.
-    bool StartServer(unsigned short port);
+    bool StartServer(unsigned short port, unsigned int maxConnections = 128);
     /// Stop the server.
     void StopServer();
     /// Start NAT punchtrough client to allow remote connections.


### PR DESCRIPTION
- Now you can send messages through urho networking using message ID as unsigned int, instead of byte (only urho messages, SLiketNet messages keep the same thing).
- Is possible to set the max connections of Urho server, on **Network::StartServer** function. Before was allowed only 128 connections, and you couldn't change it.
