### PR TITLE
Add MaxSuspensionForce to RaycastVehicle

### DIFF
--- a/Source/Urho3D/AngelScript/PhysicsAPI.cpp
+++ b/Source/Urho3D/AngelScript/PhysicsAPI.cpp
@@ -351,7 +351,7 @@ void RegisterRaycastVehicleAPI(asIScriptEngine* engine)
     engine->RegisterObjectMethod("RaycastVehicle", "void UpdateWheelTransform(int, bool)", asMETHOD(RaycastVehicle, UpdateWheelTransform), asCALL_THISCALL);
     engine->RegisterObjectMethod("RaycastVehicle", "void SetSteeringValue(int, float)", asMETHOD(RaycastVehicle, SetSteeringValue), asCALL_THISCALL);
     engine->RegisterObjectMethod("RaycastVehicle", "void SetWheelSuspensionStiffness(int, float)", asMETHOD(RaycastVehicle, SetWheelSuspensionStiffness), asCALL_THISCALL);
-	engine->RegisterObjectMethod("RaycastVehicle", "void SetWheelMaxSuspensionForce(int, float)", asMETHOD(RaycastVehicle, SetWheelMaxSuspensionForce), asCALL_THISCALL);
+    engine->RegisterObjectMethod("RaycastVehicle", "void SetWheelMaxSuspensionForce(int, float)", asMETHOD(RaycastVehicle, SetWheelMaxSuspensionForce), asCALL_THISCALL);
     engine->RegisterObjectMethod("RaycastVehicle", "void SetWheelDampingRelaxation(int, float)", asMETHOD(RaycastVehicle, SetWheelDampingRelaxation), asCALL_THISCALL);
     engine->RegisterObjectMethod("RaycastVehicle", "void SetWheelDampingCompression(int, float)", asMETHOD(RaycastVehicle, SetWheelDampingCompression), asCALL_THISCALL);
     engine->RegisterObjectMethod("RaycastVehicle", "void SetWheelFrictionSlip(int, float)", asMETHOD(RaycastVehicle, SetWheelFrictionSlip), asCALL_THISCALL);
@@ -374,7 +374,7 @@ void RegisterRaycastVehicleAPI(asIScriptEngine* engine)
     engine->RegisterObjectMethod("RaycastVehicle", "Node@+ GetWheelNode(int)", asMETHOD(RaycastVehicle, GetWheelNode), asCALL_THISCALL);
     engine->RegisterObjectMethod("RaycastVehicle", "float GetSteeringValue(int)", asMETHOD(RaycastVehicle, GetSteeringValue), asCALL_THISCALL);
     engine->RegisterObjectMethod("RaycastVehicle", "float GetWheelSuspensionStiffness(int)", asMETHOD(RaycastVehicle, GetWheelSuspensionStiffness), asCALL_THISCALL);
-	engine->RegisterObjectMethod("RaycastVehicle", "float GetWheelMaxSuspensionForce(int)", asMETHOD(RaycastVehicle, GetWheelMaxSuspensionForce), asCALL_THISCALL);
+    engine->RegisterObjectMethod("RaycastVehicle", "float GetWheelMaxSuspensionForce(int)", asMETHOD(RaycastVehicle, GetWheelMaxSuspensionForce), asCALL_THISCALL);
     engine->RegisterObjectMethod("RaycastVehicle", "float GetWheelDampingRelaxation(int)", asMETHOD(RaycastVehicle, GetWheelDampingRelaxation), asCALL_THISCALL);
     engine->RegisterObjectMethod("RaycastVehicle", "float GetWheelDampingCompression(int)", asMETHOD(RaycastVehicle, GetWheelDampingCompression), asCALL_THISCALL);
     engine->RegisterObjectMethod("RaycastVehicle", "float GetWheelFrictionSlip(int)", asMETHOD(RaycastVehicle, GetWheelFrictionSlip), asCALL_THISCALL);

