### PR TITLE
Console message type style fixed

### DIFF
--- a/Source/Urho3D/Engine/Console.cpp
+++ b/Source/Urho3D/Engine/Console.cpp
@@ -51,6 +51,7 @@ static const int DEFAULT_HISTORY_SIZE = 16;
 
 const char* logStyles[] =
 {
+    "ConsoleTraceText",
     "ConsoleDebugText",
     "ConsoleInfoText",
     "ConsoleWarningText",

--- a/bin/Data/UI/DefaultStyle.xml
+++ b/bin/Data/UI/DefaultStyle.xml
@@ -255,6 +255,9 @@
     <element type="ConsoleErrorText" style="ConsoleText" auto="false">
         <attribute name="Color" value="1 0 0 1" />
     </element>
+    <element type="ConsoleTraceText" style="ConsoleText" auto="false">
+        <attribute name="Color" value="0.5 0.5 0.5 1" />
+    </element>
     <element type="ConsoleDebugText" style="ConsoleText" auto="false">
         <attribute name="Color" value="1 0.6 0 1" />
     </element>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/7426555/73590161-f82c2c00-44e7-11ea-872b-e4cc93d726ce.png)

After:
![image](https://user-images.githubusercontent.com/7426555/73590189-44776c00-44e8-11ea-836b-0e2fa920b059.png)
