### PR TITLE
Add check for Pushing *this to PODVector

### DIFF
--- a/Source/Urho3D/Container/Vector.h
+++ b/Source/Urho3D/Container/Vector.h
@@ -850,9 +850,11 @@ public:
     /// Add another vector at the end.
     void Push(const PODVector<T>& vector)
     {
-        unsigned oldSize = size_;
-        Resize(size_ + vector.size_);
-        CopyElements(Buffer() + oldSize, vector.Buffer(), (this == &vector) ? oldSize : vector.size_);
+        // Obtain the size before resizing, in case the other vector is another reference to this vector
+        unsigned thisSize = size_;
+        unsigned vectorSize = vector.size_;
+        Resize(thisSize + vectorSize);
+        CopyElements(Buffer() + thisSize, vector.Buffer(), vectorSize);
     }
 
     /// Remove the last element.

--- a/Source/Urho3D/Container/Vector.h
+++ b/Source/Urho3D/Container/Vector.h
@@ -852,7 +852,7 @@ public:
     {
         unsigned oldSize = size_;
         Resize(size_ + vector.size_);
-        CopyElements(Buffer() + oldSize, vector.Buffer(), vector.size_);
+        CopyElements(Buffer() + oldSize, vector.Buffer(), (this == &vector) ? oldSize : vector.size_);
     }
 
     /// Remove the last element.


### PR DESCRIPTION
My first attempt at a solution to #2563. I'm certainly open to other options if anyone can think of a better approach to this. I'm pretty sure the issues described in #1556 may still affect this when pushing a single item from the old vector.

Do you think it might be better to go with a more complete change like was done with PR #1561?