### PR TITLE
Suppressed FileSystem compiling warnings with lambda wraps

### DIFF
--- a/Source/Urho3D/IO/FileSystem.cpp
+++ b/Source/Urho3D/IO/FileSystem.cpp
@@ -542,7 +542,7 @@ String FileSystem::GetCurrentDir() const
 #else
     char path[MAX_PATH];
     path[0] = 0;
-    getcwd(path, MAX_PATH);
+    [&]{ return getcwd(path, MAX_PATH); }();
     return AddTrailingSlash(String(path));
 #endif
 }
@@ -713,7 +713,7 @@ String FileSystem::GetProgramDir() const
     memset(exeName, 0, MAX_PATH);
     pid_t pid = getpid();
     String link = "/proc/" + String(pid) + "/exe";
-    readlink(link.CString(), exeName, MAX_PATH);
+    [&]{ return readlink(link.CString(), exeName, MAX_PATH); }();
     return GetPath(String(exeName));
 #else
     return GetCurrentDir();


### PR DESCRIPTION
I wrapped `getcwd` and `readlink` in lambda functions in order to suppress those pesky warnings.