### PR TITLE
Fix problem with anomalies in point light shadows in OpenGL mode.

### DIFF
--- a/Source/Urho3D/Graphics/OpenGL/OGLTextureCube.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLTextureCube.cpp
@@ -505,6 +505,16 @@ bool TextureCube::Create()
     glTexParameteri(target_, GL_TEXTURE_MAX_LEVEL, levels_ - 1);
 #endif
 
+#if GL_ARB_seamless_cubemap_per_texture
+    if (glIsEnabled(GL_TEXTURE_CUBE_MAP_SEAMLESS))
+    {
+        // Disables the global setting because otherwise it 
+        // overrides the per texture setting below.
+        glDisable(GL_TEXTURE_CUBE_MAP_SEAMLESS);
+    }
+    glTexParameteri(target_, GL_TEXTURE_CUBE_MAP_SEAMLESS, seamless_ ? 1 : 0);
+#endif
+
     // Set initial parameters, then unbind the texture
     UpdateParameters();
     graphics_->SetTexture(0, nullptr);

--- a/Source/Urho3D/Graphics/OpenGL/OGLTextureCube.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLTextureCube.cpp
@@ -509,7 +509,7 @@ bool TextureCube::Create()
     if (glIsEnabled(GL_TEXTURE_CUBE_MAP_SEAMLESS))
     {
         // Disables the global setting because otherwise it 
-        // overrides the per texture setting below.
+        // overrides the per texture setting below
         glDisable(GL_TEXTURE_CUBE_MAP_SEAMLESS);
     }
     glTexParameteri(target_, GL_TEXTURE_CUBE_MAP_SEAMLESS, seamless_ ? 1 : 0);

--- a/Source/Urho3D/Graphics/Renderer.cpp
+++ b/Source/Urho3D/Graphics/Renderer.cpp
@@ -1814,11 +1814,17 @@ void Renderer::CreateGeometries()
     if (graphics_->GetShadowMapFormat())
     {
         faceSelectCubeMap_ = new TextureCube(context_);
+        faceSelectCubeMap_->SetSeamless(false);
         faceSelectCubeMap_->SetNumLevels(1);
         faceSelectCubeMap_->SetSize(1, graphics_->GetRGBAFormat());
         faceSelectCubeMap_->SetFilterMode(FILTER_NEAREST);
 
         indirectionCubeMap_ = new TextureCube(context_);
+        // We disable seamless mode because sampling across faces with
+        // bilinear filter is not valid for the positional data stored 
+        // in this cube map and may result in anomolies in the shadows
+        // projected from the cube edges.
+        indirectionCubeMap_->SetSeamless(false);
         indirectionCubeMap_->SetNumLevels(1);
         indirectionCubeMap_->SetSize(256, graphics_->GetRGBAFormat());
         indirectionCubeMap_->SetFilterMode(FILTER_BILINEAR);

--- a/Source/Urho3D/Graphics/Renderer.cpp
+++ b/Source/Urho3D/Graphics/Renderer.cpp
@@ -1822,8 +1822,8 @@ void Renderer::CreateGeometries()
         indirectionCubeMap_ = new TextureCube(context_);
         // We disable seamless mode because sampling across faces with
         // bilinear filter is not valid for the positional data stored 
-        // in this cube map and may result in anomolies in the shadows
-        // projected from the cube edges.
+        // in this cube map and may result in anomalies in the shadows
+        // projected from the cube edges
         indirectionCubeMap_->SetSeamless(false);
         indirectionCubeMap_->SetNumLevels(1);
         indirectionCubeMap_->SetSize(256, graphics_->GetRGBAFormat());

--- a/Source/Urho3D/Graphics/TextureCube.cpp
+++ b/Source/Urho3D/Graphics/TextureCube.cpp
@@ -64,6 +64,8 @@ TextureCube::TextureCube(Context* context) :
 #ifdef URHO3D_OPENGL
     target_ = GL_TEXTURE_CUBE_MAP;
 #endif
+    // Default to seamless sampling across cube faces (if supported)
+    seamless_ = true;
 
     // Default to clamp mode addressing
     addressModes_[COORD_U] = ADDRESS_CLAMP;

--- a/Source/Urho3D/Graphics/TextureCube.h
+++ b/Source/Urho3D/Graphics/TextureCube.h
@@ -73,8 +73,9 @@ public:
     /// Return render surface for one face.
     RenderSurface* GetRenderSurface(CubeMapFace face) const { return renderSurfaces_[face]; }
 
-    /// Control for texture sampling across cube faces.
+    /// Get whether texture sampling across cube faces is used.
     bool GetSeamless() const { return seamless_; }
+    /// Set whether texture sampling across cube faces is used.
     void SetSeamless(bool seamless) { seamless_ = seamless; }
 
 protected:

--- a/Source/Urho3D/Graphics/TextureCube.h
+++ b/Source/Urho3D/Graphics/TextureCube.h
@@ -73,6 +73,10 @@ public:
     /// Return render surface for one face.
     RenderSurface* GetRenderSurface(CubeMapFace face) const { return renderSurfaces_[face]; }
 
+    /// Control for texture sampling across cube faces.
+    bool GetSeamless() const { return seamless_; }
+    void SetSeamless(bool seamless) { seamless_ = seamless; }
+
 protected:
     /// Create the GPU texture.
     bool Create() override;
@@ -89,6 +93,8 @@ private:
     Vector<SharedPtr<Image> > loadImages_;
     /// Parameter file acquired during BeginLoad.
     SharedPtr<XMLFile> loadParameters_;
+    /// If supported, allows control of texture sampling across cube faces.
+    bool seamless_;
 };
 
 }


### PR DESCRIPTION
This pull request is a fix for issue reported in #2606

The problem is caused by the bilinear texture sampling filter used on the cubemap used to index into the cube depthmap render for point lights. It seems that the default mode for cubemaps in desktop OpenGL implementations will sample textures across cubemap faces, but because the content of the `indirectionCubeMap` is positional information and therefore should not be interpolated across cube faces otherwise it results in shadow anomalies where the projections of edges of the light's cubemap hit the scene.

Note that I have only implemented the ability to disable seamless cubemap mode for OpenGL as I do not experience the issue in DirectX9.  I can only assume that in DirectX9 seamless cubemap sampling is disabled by default in DirectX9, and therefore not exhibiting the issue?
  