### PR TITLE
Prevent canvas resize while the window size is still changing

### DIFF
--- a/Source/Urho3D/Graphics/OpenGL/OGLIndexBuffer.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLIndexBuffer.cpp
@@ -35,6 +35,9 @@ namespace Urho3D
 
 void IndexBuffer::OnDeviceLost()
 {
+    if (object_.name_ && !graphics_->IsDeviceLost())
+        glDeleteBuffers(1, &object_.name_);
+
     GPUObject::OnDeviceLost();
 }
 

--- a/Source/Urho3D/Graphics/OpenGL/OGLRenderSurface.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLRenderSurface.cpp
@@ -103,7 +103,7 @@ void RenderSurface::OnDeviceLost()
     // Clean up also from non-active FBOs
     graphics->CleanupRenderSurface(this);
 
-    if (renderBuffer_ && !graphics_->IsDeviceLost())
+    if (renderBuffer_ && !graphics->IsDeviceLost())
         glDeleteRenderbuffersEXT(1, &renderBuffer_);
 
     renderBuffer_ = 0;

--- a/Source/Urho3D/Graphics/OpenGL/OGLRenderSurface.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLRenderSurface.cpp
@@ -103,6 +103,9 @@ void RenderSurface::OnDeviceLost()
     // Clean up also from non-active FBOs
     graphics->CleanupRenderSurface(this);
 
+    if (renderBuffer_ && !graphics_->IsDeviceLost())
+        glDeleteRenderbuffersEXT(1, &renderBuffer_);
+
     renderBuffer_ = 0;
 }
 

--- a/Source/Urho3D/Graphics/OpenGL/OGLShaderProgram.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLShaderProgram.cpp
@@ -74,6 +74,9 @@ ShaderProgram::~ShaderProgram()
 
 void ShaderProgram::OnDeviceLost()
 {
+    if (object_.name_ && !graphics_->IsDeviceLost())
+        glDeleteProgram(object_.name_);
+
     GPUObject::OnDeviceLost();
 
     if (graphics_ && graphics_->GetShaderProgram() == this)

--- a/Source/Urho3D/Graphics/OpenGL/OGLShaderVariation.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLShaderVariation.cpp
@@ -49,6 +49,9 @@ const char* ShaderVariation::elementSemanticNames[] =
 
 void ShaderVariation::OnDeviceLost()
 {
+    if (object_.name_ && !graphics_->IsDeviceLost())
+        glDeleteShader(object_.name_);
+
     GPUObject::OnDeviceLost();
 
     compilerOutput_.Clear();

--- a/Source/Urho3D/Graphics/OpenGL/OGLTexture2D.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLTexture2D.cpp
@@ -41,6 +41,9 @@ namespace Urho3D
 
 void Texture2D::OnDeviceLost()
 {
+    if (object_.name_ && !graphics_->IsDeviceLost())
+        glDeleteTextures(1, &object_.name_);
+
     GPUObject::OnDeviceLost();
 
     if (renderSurface_)

--- a/Source/Urho3D/Graphics/OpenGL/OGLTexture2DArray.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLTexture2DArray.cpp
@@ -45,6 +45,9 @@ namespace Urho3D
 
 void Texture2DArray::OnDeviceLost()
 {
+    if (object_.name_ && !graphics_->IsDeviceLost())
+        glDeleteTextures(1, &object_.name_);
+
     GPUObject::OnDeviceLost();
 
     if (renderSurface_)

--- a/Source/Urho3D/Graphics/OpenGL/OGLTexture3D.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLTexture3D.cpp
@@ -41,6 +41,9 @@ namespace Urho3D
 
 void Texture3D::OnDeviceLost()
 {
+    if (object_.name_ && !graphics_->IsDeviceLost())
+        glDeleteTextures(1, &object_.name_);
+
     GPUObject::OnDeviceLost();
 }
 

--- a/Source/Urho3D/Graphics/OpenGL/OGLTextureCube.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLTextureCube.cpp
@@ -45,6 +45,9 @@ namespace Urho3D
 
 void TextureCube::OnDeviceLost()
 {
+    if (object_.name_ && !graphics_->IsDeviceLost())
+        glDeleteTextures(1, &object_.name_);
+
     GPUObject::OnDeviceLost();
 
     for (auto& renderSurface : renderSurfaces_)

--- a/Source/Urho3D/Graphics/OpenGL/OGLVertexBuffer.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLVertexBuffer.cpp
@@ -34,6 +34,9 @@ namespace Urho3D
 
 void VertexBuffer::OnDeviceLost()
 {
+    if (object_.name_ && !graphics_->IsDeviceLost())
+        glDeleteBuffers(1, &object_.name_);
+
     GPUObject::OnDeviceLost();
 }
 

--- a/bin/shell.html
+++ b/bin/shell.html
@@ -134,10 +134,14 @@
         document.addEventListener('msvisibilitychange', visibilityChanged, false);
         document.addEventListener('webkitvisibilitychange', visibilityChanged, false);
 
+        var resizeTimeout = false;
         // When window size has changed, resize the canvas accordingly
         window.addEventListener('resize', function(evt) {
             // resize event is called before the resizing has finished, we must wait a bit so the new calculations use the new viewport size
-            setTimeout(() => {
+            if (resizeTimeout) {
+                clearTimeout(resizeTimeout);
+            }
+            resizeTimeout = setTimeout(() => {
                 viewportResizeHandler(evt);
             }, 1000);
         });


### PR DESCRIPTION
Wait till the viewport resizing is actually finished, then wait 1s to actually apply the new viewport size.