### PR TITLE
Image too dark for DX9 caused by mismatch between code PBRLitSolid.hlsl and PBRLitSolid.glsl  

### DIFF
--- a/bin/CoreData/Shaders/HLSL/PBRLitSolid.hlsl
+++ b/bin/CoreData/Shaders/HLSL/PBRLitSolid.hlsl
@@ -222,7 +222,6 @@ void PS(
     metalness = clamp(metalness, METALNESS_FLOOR, 1.0);
 
     float3 specColor = lerp(0.08 * cMatSpecColor.rgb, diffColor.rgb, metalness);
-    specColor *= cMatSpecColor.rgb;
     diffColor.rgb = diffColor.rgb - diffColor.rgb * metalness; // Modulate down the diffuse
 
     // Get normal


### PR DESCRIPTION
This change removes a line of HLSL code that does not occur in the GLSL version of the code.
In my experiments I noticed that the environment mapping was much darker in DX9 vs OGL versions.
I tracked to the difference to be purely a consequence of this line of code, which in effect squares the darkening effect of the specular color.  I suspect this difference may not have been noticed because it makes no difference if the material specular color is full white.

It may be that it is the GLSL version that needs correcting to make it consistent with the HLSL version, but I'm not really sure why the HLSL version of this code would need to effectively multiply a specular color by itself. But in anycase, I think the HLSL and GLSL code should at least be consistent in this respect.

Too dark in DX9:
![PBRUrho3DDX9-envmap-too-dark](https://user-images.githubusercontent.com/2325443/85930918-21df5880-b8b8-11ea-98f0-e2ad896a04fb.png)

OK in OGL:
![PBRUrho3DOpenGL](https://user-images.githubusercontent.com/2325443/85930846-7fbf7080-b8b7-11ea-89ae-312ddcf289b1.png)

OK in DX9 with fix in this PR:
![PBRUrho3DDX9](https://user-images.githubusercontent.com/2325443/85930847-80580700-b8b7-11ea-9238-bd8765938896.png)






