### PR TITLE
Upgrade to support spine runtime 3.7 and above

### DIFF
--- a/Source/Urho3D/Urho2D/AnimatedSprite2D.cpp
+++ b/Source/Urho3D/Urho2D/AnimatedSprite2D.cpp
@@ -306,6 +306,8 @@ void AnimatedSprite2D::UpdateSpineAnimation(float timeStep)
     worldBoundingBoxDirty_ = true;
 }
 
+// This enum used to be defined in spine/RegionAttachment.h but it got moved inside RegionAttachment.c so it's no longer accessible.
+// It's required because AnimatedSprite2D::UpdateSourceBatchesSpine() references its values (SP_VERTEX_*)
 typedef enum {
 	SP_VERTEX_X1 = 0, SP_VERTEX_Y1, SP_VERTEX_X2, SP_VERTEX_Y2, SP_VERTEX_X3, SP_VERTEX_Y3, SP_VERTEX_X4, SP_VERTEX_Y4
 } spVertexIndex;

--- a/Source/Urho3D/Urho2D/AnimatedSprite2D.cpp
+++ b/Source/Urho3D/Urho2D/AnimatedSprite2D.cpp
@@ -119,8 +119,8 @@ void AnimatedSprite2D::SetAnimationSet(AnimationSet2D* animationSet)
 
         // Create skeleton
         skeleton_ = spSkeleton_create(skeletonData);
-        skeleton_->flipX = flipX_;
-        skeleton_->flipY = flipY_;
+        skeleton_->scaleX = flipX_ ? -1 : 1;
+        skeleton_->scaleY = flipY_ ? -1 : 1;
 
         if (skeleton_->data->skinsCount > 0)
         {
@@ -294,8 +294,8 @@ void AnimatedSprite2D::UpdateSpineAnimation(float timeStep)
 {
     timeStep *= speed_;
 
-    skeleton_->flipX = flipX_;
-    skeleton_->flipY = flipY_;
+    skeleton_->scaleX = flipX_ ? -1 : 1;
+    skeleton_->scaleY = flipY_ ? -1 : 1;
 
     spSkeleton_update(skeleton_, timeStep);
     spAnimationState_update(animationState_, timeStep);
@@ -305,6 +305,10 @@ void AnimatedSprite2D::UpdateSpineAnimation(float timeStep)
     sourceBatchesDirty_ = true;
     worldBoundingBoxDirty_ = true;
 }
+
+typedef enum {
+	SP_VERTEX_X1 = 0, SP_VERTEX_Y1, SP_VERTEX_X2, SP_VERTEX_Y2, SP_VERTEX_X3, SP_VERTEX_Y3, SP_VERTEX_X4, SP_VERTEX_Y4
+} spVertexIndex;
 
 void AnimatedSprite2D::UpdateSourceBatchesSpine()
 {
@@ -323,15 +327,15 @@ void AnimatedSprite2D::UpdateSourceBatchesSpine()
         if (!attachment)
             continue;
 
-        unsigned color = Color(color_.r_ * slot->r,
-            color_.g_ * slot->g,
-            color_.b_ * slot->b,
-            color_.a_ * slot->a).ToUInt();
+        unsigned color = Color(color_.r_ * slot->color.r,
+            color_.g_ * slot->color.g,
+            color_.b_ * slot->color.b,
+            color_.a_ * slot->color.a).ToUInt();
 
         if (attachment->type == SP_ATTACHMENT_REGION)
         {
             spRegionAttachment* region = (spRegionAttachment*)attachment;
-            spRegionAttachment_computeWorldVertices(region, slot->bone, slotVertices);
+            spRegionAttachment_computeWorldVertices(region, slot->bone, slotVertices, 0, 2);
 
             Vertex2D vertices[4];
             vertices[0].position_ = worldTransform * Vector3(slotVertices[SP_VERTEX_X1], slotVertices[SP_VERTEX_Y1]);
@@ -354,13 +358,13 @@ void AnimatedSprite2D::UpdateSourceBatchesSpine()
             sourceBatches_[0].vertices_.Push(vertices[2]);
             sourceBatches_[0].vertices_.Push(vertices[3]);
         }
-        else if (attachment->type == SP_ATTACHMENT_MESH)
+        else if (attachment->type == SP_ATTACHMENT_MESH || attachment->type == SP_ATTACHMENT_LINKED_MESH)
         {
             spMeshAttachment* mesh = (spMeshAttachment*)attachment;
-            if (mesh->verticesCount > SLOT_VERTEX_COUNT_MAX)
+            if (mesh->super.verticesCount > SLOT_VERTEX_COUNT_MAX)
                 continue;
 
-            spMeshAttachment_computeWorldVertices(mesh, slot, slotVertices);
+            spVertexAttachment_computeWorldVertices(&mesh->super, slot, 0, mesh->super.verticesCount, slotVertices, 0, 2);
 
             Vertex2D vertex;
             vertex.color_ = color;
@@ -369,28 +373,6 @@ void AnimatedSprite2D::UpdateSourceBatchesSpine()
                 int index = mesh->triangles[j] << 1;
                 vertex.position_ = worldTransform * Vector3(slotVertices[index], slotVertices[index + 1]);
                 vertex.uv_ = Vector2(mesh->uvs[index], mesh->uvs[index + 1]);
-
-                sourceBatches_[0].vertices_.Push(vertex);
-                // Add padding vertex
-                if (j % 3 == 2)
-                    sourceBatches_[0].vertices_.Push(vertex);
-            }
-        }
-        else if (attachment->type == SP_ATTACHMENT_SKINNED_MESH)
-        {
-            spSkinnedMeshAttachment* skinnedMesh = (spSkinnedMeshAttachment*)attachment;
-            if (skinnedMesh->uvsCount > SLOT_VERTEX_COUNT_MAX)
-                continue;
-
-            spSkinnedMeshAttachment_computeWorldVertices(skinnedMesh, slot, slotVertices);
-
-            Vertex2D vertex;
-            vertex.color_ = color;
-            for (int j = 0; j < skinnedMesh->trianglesCount; ++j)
-            {
-                int index = skinnedMesh->triangles[j] << 1;
-                vertex.position_ = worldTransform * Vector3(slotVertices[index], slotVertices[index + 1]);
-                vertex.uv_ = Vector2(skinnedMesh->uvs[index], skinnedMesh->uvs[index + 1]);
 
                 sourceBatches_[0].vertices_.Push(vertex);
                 // Add padding vertex


### PR DESCRIPTION
I updated **AnimatedSprite2D.cpp** to support Spine version 3.7 and 3.8

In a nutshell:

- **flipX/Y** became **scaleX/Y**
Followed instructions at http://esotericsoftware.com/forum/Spine-Unity-3-6-to-3-7-Upgrade-Guide-10446

- **spRegionAttachment_computeWorldVertices** gets two additional parameters and **spVertexAttachment_computeWorldVertices** gets replaced by **spMeshAttachment_computeWorldVertice**
Followed instructions at http://esotericsoftware.com/forum/Upgrading-QML-plugin-to-latest-c-runtime-9419

- **SP_ATTACHMENT_SKINNED_MESH** goes away.
Followed instructions at http://zh.esotericsoftware.com/forum/Updating-to-latest-spine-c-runtime-6720

- Other structural changes that were easy to follow (e.g. **slot->a/r/g/b** is **slot->color.a/r/g/b**)

I also created a sample cloning **33_Urho2DSpriterAnimation** but since the runtime is not included with Urho3D it's probably not a good idea to include it. I created a separate repo for it, and included the runtime files for your convenience: https://github.com/royalstream/Urho3D-spine37up

