### PR TITLE
Allow Camera::SetFlipVertical to be used externally for OpenGL

### DIFF
--- a/Source/Urho3D/Graphics/View.cpp
+++ b/Source/Urho3D/Graphics/View.cpp
@@ -601,6 +601,10 @@ void View::Render()
     {
         // On OpenGL, flip the projection if rendering to a texture so that the texture can be addressed in the same way
         // as a render texture produced on Direct3D9
+        // Note that the state of the FlipVertical mode is toggled here rather than enabled
+        // The reason for this is that we want the mode to be the opposite of what the user has currently set for the
+        // camera when rendering to texture for OpenGL
+        // This mode is returned to the original state by toggling it again below, after the render
         if (camera_)
             camera_->SetFlipVertical(!camera_->GetFlipVertical());
     }

--- a/Source/Urho3D/Graphics/View.cpp
+++ b/Source/Urho3D/Graphics/View.cpp
@@ -596,15 +596,15 @@ void View::Render()
     }
 #endif
 
+#ifdef URHO3D_OPENGL
     if (renderTarget_)
     {
         // On OpenGL, flip the projection if rendering to a texture so that the texture can be addressed in the same way
         // as a render texture produced on Direct3D9
-#ifdef URHO3D_OPENGL
         if (camera_)
-            camera_->SetFlipVertical(true);
-#endif
+            camera_->SetFlipVertical(!camera_->GetFlipVertical());
     }
+#endif
 
     // Render
     ExecuteRenderPathCommands();
@@ -651,8 +651,12 @@ void View::Render()
     }
 
 #ifdef URHO3D_OPENGL
-    if (camera_)
-        camera_->SetFlipVertical(false);
+    if (renderTarget_)
+    {
+        // Restores original setting of FlipVertical when flipped by code above.
+        if (camera_)
+            camera_->SetFlipVertical(!camera_->GetFlipVertical());
+    }
 #endif
 
     // Run framebuffer blitting if necessary. If scene was resolved from backbuffer, do not touch depth


### PR DESCRIPTION
Allow `Camera::SetFlipVertical` to be used externally for OpenGL by toggling it either side of render to texture, i.e. instead of "set and clear" either side of render to texture.

The purpose of this pull request is to allow `Camera::SetFlipVertical` to be used for both DirectX and OpenGL to switch into a right handed coordinate system (see #2642). 

This pull request should not change the behaviour of any application that does not call `Camera::SetFlipVertical` directly. It also should correct the scenario where if the render to texture should not be flipped if the camera is already flipped (hence the toggling of state in the changes) 

Closes #2642