### PR TITLE
Added PODVector::Resize overload with default value

### DIFF
--- a/Source/Urho3D/Container/Vector.h
+++ b/Source/Urho3D/Container/Vector.h
@@ -1053,6 +1053,15 @@ public:
         size_ = newSize;
     }
 
+    /// Resize the vector and fill new elements with default value.
+    void Resize(unsigned newSize, const T& value)
+    {
+        unsigned oldSize = Size();
+        Resize(newSize);
+        for (unsigned i = oldSize; i < newSize; ++i)
+            At(i) = value;
+    }
+
     /// Set new capacity.
     void Reserve(unsigned newCapacity)
     {


### PR DESCRIPTION
Added PODVector::Resize overload that fills new elements with a default value.

I think it's useful as the user may prefer something like PODVector<Vector3> to be extended with a "nice" value like Vector3::ZERO in some circumstances while not caring in the general case.