### PR TITLE
(DISCARDED) FileWatcher extended with minimum modification. (Currently only implemented for Windows)

### DIFF
--- a/Source/Urho3D/Resource/ResourceCache.cpp
+++ b/Source/Urho3D/Resource/ResourceCache.cpp
@@ -125,7 +125,7 @@ bool ResourceCache::AddResourceDir(const String& pathName, unsigned priority)
     if (autoReloadResources_)
     {
         SharedPtr<FileWatcher> watcher(new FileWatcher(context_));
-        watcher->StartWatching(fixedPath, true);
+        watcher->StartWatching(fixedPath, true, false);
         fileWatchers_.Push(watcher);
     }
 
@@ -447,7 +447,7 @@ void ResourceCache::SetAutoReloadResources(bool enable)
             for (unsigned i = 0; i < resourceDirs_.Size(); ++i)
             {
                 SharedPtr<FileWatcher> watcher(new FileWatcher(context_));
-                watcher->StartWatching(resourceDirs_[i], true);
+                watcher->StartWatching(resourceDirs_[i], true, false);
                 fileWatchers_.Push(watcher);
             }
         }
@@ -1074,17 +1074,17 @@ void ResourceCache::HandleBeginFrame(StringHash eventType, VariantMap& eventData
 {
     for (unsigned i = 0; i < fileWatchers_.Size(); ++i)
     {
-        String fileName;
-        while (fileWatchers_[i]->GetNextChange(fileName))
+        FileChange change;
+        while (fileWatchers_[i]->GetNextChange(change))
         {
-            ReloadResourceWithDependencies(fileName);
+            ReloadResourceWithDependencies(change.fileName_);
 
             // Finally send a general file changed event even if the file was not a tracked resource
             using namespace FileChanged;
 
             VariantMap& eventData = GetEventDataMap();
-            eventData[P_FILENAME] = fileWatchers_[i]->GetPath() + fileName;
-            eventData[P_RESOURCENAME] = fileName;
+            eventData[P_FILENAME] = fileWatchers_[i]->GetPath() + change.fileName_;
+            eventData[P_RESOURCENAME] = change.fileName_;
             SendEvent(E_FILECHANGED, eventData);
         }
     }


### PR DESCRIPTION
Extended `FileWatcher` with minimum modification to current `FileWatcher` and resource-auto-reload function. Only Windows implementation has been done.