### PR TITLE
Handle when the content of a dropdown changes size while selected

### DIFF
--- a/Source/Urho3D/UI/DropDownList.h
+++ b/Source/Urho3D/UI/DropDownList.h
@@ -116,9 +116,13 @@ private:
     void HandleListViewKey(StringHash eventType, VariantMap& eventData);
     /// Handle the listview selection change. Set placeholder text hidden/visible as necessary.
     void HandleSelectionChanged(StringHash eventType, VariantMap& eventData);
+    /// Handle when an item is resized.
+    void HandleSelectionResized(StringHash eventType, VariantMap& eventData);
 
     /// Selected item index attribute.
     unsigned selectionAttr_;
+    /// Current selected item
+    UIElement* selectedItem_;
 };
 
 }


### PR DESCRIPTION
The preview (the redrawing of the element that's shown in the main dropdown part) could end up offset incorrectly due to it's size not being updated if the size of the selected item was changed.