--- a/Source/Urho3D/AngelScript/PhysicsAPI.cpp
+++ b/Source/Urho3D/AngelScript/PhysicsAPI.cpp
@@ -351,6 +351,7 @@ void RegisterRaycastVehicleAPI(asIScriptEngine* engine)
     engine->RegisterObjectMethod("RaycastVehicle", "void UpdateWheelTransform(int, bool)", asMETHOD(RaycastVehicle, UpdateWheelTransform), asCALL_THISCALL);
     engine->RegisterObjectMethod("RaycastVehicle", "void SetSteeringValue(int, float)", asMETHOD(RaycastVehicle, SetSteeringValue), asCALL_THISCALL);
     engine->RegisterObjectMethod("RaycastVehicle", "void SetWheelSuspensionStiffness(int, float)", asMETHOD(RaycastVehicle, SetWheelSuspensionStiffness), asCALL_THISCALL);
+	engine->RegisterObjectMethod("RaycastVehicle", "void SetWheelMaxSuspensionForce(int, float)", asMETHOD(RaycastVehicle, SetWheelMaxSuspensionForce), asCALL_THISCALL);
     engine->RegisterObjectMethod("RaycastVehicle", "void SetWheelDampingRelaxation(int, float)", asMETHOD(RaycastVehicle, SetWheelDampingRelaxation), asCALL_THISCALL);
     engine->RegisterObjectMethod("RaycastVehicle", "void SetWheelDampingCompression(int, float)", asMETHOD(RaycastVehicle, SetWheelDampingCompression), asCALL_THISCALL);
     engine->RegisterObjectMethod("RaycastVehicle", "void SetWheelFrictionSlip(int, float)", asMETHOD(RaycastVehicle, SetWheelFrictionSlip), asCALL_THISCALL);
@@ -373,6 +374,7 @@ void RegisterRaycastVehicleAPI(asIScriptEngine* engine)
     engine->RegisterObjectMethod("RaycastVehicle", "Node@+ GetWheelNode(int)", asMETHOD(RaycastVehicle, GetWheelNode), asCALL_THISCALL);
     engine->RegisterObjectMethod("RaycastVehicle", "float GetSteeringValue(int)", asMETHOD(RaycastVehicle, GetSteeringValue), asCALL_THISCALL);
     engine->RegisterObjectMethod("RaycastVehicle", "float GetWheelSuspensionStiffness(int)", asMETHOD(RaycastVehicle, GetWheelSuspensionStiffness), asCALL_THISCALL);
+	engine->RegisterObjectMethod("RaycastVehicle", "float GetWheelMaxSuspensionForce(int)", asMETHOD(RaycastVehicle, GetWheelMaxSuspensionForce), asCALL_THISCALL);
     engine->RegisterObjectMethod("RaycastVehicle", "float GetWheelDampingRelaxation(int)", asMETHOD(RaycastVehicle, GetWheelDampingRelaxation), asCALL_THISCALL);
     engine->RegisterObjectMethod("RaycastVehicle", "float GetWheelDampingCompression(int)", asMETHOD(RaycastVehicle, GetWheelDampingCompression), asCALL_THISCALL);
     engine->RegisterObjectMethod("RaycastVehicle", "float GetWheelFrictionSlip(int)", asMETHOD(RaycastVehicle, GetWheelFrictionSlip), asCALL_THISCALL);

--- a/Source/Urho3D/LuaScript/pkgs/Physics/RaycastVehicle.pkg
+++ b/Source/Urho3D/LuaScript/pkgs/Physics/RaycastVehicle.pkg
@@ -11,6 +11,7 @@ class RaycastVehicle : public LogicComponent
     void UpdateWheelTransform(int wheel, bool interpolated);
     void SetSteeringValue(int wheel, float steeringValue);
     void SetWheelSuspensionStiffness(int wheel, float stiffness);
