### PR TITLE
Make FlagSet to bool conversion operator explicit. Fixes #2631.

### DIFF
--- a/Source/Urho3D/Container/FlagSet.h
+++ b/Source/Urho3D/Container/FlagSet.h
@@ -163,7 +163,7 @@ public:
     }
 
     /// Returns true if any flag is set.
-    operator bool () const
+    explicit operator bool () const
     {
         return value_ != 0;
     }


### PR DESCRIPTION
Made a PR to run CI just in case.
Having two impicit conversions to compatible types is clearly a design fault of `FlagSet` and shall be fixed until it fires somewhere else.