### PR TITLE
Changed required TMX version from 1.0 to 1.*

### DIFF
--- a/Source/Urho3D/Urho2D/TmxFile2D.cpp
+++ b/Source/Urho3D/Urho2D/TmxFile2D.cpp
@@ -453,15 +453,17 @@ bool TmxFile2D::EndLoad()
     if (!loadXMLFile_)
         return false;
 
-    XMLElement rootElem = loadXMLFile_->GetRoot("map");
-    String version = rootElem.GetAttribute("version");
-    if (version != "1.0")
+    const XMLElement rootElem{ loadXMLFile_->GetRoot("map") };
+    const String version{ rootElem.GetAttribute("version") };
+
+    if (!version.StartsWith("1."))
     {
         URHO3D_LOGERROR("Invalid version");
         return false;
     }
 
-    String orientation = rootElem.GetAttribute("orientation");
+    const String orientation{ rootElem.GetAttribute("orientation") };
+
     if (orientation == "orthogonal")
         info_.orientation_ = O_ORTHOGONAL;
     else if (orientation == "isometric")
@@ -481,16 +483,20 @@ bool TmxFile2D::EndLoad()
     info_.tileWidth_ = rootElem.GetFloat("tilewidth") * PIXEL_SIZE;
     info_.tileHeight_ = rootElem.GetFloat("tileheight") * PIXEL_SIZE;
 
-    for (unsigned i = 0; i < layers_.Size(); ++i)
+    for (unsigned i{ 0 }; i < layers_.Size(); ++i)
         delete layers_[i];
+
     layers_.Clear();
 
-    for (XMLElement childElement = rootElem.GetChild(); childElement; childElement = childElement.GetNext())
+    for (XMLElement childElement{ rootElem.GetChild() }; childElement; childElement = childElement.GetNext())
     {
-        bool ret = true;
-        String name = childElement.GetName();
+        bool ret{ true };
+        const String name{ childElement.GetName() };
+
         if (name == "tileset")
+        {
             ret = LoadTileSet(childElement);
+        }
         else if (name == "layer")
         {
             auto* tileLayer = new TmxTileLayer2D(this);

--- a/Source/Urho3D/Urho2D/TmxFile2D.cpp
+++ b/Source/Urho3D/Urho2D/TmxFile2D.cpp
@@ -375,7 +375,14 @@ Sprite2D* TmxImageLayer2D::GetSprite() const
 
 TmxFile2D::TmxFile2D(Context* context) :
     Resource(context),
-    edgeOffset_(0.f)
+    loadXMLFile_{ nullptr },
+    tsxXMLFiles_{},
+    info_{},
+    gidToSpriteMapping_{},
+    gidToPropertySetMapping_{},
+    gidToCollisionShapeMapping_{},
+    layers_{},
+    edgeOffset_{ 0.0f }
 {
 }
 

--- a/Source/Urho3D/Urho2D/TmxFile2D.h
+++ b/Source/Urho3D/Urho2D/TmxFile2D.h
@@ -215,7 +215,7 @@ private:
     /// TSX name to XML file mapping.
     HashMap<String, SharedPtr<XMLFile> > tsxXMLFiles_;
     /// Tile map information.
-    TileMapInfo2D info_{};
+    TileMapInfo2D info_;
     /// Gid to tile sprite mapping.
     HashMap<unsigned, SharedPtr<Sprite2D> > gidToSpriteMapping_;
     /// Gid to tile property set mapping.


### PR DESCRIPTION
The latest version of Tiled saves TMX files of version 1.2, Urho currently only accepts files that have version 1.0. To support the latest while maintaining backwards compatibility the version validation has been loosened to `StartsWith( "1.")`. It seems to work well enough at first glance, including for flipped and rotated tiles.

Also enforced ES.23 & Con.4 within the same function.