### PR TITLE
Fixed warning: enumeral and non-enumeral type…

### DIFF
--- a/Source/Urho3D/Input/Input.h
+++ b/Source/Urho3D/Input/Input.h
@@ -103,7 +103,7 @@ struct JoystickState
     float GetAxisPosition(unsigned index) const { return index < axes_.Size() ? axes_[index] : 0.0f; }
 
     /// Return hat position.
-    int GetHatPosition(unsigned index) const { return index < hats_.Size() ? hats_[index] : HAT_CENTER; }
+    int GetHatPosition(unsigned index) const { return index < hats_.Size() ? hats_[index] : int(HAT_CENTER); }
 
     /// SDL joystick.
     SDL_Joystick* joystick_{};


### PR DESCRIPTION
…in conditional expression [-Wextra]

Urho3D/Input/Input.h:106

 int GetHatPosition(unsigned index) const { return index < hats_.Size() ? hats_[index] : HAT_CENTER; }

gcc (Debian 8.3.0-6) 8.3.0