### PR TITLE
Add support for animated tilesets (tmx files)

### DIFF
--- a/Source/Urho3D/Urho2D/TileMap2D.h
+++ b/Source/Urho3D/Urho2D/TileMap2D.h
@@ -44,6 +44,9 @@ public:
     /// Register object factory.
     static void RegisterObject(Context* context);
 
+    /// Handle node being assigned.
+    void OnNodeSet(Node* node) override;
+
     /// Visualize the component as debug geometry.
     void DrawDebugGeometry(DebugRenderer* debug, bool depthTest) override;
 
@@ -75,6 +78,9 @@ public:
     ///
     Vector<SharedPtr<TileMapObject2D> > GetTileCollisionShapes(unsigned gid) const;
 private:
+    /// Handle scene update.
+    void HandleSceneUpdate(StringHash eventType, VariantMap& eventData);
+
     /// Tmx file.
     SharedPtr<TmxFile2D> tmxFile_;
     /// Tile map information.

--- a/Source/Urho3D/Urho2D/TileMapDefs2D.cpp
+++ b/Source/Urho3D/Urho2D/TileMapDefs2D.cpp
@@ -160,6 +160,46 @@ const String& PropertySet2D::GetProperty(const String& name) const
     return i->second_;
 }
 
+FrameSet2D::FrameSet2D() = default;
+
+FrameSet2D::~FrameSet2D() = default;
+
+void FrameSet2D::Load(const XMLElement& element)
+{
+    assert(element.GetName() == "animation");
+    for (XMLElement frameElem = element.GetChild("frame"); frameElem; frameElem = frameElem.GetNext("frame"))
+    {
+        SharedPtr<TileFrameInfo2D> info(new TileFrameInfo2D());
+        info->gid_ = frameElem.GetUInt("tileid") + 1;
+        info->duration_ = frameElem.GetUInt("duration");
+        frames_.Push(info);
+
+        lapTime_ += info->duration_;
+    }
+
+}
+
+void FrameSet2D::UpdateTimer(float timeStep)
+{
+    timeElapsed_ += timeStep * 1000.0f;
+    if (timeElapsed_ > lapTime_)
+        timeElapsed_ -= lapTime_;
+}
+
+unsigned FrameSet2D::GetCurrentFrameGid() const
+{
+    unsigned minInterval = 0;
+    unsigned maxInterval = 0;
+    for (unsigned i = 0; i < frames_.Size(); ++i)
+    {
+        minInterval = maxInterval;
+        maxInterval += frames_[i]->duration_;
+        if (timeElapsed_ >= static_cast<float>(minInterval) && timeElapsed_ < static_cast<float>(maxInterval))
+            return frames_[i]->gid_;
+    }
+    return frames_[0]->gid_;
+}
+
 Tile2D::Tile2D() :
     gid_(0)
 {
@@ -183,6 +223,14 @@ const String& Tile2D::GetProperty(const String& name) const
         return String::EMPTY;
 
     return propertySet_->GetProperty(name);
+}
+
+bool Tile2D::IsAnimated() const
+{
+    if (!frameSet_)
+        return false;
+    else
+        return true;
 }
 
 TileMapObject2D::TileMapObject2D() = default;

--- a/Source/Urho3D/Urho2D/TileMapDefs2D.h
+++ b/Source/Urho3D/Urho2D/TileMapDefs2D.h
@@ -41,7 +41,7 @@ enum Orientation2D
     O_ISOMETRIC,
     /// Staggered.
     O_STAGGERED,
-    /// Hexagonal
+    /// Hexagonal.
     O_HEXAGONAL
 };
 
@@ -69,6 +69,14 @@ struct URHO3D_API TileMapInfo2D
     Vector2 TileIndexToPosition(int x, int y) const;
     /// Convert position to tile index, if out of map return false.
     bool PositionToTileIndex(int& x, int& y, const Vector2& position) const;
+};
+
+struct URHO3D_API TileFrameInfo2D : public RefCounted
+{
+    /// Gid;
+    unsigned gid_;
+    /// Duration.
+    unsigned duration_;
 };
 
 /// Tile map layer type.
@@ -120,6 +128,29 @@ protected:
     HashMap<String, String> nameToValueMapping_;
 };
 
+/// Frame set.
+class URHO3D_API FrameSet2D : public RefCounted
+{
+public:
+    FrameSet2D();
+    ~FrameSet2D() override;
+
+    /// Load from XML element.
+    void Load(const XMLElement& element);
+    /// Update animation timer.
+    void UpdateTimer(float timeStep);
+    /// Return current tile gid.
+    unsigned GetCurrentFrameGid() const;
+
+protected:
+    /// Animation frame infos.
+    Vector<SharedPtr<TileFrameInfo2D> > frames_;
+    /// Time elapsed in the animation (circular timer).
+    float timeElapsed_{0.0f};
+    /// Time it takes to complete one animation.
+    unsigned lapTime_{0};
+};
+
 /// Tile flipping flags.
 static const unsigned FLIP_HORIZONTAL = 0x80000000u;
 static const unsigned FLIP_VERTICAL   = 0x40000000u;
