### PR TITLE
Improve StringHash Saving

### DIFF
--- a/Source/Urho3D/Resource/JSONValue.cpp
+++ b/Source/Urho3D/Resource/JSONValue.cpp
@@ -567,7 +567,7 @@ void JSONValue::SetVariantMap(const VariantMap& variantMap, Context* context)
 {
     SetType(JSON_OBJECT);
     for (VariantMap::ConstIterator i = variantMap.Begin(); i != variantMap.End(); ++i)
-        (*this)[i->first_.ToString()].SetVariant(i->second_);
+        (*this)[i->first_.ToString()].SetVariant(i->second_, context);
 }
 
 VariantMap JSONValue::GetVariantMap() const

--- a/Source/Urho3D/Resource/JSONValue.cpp
+++ b/Source/Urho3D/Resource/JSONValue.cpp
@@ -52,6 +52,9 @@ static const char* numberTypeNames[] =
     nullptr
 };
 
+// The marker that indicates that we have a string for the VariantMap key as opposed to a hexadecimal number. Could be anything other than an allowed base-16 digit.
+static const char variantMapStringKeyMarker = '$';
+
 const JSONValue JSONValue::EMPTY;
 const JSONArray JSONValue::emptyArray { };
 const JSONObject JSONValue::emptyObject;
@@ -567,7 +570,10 @@ void JSONValue::SetVariantMap(const VariantMap& variantMap, Context* context)
 {
     SetType(JSON_OBJECT);
     for (VariantMap::ConstIterator i = variantMap.Begin(); i != variantMap.End(); ++i)
-        (*this)[i->first_.ToString()].SetVariant(i->second_, context);
+        if (i->first_.GetGlobalStringHashRegister() && !i->first_.Reverse().Empty())
+            (*this)[variantMapStringKeyMarker + i->first_.Reverse()].SetVariant(i->second_, context);
+        else
+            (*this)[i->first_.ToString()].SetVariant(i->second_, context);
 }
 
 VariantMap JSONValue::GetVariantMap() const
@@ -581,8 +587,12 @@ VariantMap JSONValue::GetVariantMap() const
 
     for (ConstJSONObjectIterator i = Begin(); i != End(); ++i)
     {
-        /// \todo Ideally this should allow any strings, but for now the convention is that the keys need to be hexadecimal StringHashes
-        StringHash key(ToUInt(i->first_, 16));
+        // Keys are allowed to be hexadecimal string hash values or arbitrary strings prefixed with $
+        StringHash key;
+        if (!i->first_.Empty() && i->first_[0] == variantMapStringKeyMarker)
+            key = StringHash(i->first_.Substring(1));
+        else
+            key = ToUInt(i->first_, 16);
         Variant variant = i->second_.GetVariant();
         variantMap[key] = variant;
     }

--- a/Source/Urho3D/Resource/JSONValue.h
+++ b/Source/Urho3D/Resource/JSONValue.h
@@ -29,6 +29,8 @@
 namespace Urho3D
 {
 
+class Context;
+
 /// JSON value type.
 enum JSONValueType
 {

--- a/Source/Urho3D/Resource/XMLElement.cpp
+++ b/Source/Urho3D/Resource/XMLElement.cpp
@@ -513,7 +513,11 @@ bool XMLElement::SetVariantMap(const VariantMap& value)
         XMLElement variantElem = CreateChild("variant");
         if (!variantElem)
             return false;
-        variantElem.SetUInt("hash", i->first_.Value());
+
+        if (i->first_.GetGlobalStringHashRegister() && !i->first_.Reverse().Empty())
+            variantElem.SetAttribute("name", i->first_.Reverse());
+        else
+            variantElem.SetUInt("hash", i->first_.Value());
         variantElem.SetVariant(i->second_);
     }
 

--- a/Source/Urho3D/Scene/ValueAnimation.cpp
+++ b/Source/Urho3D/Scene/ValueAnimation.cpp
@@ -145,7 +145,10 @@ bool ValueAnimation::SaveXML(XMLElement& dest) const
         const VAnimEventFrame& eventFrame = eventFrames_[i];
         XMLElement eventFrameElem = dest.CreateChild("eventframe");
         eventFrameElem.SetFloat("time", eventFrame.time_);
-        eventFrameElem.SetUInt("eventtype", eventFrame.eventType_.Value());
+        if (StringHash::GetGlobalStringHashRegister() && !eventFrame.eventType_.Reverse().Empty())
+            eventFrameElem.SetAttribute("eventname",eventFrame.eventType_.Reverse());
+        else
+            eventFrameElem.SetUInt("eventtype", eventFrame.eventType_.Value());
         eventFrameElem.CreateChild("eventdata").SetVariantMap(eventFrame.eventData_);
     }
 
