### PR TITLE
Send Mouse Clicks on Event

### DIFF
--- a/Source/Urho3D/Input/Input.cpp
+++ b/Source/Urho3D/Input/Input.cpp
@@ -1646,9 +1646,9 @@ void Input::ResetState()
     ResetTouches();
 
     // Use SetMouseButton() to reset the state so that mouse events will be sent properly
-    SetMouseButton(MOUSEB_LEFT, false);
-    SetMouseButton(MOUSEB_RIGHT, false);
-    SetMouseButton(MOUSEB_MIDDLE, false);
+    SetMouseButton(MOUSEB_LEFT, false, 0);
+    SetMouseButton(MOUSEB_RIGHT, false, 0);
+    SetMouseButton(MOUSEB_MIDDLE, false, 0);
 
     mouseMove_ = IntVector2::ZERO;
     mouseMoveWheel_ = 0;
@@ -1744,7 +1744,7 @@ void Input::SendInputFocusEvent()
     SendEvent(E_INPUTFOCUS, eventData);
 }
 
-void Input::SetMouseButton(MouseButton button, bool newState)
+void Input::SetMouseButton(MouseButton button, bool newState, int clicks)
 {
     if (newState)
     {
@@ -1767,6 +1767,7 @@ void Input::SetMouseButton(MouseButton button, bool newState)
     eventData[P_BUTTON] = button;
     eventData[P_BUTTONS] = (unsigned)mouseButtonDown_;
     eventData[P_QUALIFIERS] = (unsigned)GetQualifiers();
+    eventData[P_CLICKS] = clicks;
     SendEvent(newState ? E_MOUSEBUTTONDOWN : E_MOUSEBUTTONUP, eventData);
 }
 
@@ -1934,7 +1935,7 @@ void Input::HandleSDLEvent(void* sdlEvent)
         if (!touchEmulation_)
         {
             const auto mouseButton = static_cast<MouseButton>(1u << (evt.button.button - 1u));  // NOLINT(misc-misplaced-widening-cast)
-            SetMouseButton(mouseButton, true);
+            SetMouseButton(mouseButton, true, evt.button.clicks);
         }
         else
         {
@@ -1960,7 +1961,7 @@ void Input::HandleSDLEvent(void* sdlEvent)
         if (!touchEmulation_)
         {
             const auto mouseButton = static_cast<MouseButton>(1u << (evt.button.button - 1u));  // NOLINT(misc-misplaced-widening-cast)
-            SetMouseButton(mouseButton, false);
+            SetMouseButton(mouseButton, false, evt.button.clicks);
         }
         else
         {

--- a/Source/Urho3D/Input/Input.h
+++ b/Source/Urho3D/Input/Input.h
@@ -326,7 +326,7 @@ private:
     /// Send an input focus or window minimization change event.
     void SendInputFocusEvent();
     /// Handle a mouse button change.
-    void SetMouseButton(MouseButton button, bool newState);
+    void SetMouseButton(MouseButton button, bool newState, int clicks);
     /// Handle a key change.
     void SetKey(Key key, Scancode scancode, bool newState);
     /// Handle mouse wheel change.

--- a/Source/Urho3D/Input/InputEvents.h
+++ b/Source/Urho3D/Input/InputEvents.h
@@ -35,6 +35,7 @@ URHO3D_EVENT(E_MOUSEBUTTONDOWN, MouseButtonDown)
     URHO3D_PARAM(P_BUTTON, Button);                // int
     URHO3D_PARAM(P_BUTTONS, Buttons);              // int
     URHO3D_PARAM(P_QUALIFIERS, Qualifiers);        // int
+    URHO3D_PARAM(P_CLICKS, Clicks);                // int
 }
 
 /// Mouse button released.


### PR DESCRIPTION
Get the clicks from SDL_MouseButtonEvent and send it on Urho Event (E_MOUSEBUTTONDOWN and E_MOUSEBUTTONUP).

This is useful for detect double click (or more) without use UI Event.