@@ -149,6 +180,8 @@ public:
     bool HasProperty(const String& name) const;
     /// Return property.
     const String& GetProperty(const String& name) const;
+    /// Checks if tile has animation frames.
+    bool IsAnimated() const;
 
 private:
     friend class TmxTileLayer2D;
@@ -159,6 +192,8 @@ private:
     SharedPtr<Sprite2D> sprite_;
     /// Property set.
     SharedPtr<PropertySet2D> propertySet_;
+    /// Frame set.
+    SharedPtr<FrameSet2D> frameSet_;
 };
 
 /// Tile map object.

--- a/Source/Urho3D/Urho2D/TileMapLayer2D.cpp
+++ b/Source/Urho3D/Urho2D/TileMapLayer2D.cpp
@@ -25,6 +25,8 @@
 #include "../Core/Context.h"
 #include "../Graphics/DebugRenderer.h"
 #include "../Resource/ResourceCache.h"
+#include "../Scene/Scene.h"
+#include "../Scene/SceneEvents.h"
 #include "../Scene/Node.h"
 #include "../Urho2D/StaticSprite2D.h"
 #include "../Urho2D/TileMap2D.h"
@@ -243,6 +245,37 @@ void TileMapLayer2D::SetVisible(bool visible)
     {
         if (nodes_[i])
             nodes_[i]->SetEnabled(visible_);
+    }
+}
+
+void TileMapLayer2D::UpdateAnimations()
+{
+    if (GetLayerType() != LT_TILE_LAYER)
+        return;
+
+    TmxFile2D* tmxFile = GetTileMap()->GetTmxFile();
+    for (int y = 0; y < GetHeight(); y++)
+    {
+        for (int x = 0; x < GetWidth(); x++)
+        {
+            Tile2D* tile = GetTile(x, y);
+            if (tile->IsAnimated())
+            {
+                Node* node = GetTileNode(x, y);
+                if (node)
+                {
+                    unsigned curGid = tile->GetGid();
+                    FrameSet2D* frameSet = tmxFile->GetTileFrameSet(curGid);
+                    unsigned newGid = frameSet->GetCurrentFrameGid();
+                    if (curGid != newGid)
+                    {
+                        Sprite2D* sprite = tmxFile->GetTileSprite(newGid);
+                        auto* spriteComponent = node->GetComponent<StaticSprite2D>();
+                        spriteComponent->SetSprite(sprite);
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/Source/Urho3D/Urho2D/TileMapLayer2D.h
+++ b/Source/Urho3D/Urho2D/TileMapLayer2D.h
@@ -58,10 +58,12 @@ public:
 
     /// Initialize with tile map and tmx layer.
     void Initialize(TileMap2D* tileMap, const TmxLayer2D* tmxLayer);
-    /// Set draw order
+    /// Set draw order.
     void SetDrawOrder(int drawOrder);
     /// Set visible.
     void SetVisible(bool visible);
+    /// For tile layers, update animated tile sprites.
+    void UpdateAnimations();
 
     /// Return tile map.
     TileMap2D* GetTileMap() const;
@@ -75,7 +77,7 @@ public:
     /// Return visible.
     bool IsVisible() const { return visible_; }
 
-    /// Return has property
+    /// Return has property.
     bool HasProperty(const String& name) const;
     /// Return property.
     const String& GetProperty(const String& name) const;

--- a/Source/Urho3D/Urho2D/TmxFile2D.h
+++ b/Source/Urho3D/Urho2D/TmxFile2D.h
@@ -192,6 +192,12 @@ public:
     /// Return tile property set by gid, if not exist return 0.
     PropertySet2D* GetTilePropertySet(unsigned gid) const;
 
+    /// Return tile frame set by gid, if not exist return 0.
+    FrameSet2D* GetTileFrameSet(unsigned gid) const;
+
+    /// Updates FrameSet's timers, in all tile sets.
+    void UpdateAnimationTimers(float timeStep);
+
     /// Return number of layers.
     unsigned GetNumLayers() const { return layers_.Size(); }
 
@@ -220,6 +226,8 @@ private:
     HashMap<unsigned, SharedPtr<Sprite2D> > gidToSpriteMapping_;
     /// Gid to tile property set mapping.
     HashMap<unsigned, SharedPtr<PropertySet2D> > gidToPropertySetMapping_;
+    /// Gid to tile frame set mapping.
+    HashMap<unsigned, SharedPtr<FrameSet2D> > gidToFrameSetMapping_;
     /// Gid to tile collision shape mapping.
     HashMap<unsigned, Vector<SharedPtr<TileMapObject2D> > > gidToCollisionShapeMapping_;
     /// Layers.


### PR DESCRIPTION
These changes allow the use of animated tiles in tmx maps.
I tested it by updating the map of sample 36 to contain some animated tiles.
I don't know if the way I choose to implement this fits with the codebase (I tried to). If it does, I'll check AS and LUA bindings. I'm dabbling with those bindings, so I'll only commit to that code if this one is ok.