@@ -219,7 +222,10 @@ bool ValueAnimation::SaveJSON(JSONValue& dest) const
         const VAnimEventFrame& eventFrame = eventFrames_[i];
         JSONValue eventFrameVal;
         eventFrameVal.Set("time", eventFrame.time_);
-        eventFrameVal.Set("eventtype", eventFrame.eventType_.Value());
+        if (StringHash::GetGlobalStringHashRegister() && !eventFrame.eventType_.Reverse().Empty())
+            eventFrameVal.Set("eventname",eventFrame.eventType_.Reverse());
+        else
+            eventFrameVal.Set("eventtype", eventFrame.eventType_.Value());
         JSONValue eventDataVal;
         eventDataVal.SetVariantMap(eventFrame.eventData_,GetContext());
         eventFrameVal.Set("eventdata", eventDataVal);

--- a/Source/Urho3D/Scene/ValueAnimation.cpp
+++ b/Source/Urho3D/Scene/ValueAnimation.cpp
@@ -112,7 +112,11 @@ bool ValueAnimation::LoadXML(const XMLElement& source)
     while (eventFrameElem)
     {
         float time = eventFrameElem.GetFloat("time");
-        unsigned eventType = eventFrameElem.GetUInt("eventtype");
+        unsigned eventType = 0;
+        if (eventFrameElem.HasAttribute("eventname"))
+            eventType = StringHash(eventFrameElem.GetAttributeCString("eventname")).Value();
+        else
+            eventType = eventFrameElem.GetUInt("eventtype");
         VariantMap eventData = eventFrameElem.GetChild("eventdata").GetVariantMap();
 
         SetEventFrame(time, StringHash(eventType), eventData);
@@ -176,7 +180,11 @@ bool ValueAnimation::LoadJSON(const JSONValue& source)
     {
         const JSONValue& eventFrameVal = eventFramesArray[i];
         float time = eventFrameVal.Get("time").GetFloat();
-        unsigned eventType = eventFrameVal.Get("eventtype").GetUInt();
+        unsigned eventType = 0;
+        if (eventFrameVal.Contains("eventname"))
+            eventType = StringHash(eventFrameVal.GetCString()).Value();
+        else
+            eventType = eventFrameVal.Get("eventtype").GetUInt();
         VariantMap eventData = eventFrameVal.Get("eventdata").GetVariantMap();
         SetEventFrame(time, StringHash(eventType), eventData);
     }

--- a/Source/Urho3D/Scene/ValueAnimation.cpp
+++ b/Source/Urho3D/Scene/ValueAnimation.cpp
@@ -198,7 +198,7 @@ bool ValueAnimation::SaveJSON(JSONValue& dest) const
         JSONValue keyFrameVal;
         keyFrameVal.Set("time", keyFrame.time_);
         JSONValue valueVal;
-        valueVal.SetVariant(keyFrame.value_);
+        valueVal.SetVariant(keyFrame.value_,GetContext());
         keyFrameVal.Set("value", valueVal);
         keyFramesArray.Push(keyFrameVal);
     }
@@ -213,7 +213,7 @@ bool ValueAnimation::SaveJSON(JSONValue& dest) const
         eventFrameVal.Set("time", eventFrame.time_);
         eventFrameVal.Set("eventtype", eventFrame.eventType_.Value());
         JSONValue eventDataVal;
-        eventDataVal.SetVariantMap(eventFrame.eventData_);
+        eventDataVal.SetVariantMap(eventFrame.eventData_,GetContext());
         eventFrameVal.Set("eventdata", eventDataVal);
 
         eventFramesArray.Push(eventFrameVal);


### PR DESCRIPTION
Since we have the optional ability to compile support for a reverse StringHash lookup, I added the ability to save the string version rather than just the hash for VariantMaps and events in ValueAnimations. Without URHO3D_HASH_DEBUG enabled, reading from these strings is still supported, but saving will simply be done by the hash value instead.

As part of this I also added support for reading a VariantMap from JSON with arbitrary string keys, they simply have to be prefixed with $ to distinguish, for example "BAD" as a string from 0xBAD as a hexadecimal number. I'm open to a different marker besides $, I just like it as I believe it would be allowed in Javascript, it's easy to type, and it would generally be reasonably clear that it's a marker and not part of the string, plus $ looks a lot like S for String.