### PR TITLE
Fix mobile web sample resolution

### DIFF
--- a/Source/Samples/Sample.inl
+++ b/Source/Samples/Sample.inl
@@ -62,6 +62,10 @@ void Sample::Setup()
     engineParameters_[EP_FULL_SCREEN]  = false;
     engineParameters_[EP_HEADLESS]     = false;
     engineParameters_[EP_SOUND]        = false;
+    
+    // Force not high DPI on web so mobile devices don't have extremely high resolutions
+    if (GetPlatform() == "Web")
+        engineParameters_[EP_HIGH_DPI] = false;
 
     // Construct a search path to find the resource prefix with two entries:
     // The first entry is an empty path which will be substituted with program/bin directory -- this entry is for binary when it is still in build tree


### PR DESCRIPTION
Fix mobile web sample resolution by setting EP_HIGH_DPI to false on Web platform (Issue #2555).
