### PR TITLE
Fix Progress Bar direction #2050

### DIFF
--- a/Source/Urho3D/UI/ProgressBar.cpp
+++ b/Source/Urho3D/UI/ProgressBar.cpp
@@ -155,7 +155,7 @@ void ProgressBar::UpdateProgressBar()
             auto loadingBarLength = (int) Max((float) GetHeight() * value_ / range_,
                                              (float) (border.top_ + border.bottom_));
             knob_->SetSize(GetWidth(), loadingBarLength);
-            knob_->SetPosition(0, Clamp(0, 0, GetHeight() - knob_->GetHeight()));
+            knob_->SetPosition(0, Clamp(GetHeight() - knob_->GetHeight(), 0, GetHeight() - knob_->GetHeight()));
         }
     }
     else


### PR DESCRIPTION
Progress bar in vertical mode was scaling from top to bottom, the correct way on this mode is from bottom to top.