+    void SetWheelMaxSuspensionForce(int wheel, float force);
     void SetWheelDampingRelaxation(int wheel, float damping);
     void SetWheelDampingCompression(int wheel, float compression);
     void SetWheelFrictionSlip(int wheel, float slip);
@@ -38,6 +39,7 @@ class RaycastVehicle : public LogicComponent
     Node *GetWheelNode(int wheel);
     float GetSteeringValue(int wheel) const;
     float GetWheelSuspensionStiffness(int wheel) const;
+    float GetWheelMaxSuspensionForce(int wheel) const;
     float GetWheelDampingRelaxation(int wheel) const;
     float GetWheelDampingCompression(int wheel) const;
     float GetWheelFrictionSlip(int wheel) const;

--- a/Source/Urho3D/Physics/RaycastVehicle.cpp
+++ b/Source/Urho3D/Physics/RaycastVehicle.cpp
@@ -173,6 +173,7 @@ static const StringVector wheelElementNames =
     "   Contact position",
     "   Contact normal",
     "   Suspension stiffness",
+	"   Max suspension force",
     "   Damping relaxation",
     "   Damping compression",
     "   Friction slip",
@@ -228,6 +229,7 @@ void RaycastVehicle::ApplyAttributes()
         Vector3 contactPosition = value[index++].GetVector3();
         Vector3 contactNormal = value[index++].GetVector3();
         float suspensionStiffness = value[index++].GetFloat();
+		float maxSuspensionForce = value[index++].GetFloat();
         float dampingRelaxation = value[index++].GetFloat();
         float dampingCompression = value[index++].GetFloat();
         float frictionSlip = value[index++].GetFloat();
@@ -262,6 +264,7 @@ void RaycastVehicle::ApplyAttributes()
         wheel.m_raycastInfo.m_contactNormalWS = btVector3(contactNormal.x_, contactNormal.y_, contactNormal.z_);
         wheel.m_raycastInfo.m_contactPointWS = btVector3(contactPosition.x_, contactPosition.y_, contactPosition.z_);
         wheel.m_suspensionStiffness = suspensionStiffness;
+		wheel.m_maxSuspensionForce = maxSuspensionForce;
         wheel.m_wheelsDampingRelaxation = dampingRelaxation;
         wheel.m_wheelsDampingCompression = dampingCompression;
         wheel.m_frictionSlip = frictionSlip;
@@ -739,6 +742,7 @@ VariantVector RaycastVehicle::GetWheelDataAttr() const
         ret.Push(GetContactPosition(i));
         ret.Push(GetContactNormal(i));       // 14
         ret.Push(GetWheelSuspensionStiffness(i));
+		ret.Push(GetWheelMaxSuspensionForce(i));
         ret.Push(GetWheelDampingRelaxation(i));
         ret.Push(GetWheelDampingCompression(i));
         ret.Push(GetWheelFrictionSlip(i));

--- a/Source/Urho3D/Physics/RaycastVehicle.cpp
+++ b/Source/Urho3D/Physics/RaycastVehicle.cpp
@@ -173,7 +173,7 @@ static const StringVector wheelElementNames =
     "   Contact position",
     "   Contact normal",
     "   Suspension stiffness",
-	"   Max suspension force",
+    "   Max suspension force",
     "   Damping relaxation",
     "   Damping compression",
     "   Friction slip",
@@ -229,7 +229,7 @@ void RaycastVehicle::ApplyAttributes()
         Vector3 contactPosition = value[index++].GetVector3();
         Vector3 contactNormal = value[index++].GetVector3();
         float suspensionStiffness = value[index++].GetFloat();
-		float maxSuspensionForce = value[index++].GetFloat();
+        float maxSuspensionForce = value[index++].GetFloat();
         float dampingRelaxation = value[index++].GetFloat();
         float dampingCompression = value[index++].GetFloat();
         float frictionSlip = value[index++].GetFloat();
@@ -264,7 +264,7 @@ void RaycastVehicle::ApplyAttributes()
         wheel.m_raycastInfo.m_contactNormalWS = btVector3(contactNormal.x_, contactNormal.y_, contactNormal.z_);
         wheel.m_raycastInfo.m_contactPointWS = btVector3(contactPosition.x_, contactPosition.y_, contactPosition.z_);
         wheel.m_suspensionStiffness = suspensionStiffness;
-		wheel.m_maxSuspensionForce = maxSuspensionForce;
+        wheel.m_maxSuspensionForce = maxSuspensionForce;
         wheel.m_wheelsDampingRelaxation = dampingRelaxation;
         wheel.m_wheelsDampingCompression = dampingCompression;
         wheel.m_frictionSlip = frictionSlip;
@@ -742,7 +742,7 @@ VariantVector RaycastVehicle::GetWheelDataAttr() const
         ret.Push(GetContactPosition(i));
         ret.Push(GetContactNormal(i));       // 14
         ret.Push(GetWheelSuspensionStiffness(i));
-		ret.Push(GetWheelMaxSuspensionForce(i));
+        ret.Push(GetWheelMaxSuspensionForce(i));
         ret.Push(GetWheelDampingRelaxation(i));
         ret.Push(GetWheelDampingCompression(i));
         ret.Push(GetWheelFrictionSlip(i));

--- a/Source/Urho3D/Physics/RaycastVehicle.cpp
+++ b/Source/Urho3D/Physics/RaycastVehicle.cpp
@@ -460,6 +460,20 @@ float RaycastVehicle::GetWheelSuspensionStiffness(int wheel) const
     return whInfo.m_suspensionStiffness;
 }
 
+void RaycastVehicle::SetWheelMaxSuspensionForce(int wheel, float force)
+{
+    btRaycastVehicle* vehicle = vehicleData_->Get();
+    btWheelInfo& whInfo = vehicle->getWheelInfo(wheel);
+    whInfo.m_maxSuspensionForce = force;
+}
+
+float RaycastVehicle::GetWheelMaxSuspensionForce(int wheel) const
+{
+    btRaycastVehicle* vehicle = vehicleData_->Get();
+    btWheelInfo whInfo = vehicle->getWheelInfo(wheel);
+    return whInfo.m_maxSuspensionForce;
+}
+
 void RaycastVehicle::SetWheelDampingRelaxation(int wheel, float damping)
 {
     btRaycastVehicle* vehicle = vehicleData_->Get();

--- a/Source/Urho3D/Physics/RaycastVehicle.h
+++ b/Source/Urho3D/Physics/RaycastVehicle.h
@@ -59,6 +59,8 @@ public:
     void SetSteeringValue(int wheel, float steeringValue);
     /// Set suspension stiffness for particular wheel.
     void SetWheelSuspensionStiffness(int wheel, float stiffness);
+    /// Set wheel max suspension force. Good results are often obtained by a value that is about 3x to 4x the vehicle weight. 
+    void SetWheelMaxSuspensionForce(int wheel, float force);
     /// Set wheel damping relaxation.
     void SetWheelDampingRelaxation(int wheel, float damping);
     /// Set wheel damping compression.
@@ -116,6 +118,8 @@ public:
     float GetSteeringValue(int wheel) const;
     /// Get suspension stiffness for particular wheel.
     float GetWheelSuspensionStiffness(int wheel) const;
+    /// Get wheel max suspension force. 
+    float GetWheelMaxSuspensionForce(int wheel) const;
     /// Get wheel damping relaxation.
     float GetWheelDampingRelaxation(int wheel) const;
     /// Get wheel damping compression.


### PR DESCRIPTION
While playing with a heavy vehicle (small tank weighting 22 tons), the suspension had a strange behavior.
I tried solve it by setting the suspension stiffness and the maxtraveldistance.
That made the behavior much better, but still a bit wrong.
By exposing this bullet property all worked as I expected.
I don't know if there is a reason to keep this property from the Urho3D RaycastVehicle,...