### PR TITLE
Ambient occlusion in PBR techniques

### DIFF
--- a/bin/CoreData/Shaders/GLSL/PBRLitSolid.glsl
+++ b/bin/CoreData/Shaders/GLSL/PBRLitSolid.glsl
@@ -40,7 +40,7 @@ varying vec4 vWorldPos;
     #ifdef ENVCUBEMAP
         varying vec3 vReflectionVec;
     #endif
-    #if defined(LIGHTMAP) || defined(AO)
+    #if defined(LIGHTMAP)
         varying vec2 vTexCoord2;
     #endif
 #endif
@@ -86,15 +86,13 @@ void VS()
         #endif
     #else
         // Ambient & per-vertex lighting
-        #if defined(LIGHTMAP) || defined(AO)
+        #if defined(LIGHTMAP)
             // If using lightmap, disregard zone ambient light
+            vVertexLight = vec3(0.0, 0.0, 0.0);
+            vTexCoord2 = iTexCoord1;
+        #elif defined(AO)
             // If using AO, calculate ambient in the PS
             vVertexLight = vec3(0.0, 0.0, 0.0);
-            #if defined(LIGHTMAP)
-                vTexCoord2 = iTexCoord1;
-            #else
-                vTexCoord2 = GetTexCoord(iTexCoord);
-            #endif
         #else
             vVertexLight = GetAmbient(GetZonePos(worldPos));
         #endif
@@ -226,7 +224,7 @@ void PS()
         vec3 ambientOcclusion = vec3(1.0, 1.0, 1.0);
         #ifdef AO
             // If using AO, the vertex light ambient is black, calculate occluded ambient here
-            ambientOcclusion = texture2D(sEmissiveMap, vTexCoord2).rgb;
+            ambientOcclusion = texture2D(sEmissiveMap, vTexCoord.xy).rgb;
             finalColor += ambientOcclusion * cAmbientColor.rgb * diffColor.rgb;
         #endif
 

--- a/bin/CoreData/Shaders/GLSL/PBRLitSolid.glsl
+++ b/bin/CoreData/Shaders/GLSL/PBRLitSolid.glsl
@@ -223,9 +223,11 @@ void PS()
     #else
         // Ambient & per-vertex lighting
         vec3 finalColor = vVertexLight * diffColor.rgb;
+        vec3 ambientOcclusion = vec3(1.0, 1.0, 1.0);
         #ifdef AO
             // If using AO, the vertex light ambient is black, calculate occluded ambient here
-            finalColor += texture2D(sEmissiveMap, vTexCoord2).rgb * cAmbientColor.rgb * diffColor.rgb;
+            ambientOcclusion = texture2D(sEmissiveMap, vTexCoord2).rgb;
+            finalColor += ambientOcclusion * cAmbientColor.rgb * diffColor.rgb;
         #endif
 
         #ifdef MATERIAL
@@ -245,7 +247,7 @@ void PS()
         #ifdef IBL
           vec3 iblColor = ImageBasedLighting(reflection, normal, toCamera, diffColor.rgb, specColor.rgb, roughness, cubeColor);
           float gamma = 0.0;
-          finalColor.rgb += iblColor;
+          finalColor.rgb += iblColor * ambientOcclusion;
         #endif
 
         #ifdef ENVCUBEMAP

--- a/bin/CoreData/Shaders/GLSL/PBRLitSolid.glsl
+++ b/bin/CoreData/Shaders/GLSL/PBRLitSolid.glsl
@@ -90,7 +90,11 @@ void VS()
             // If using lightmap, disregard zone ambient light
             // If using AO, calculate ambient in the PS
             vVertexLight = vec3(0.0, 0.0, 0.0);
-            vTexCoord2 = iTexCoord1;
+            #if defined(LIGHTMAP)
+                vTexCoord2 = iTexCoord1;
+            #else
+                vTexCoord2 = GetTexCoord(iTexCoord);
+            #endif
         #else
             vVertexLight = GetAmbient(GetZonePos(worldPos));
         #endif

--- a/bin/CoreData/Shaders/HLSL/PBRLitSolid.hlsl
+++ b/bin/CoreData/Shaders/HLSL/PBRLitSolid.hlsl
@@ -305,9 +305,11 @@ void PS(
     #else
         // Ambient & per-vertex lighting
         float3 finalColor = iVertexLight * diffColor.rgb;
+        float3 ambientOcclusion = float3(1.0, 1.0, 1.0);
         #ifdef AO
             // If using AO, the vertex light ambient is black, calculate occluded ambient here
-            finalColor += Sample2D(EmissiveMap, iTexCoord2).rgb * cAmbientColor.rgb * diffColor.rgb;
+            ambientOcclusion = Sample2D(EmissiveMap, iTexCoord2).rgb;
+            finalColor += ambientOcclusion * cAmbientColor.rgb * diffColor.rgb;
         #endif
 
         #ifdef MATERIAL
@@ -327,7 +329,7 @@ void PS(
         #ifdef IBL
             const float3 iblColor = ImageBasedLighting(reflection, normal, toCamera, diffColor, specColor, roughness, cubeColor);
             const float gamma = 0;
-            finalColor += iblColor;
+            finalColor += iblColor * ambientOcclusion;
         #endif
 
         #ifdef ENVCUBEMAP

--- a/bin/CoreData/Shaders/HLSL/PBRLitSolid.hlsl
+++ b/bin/CoreData/Shaders/HLSL/PBRLitSolid.hlsl
@@ -121,7 +121,11 @@ void VS(float4 iPos : POSITION,
             // If using lightmap, disregard zone ambient light
             // If using AO, calculate ambient in the PS
             oVertexLight = float3(0.0, 0.0, 0.0);
-            oTexCoord2 = iTexCoord2;
+            #if defined(LIGHTMAP)
+                oTexCoord2 = iTexCoord2;
+            #else
+                oTexCoord2 = GetTexCoord(iTexCoord);
+            #endif
         #else
             oVertexLight = GetAmbient(GetZonePos(worldPos));
         #endif

--- a/bin/CoreData/Shaders/HLSL/PBRLitSolid.hlsl
+++ b/bin/CoreData/Shaders/HLSL/PBRLitSolid.hlsl
@@ -18,7 +18,7 @@ void VS(float4 iPos : POSITION,
     #ifdef VERTEXCOLOR
         float4 iColor : COLOR0,
     #endif
-    #if defined(LIGHTMAP) || defined(AO)
+    #if defined(LIGHTMAP)
         float2 iTexCoord2 : TEXCOORD1,
     #endif
     #if (defined(NORMALMAP) || defined(TRAILFACECAM) || defined(TRAILBONE)) && !defined(BILLBOARD) && !defined(DIRBILLBOARD)
@@ -58,7 +58,7 @@ void VS(float4 iPos : POSITION,
         #ifdef ENVCUBEMAP
             out float3 oReflectionVec : TEXCOORD6,
         #endif
-        #if defined(LIGHTMAP) || defined(AO)
+        #if defined(LIGHTMAP)
             out float2 oTexCoord2 : TEXCOORD7,
         #endif
     #endif
@@ -117,15 +117,13 @@ void VS(float4 iPos : POSITION,
         #endif
     #else
         // Ambient & per-vertex lighting
-        #if defined(LIGHTMAP) || defined(AO)
+        #if defined(LIGHTMAP)
             // If using lightmap, disregard zone ambient light
+            oVertexLight = float3(0.0, 0.0, 0.0);
+            oTexCoord2 = iTexCoord2;
+        #elif defined(AO)
             // If using AO, calculate ambient in the PS
             oVertexLight = float3(0.0, 0.0, 0.0);
-            #if defined(LIGHTMAP)
-                oTexCoord2 = iTexCoord2;
-            #else
-                oTexCoord2 = GetTexCoord(iTexCoord);
-            #endif
         #else
             oVertexLight = GetAmbient(GetZonePos(worldPos));
         #endif
@@ -168,7 +166,7 @@ void PS(
         #ifdef ENVCUBEMAP
             float3 iReflectionVec : TEXCOORD6,
         #endif
-        #if defined(LIGHTMAP) || defined(AO)
+        #if defined(LIGHTMAP)
             float2 iTexCoord2 : TEXCOORD7,
         #endif
     #endif
@@ -308,7 +306,7 @@ void PS(
         float3 ambientOcclusion = float3(1.0, 1.0, 1.0);
         #ifdef AO
             // If using AO, the vertex light ambient is black, calculate occluded ambient here
-            ambientOcclusion = Sample2D(EmissiveMap, iTexCoord2).rgb;
+            ambientOcclusion = Sample2D(EmissiveMap, iTexCoord.xy).rgb;
             finalColor += ambientOcclusion * cAmbientColor.rgb * diffColor.rgb;
         #endif
 

--- a/bin/CoreData/Techniques/PBR/PBRAO.xml
+++ b/bin/CoreData/Techniques/PBR/PBRAO.xml
@@ -1,4 +1,4 @@
-<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NOUV" psdefines="PBR IBL">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="AO" psdefines="AO PBR IBL">
     <pass name="base" />
     <pass name="light" depthtest="equal" depthwrite="false" blend="add" />
     <pass name="material" psdefines="MATERIAL" depthtest="equal" depthwrite="false" />

--- a/bin/CoreData/Techniques/PBR/PBRAOAlpha.xml
+++ b/bin/CoreData/Techniques/PBR/PBRAOAlpha.xml
@@ -1,4 +1,4 @@
-<technique vs="PBRLitSolid" ps="PBRLitSolid" psdefines="PBR IBL METALLIC ROUGHNESS">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="AO" psdefines="AO PBR IBL">
     <pass name="alpha" depthwrite="false" blend="alpha" />
     <pass name="litalpha" depthwrite="false" blend="addalpha" />
     <pass name="shadow" vs="Shadow" ps="Shadow" />

--- a/bin/CoreData/Techniques/PBR/PBRDiffAO.xml
+++ b/bin/CoreData/Techniques/PBR/PBRDiffAO.xml
@@ -1,4 +1,4 @@
-<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NOUV" psdefines="PBR IBL">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="AO" psdefines="DIFFMAP AO PBR IBL">
     <pass name="base" />
     <pass name="light" depthtest="equal" depthwrite="false" blend="add" />
     <pass name="material" psdefines="MATERIAL" depthtest="equal" depthwrite="false" />

--- a/bin/CoreData/Techniques/PBR/PBRDiffAOAlpha.xml
+++ b/bin/CoreData/Techniques/PBR/PBRDiffAOAlpha.xml
@@ -1,4 +1,4 @@
-<technique vs="PBRLitSolid" ps="PBRLitSolid" psdefines="PBR IBL METALLIC ROUGHNESS">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="AO" psdefines="DIFFMAP AO PBR IBL">
     <pass name="alpha" depthwrite="false" blend="alpha" />
     <pass name="litalpha" depthwrite="false" blend="addalpha" />
     <pass name="shadow" vs="Shadow" ps="Shadow" />

--- a/bin/CoreData/Techniques/PBR/PBRDiffEmissive.xml
+++ b/bin/CoreData/Techniques/PBR/PBRDiffEmissive.xml
@@ -1,4 +1,4 @@
-<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NOUV" psdefines="PBR IBL">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" psdefines="DIFFMAP EMISSIVEMAP PBR IBL">
     <pass name="base" />
     <pass name="light" depthtest="equal" depthwrite="false" blend="add" />
     <pass name="material" psdefines="MATERIAL" depthtest="equal" depthwrite="false" />

--- a/bin/CoreData/Techniques/PBR/PBRDiffEmissiveAlpha.xml
+++ b/bin/CoreData/Techniques/PBR/PBRDiffEmissiveAlpha.xml
@@ -1,4 +1,4 @@
-<technique vs="PBRLitSolid" ps="PBRLitSolid" psdefines="PBR IBL METALLIC ROUGHNESS">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" psdefines="DIFFMAP EMISSIVEMAP PBR IBL">
     <pass name="alpha" depthwrite="false" blend="alpha" />
     <pass name="litalpha" depthwrite="false" blend="addalpha" />
     <pass name="shadow" vs="Shadow" ps="Shadow" />

--- a/bin/CoreData/Techniques/PBR/PBRDiffNormalAO.xml
+++ b/bin/CoreData/Techniques/PBR/PBRDiffNormalAO.xml
@@ -1,4 +1,4 @@
-<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP" psdefines="DIFFMAP NORMALMAP PBR IBL METALLIC ROUGHNESS">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP AO" psdefines="DIFFMAP NORMALMAP AO PBR IBL">
     <pass name="base" />
     <pass name="light" depthtest="equal" depthwrite="false" blend="add" />
     <pass name="material" psdefines="MATERIAL" depthtest="equal" depthwrite="false" />

--- a/bin/CoreData/Techniques/PBR/PBRDiffNormalAOAlpha.xml
+++ b/bin/CoreData/Techniques/PBR/PBRDiffNormalAOAlpha.xml
@@ -1,4 +1,4 @@
-<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP" psdefines="DIFFMAP NORMALMAP PBR IBL METALLIC ROUGHNESS">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP AO" psdefines="DIFFMAP NORMALMAP AO PBR IBL">
     <pass name="alpha" depthwrite="false" blend="alpha" />
     <pass name="litalpha" depthwrite="false" blend="addalpha" />
     <pass name="shadow" vs="Shadow" ps="Shadow" psexcludes="PACKEDNORMAL" />

--- a/bin/CoreData/Techniques/PBR/PBREmissive.xml
+++ b/bin/CoreData/Techniques/PBR/PBREmissive.xml
@@ -1,4 +1,4 @@
-<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NOUV" psdefines="PBR IBL">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" psdefines="EMISSIVEMAP PBR IBL">
     <pass name="base" />
     <pass name="light" depthtest="equal" depthwrite="false" blend="add" />
     <pass name="material" psdefines="MATERIAL" depthtest="equal" depthwrite="false" />

--- a/bin/CoreData/Techniques/PBR/PBREmissiveAlpha.xml
+++ b/bin/CoreData/Techniques/PBR/PBREmissiveAlpha.xml
@@ -1,4 +1,4 @@
-<technique vs="PBRLitSolid" ps="PBRLitSolid" psdefines="PBR IBL METALLIC ROUGHNESS">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" psdefines="EMISSIVEMAP PBR IBL">
     <pass name="alpha" depthwrite="false" blend="alpha" />
     <pass name="litalpha" depthwrite="false" blend="addalpha" />
     <pass name="shadow" vs="Shadow" ps="Shadow" />

--- a/bin/CoreData/Techniques/PBR/PBRMetallicRoughDiffNormalSpecAO.xml
+++ b/bin/CoreData/Techniques/PBR/PBRMetallicRoughDiffNormalSpecAO.xml
@@ -1,4 +1,4 @@
-<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP" psdefines="DIFFMAP NORMALMAP PBR IBL METALLIC ROUGHNESS">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP AO" psdefines="DIFFMAP NORMALMAP AO PBR IBL METALLIC ROUGHNESS">
     <pass name="base" />
     <pass name="light" depthtest="equal" depthwrite="false" blend="add" />
     <pass name="material" psdefines="MATERIAL" depthtest="equal" depthwrite="false" />

--- a/bin/CoreData/Techniques/PBR/PBRMetallicRoughDiffNormalSpecAOAlpha.xml
+++ b/bin/CoreData/Techniques/PBR/PBRMetallicRoughDiffNormalSpecAOAlpha.xml
@@ -1,4 +1,4 @@
-<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP" psdefines="DIFFMAP NORMALMAP PBR IBL METALLIC ROUGHNESS">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP AO" psdefines="DIFFMAP NORMALMAP AO PBR IBL METALLIC ROUGHNESS">
     <pass name="alpha" depthwrite="false" blend="alpha" />
     <pass name="litalpha" depthwrite="false" blend="addalpha" />
     <pass name="shadow" vs="Shadow" ps="Shadow" psexcludes="PACKEDNORMAL" />

--- a/bin/CoreData/Techniques/PBR/PBRMetallicRoughDiffNormalSpecEmissive.xml
+++ b/bin/CoreData/Techniques/PBR/PBRMetallicRoughDiffNormalSpecEmissive.xml
@@ -1,5 +1,4 @@
-<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP"
-           psdefines="DIFFMAP NORMALMAP EMISSIVEMAP METALLIC ROUGHNESS PBR IBL">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP" psdefines="DIFFMAP NORMALMAP EMISSIVEMAP PBR IBL METALLIC ROUGHNESS">
     <pass name="base" />
     <pass name="light" depthtest="equal" depthwrite="false" blend="add" />
     <pass name="material" psdefines="MATERIAL" depthtest="equal" depthwrite="false" />

--- a/bin/CoreData/Techniques/PBR/PBRMetallicRoughDiffNormalSpecEmissiveAlpha.xml
+++ b/bin/CoreData/Techniques/PBR/PBRMetallicRoughDiffNormalSpecEmissiveAlpha.xml
@@ -1,5 +1,4 @@
-<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP"
-           psdefines="DIFFMAP NORMALMAP EMISSIVEMAP PBR IBL METALLIC ROUGHNESS">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP" psdefines="DIFFMAP NORMALMAP EMISSIVEMAP PBR IBL METALLIC ROUGHNESS">
     <pass name="alpha" depthwrite="false" blend="alpha" />
     <pass name="litalpha" depthwrite="false" blend="addalpha" />
     <pass name="shadow" vs="Shadow" ps="Shadow" psexcludes="PACKEDNORMAL" />

--- a/bin/CoreData/Techniques/PBR/PBRMetallicRoughDiffSpecAO.xml
+++ b/bin/CoreData/Techniques/PBR/PBRMetallicRoughDiffSpecAO.xml
@@ -1,4 +1,4 @@
-<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NOUV" psdefines="PBR IBL">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="AO" psdefines="DIFFMAP AO PBR IBL METALLIC ROUGHNESS">
     <pass name="base" />
     <pass name="light" depthtest="equal" depthwrite="false" blend="add" />
     <pass name="material" psdefines="MATERIAL" depthtest="equal" depthwrite="false" />

--- a/bin/CoreData/Techniques/PBR/PBRMetallicRoughDiffSpecAOAlpha.xml
+++ b/bin/CoreData/Techniques/PBR/PBRMetallicRoughDiffSpecAOAlpha.xml
@@ -1,4 +1,4 @@
-<technique vs="PBRLitSolid" ps="PBRLitSolid" psdefines="PBR IBL METALLIC ROUGHNESS">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="AO" psdefines="DIFFMAP AO PBR IBL METALLIC ROUGHNESS">
     <pass name="alpha" depthwrite="false" blend="alpha" />
     <pass name="litalpha" depthwrite="false" blend="addalpha" />
     <pass name="shadow" vs="Shadow" ps="Shadow" />

--- a/bin/CoreData/Techniques/PBR/PBRMetallicRoughDiffSpecEmissive.xml
+++ b/bin/CoreData/Techniques/PBR/PBRMetallicRoughDiffSpecEmissive.xml
@@ -1,4 +1,4 @@
-<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NOUV" psdefines="PBR IBL">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" psdefines="DIFFMAP EMISSIVEMAP PBR IBL METALLIC ROUGHNESS">
     <pass name="base" />
     <pass name="light" depthtest="equal" depthwrite="false" blend="add" />
     <pass name="material" psdefines="MATERIAL" depthtest="equal" depthwrite="false" />

--- a/bin/CoreData/Techniques/PBR/PBRMetallicRoughDiffSpecEmissiveAlpha.xml
+++ b/bin/CoreData/Techniques/PBR/PBRMetallicRoughDiffSpecEmissiveAlpha.xml
@@ -1,4 +1,4 @@
-<technique vs="PBRLitSolid" ps="PBRLitSolid" psdefines="PBR IBL METALLIC ROUGHNESS">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" psdefines="DIFFMAP EMISSIVEMAP PBR IBL METALLIC ROUGHNESS">
     <pass name="alpha" depthwrite="false" blend="alpha" />
     <pass name="litalpha" depthwrite="false" blend="addalpha" />
     <pass name="shadow" vs="Shadow" ps="Shadow" />

--- a/bin/CoreData/Techniques/PBR/PBRMetallicRoughNormalSpec.xml
+++ b/bin/CoreData/Techniques/PBR/PBRMetallicRoughNormalSpec.xml
@@ -1,6 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-
-<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP" psdefines="NORMALMAP METALLIC ROUGHNESS PBR IBL">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP" psdefines="NORMALMAP PBR IBL METALLIC ROUGHNESS">
     <pass name="base" />
     <pass name="light" depthtest="equal" depthwrite="false" blend="add" />
     <pass name="material" psdefines="MATERIAL" depthtest="equal" depthwrite="false" />

--- a/bin/CoreData/Techniques/PBR/PBRMetallicRoughNormalSpecAO.xml
+++ b/bin/CoreData/Techniques/PBR/PBRMetallicRoughNormalSpecAO.xml
@@ -1,4 +1,4 @@
-<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP" psdefines="DIFFMAP NORMALMAP PBR IBL METALLIC ROUGHNESS">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP AO" psdefines="NORMALMAP AO PBR IBL METALLIC ROUGHNESS">
     <pass name="base" />
     <pass name="light" depthtest="equal" depthwrite="false" blend="add" />
     <pass name="material" psdefines="MATERIAL" depthtest="equal" depthwrite="false" />

--- a/bin/CoreData/Techniques/PBR/PBRMetallicRoughNormalSpecAOAlpha.xml
+++ b/bin/CoreData/Techniques/PBR/PBRMetallicRoughNormalSpecAOAlpha.xml
@@ -1,4 +1,4 @@
-<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP" psdefines="DIFFMAP NORMALMAP PBR IBL METALLIC ROUGHNESS">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP AO" psdefines="NORMALMAP AO PBR IBL METALLIC ROUGHNESS">
     <pass name="alpha" depthwrite="false" blend="alpha" />
     <pass name="litalpha" depthwrite="false" blend="addalpha" />
     <pass name="shadow" vs="Shadow" ps="Shadow" psexcludes="PACKEDNORMAL" />

--- a/bin/CoreData/Techniques/PBR/PBRMetallicRoughNormalSpecEmissive.xml
+++ b/bin/CoreData/Techniques/PBR/PBRMetallicRoughNormalSpecEmissive.xml
@@ -1,7 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-
-<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP"
-           psdefines="NORMALMAP EMISSIVEMAP METALLIC ROUGHNESS PBR IBL">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP" psdefines="NORMALMAP EMISSIVEMAP PBR IBL METALLIC ROUGHNESS">
     <pass name="base" />
     <pass name="light" depthtest="equal" depthwrite="false" blend="add" />
     <pass name="material" psdefines="MATERIAL" depthtest="equal" depthwrite="false" />

--- a/bin/CoreData/Techniques/PBR/PBRMetallicRoughNormalSpecEmissiveAlpha.xml
+++ b/bin/CoreData/Techniques/PBR/PBRMetallicRoughNormalSpecEmissiveAlpha.xml
@@ -1,7 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-
-<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP"
-           psdefines="NORMALMAP EMISSIVEMAP PBR IBL METALLIC ROUGHNESS">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP" psdefines="NORMALMAP EMISSIVEMAP PBR IBL METALLIC ROUGHNESS">
     <pass name="alpha" depthwrite="false" blend="alpha" />
     <pass name="litalpha" depthwrite="false" blend="addalpha" />
     <pass name="shadow" vs="Shadow" ps="Shadow" psexcludes="PACKEDNORMAL" />

--- a/bin/CoreData/Techniques/PBR/PBRMetallicRoughSpec.xml
+++ b/bin/CoreData/Techniques/PBR/PBRMetallicRoughSpec.xml
@@ -1,5 +1,3 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-
 <technique vs="PBRLitSolid" ps="PBRLitSolid" psdefines="PBR IBL METALLIC ROUGHNESS">
     <pass name="base" />
     <pass name="light" depthtest="equal" depthwrite="false" blend="add" />

--- a/bin/CoreData/Techniques/PBR/PBRMetallicRoughSpecAO.xml
+++ b/bin/CoreData/Techniques/PBR/PBRMetallicRoughSpecAO.xml
@@ -1,4 +1,4 @@
-<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NOUV" psdefines="PBR IBL">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="AO" psdefines="AO PBR IBL METALLIC ROUGHNESS">
     <pass name="base" />
     <pass name="light" depthtest="equal" depthwrite="false" blend="add" />
     <pass name="material" psdefines="MATERIAL" depthtest="equal" depthwrite="false" />

--- a/bin/CoreData/Techniques/PBR/PBRMetallicRoughSpecAOAlpha.xml
+++ b/bin/CoreData/Techniques/PBR/PBRMetallicRoughSpecAOAlpha.xml
@@ -1,4 +1,4 @@
-<technique vs="PBRLitSolid" ps="PBRLitSolid" psdefines="PBR IBL METALLIC ROUGHNESS">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="AO" psdefines="AO PBR IBL METALLIC ROUGHNESS">
     <pass name="alpha" depthwrite="false" blend="alpha" />
     <pass name="litalpha" depthwrite="false" blend="addalpha" />
     <pass name="shadow" vs="Shadow" ps="Shadow" />

--- a/bin/CoreData/Techniques/PBR/PBRMetallicRoughSpecEmissive.xml
+++ b/bin/CoreData/Techniques/PBR/PBRMetallicRoughSpecEmissive.xml
@@ -1,4 +1,4 @@
-<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NOUV" psdefines="PBR IBL">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" psdefines="EMISSIVEMAP PBR IBL METALLIC ROUGHNESS">
     <pass name="base" />
     <pass name="light" depthtest="equal" depthwrite="false" blend="add" />
     <pass name="material" psdefines="MATERIAL" depthtest="equal" depthwrite="false" />

--- a/bin/CoreData/Techniques/PBR/PBRMetallicRoughSpecEmissiveAlpha.xml
+++ b/bin/CoreData/Techniques/PBR/PBRMetallicRoughSpecEmissiveAlpha.xml
@@ -1,4 +1,4 @@
-<technique vs="PBRLitSolid" ps="PBRLitSolid" psdefines="PBR IBL METALLIC ROUGHNESS">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" psdefines="EMISSIVEMAP PBR IBL METALLIC ROUGHNESS">
     <pass name="alpha" depthwrite="false" blend="alpha" />
     <pass name="litalpha" depthwrite="false" blend="addalpha" />
     <pass name="shadow" vs="Shadow" ps="Shadow" />

--- a/bin/CoreData/Techniques/PBR/PBRNormal.xml
+++ b/bin/CoreData/Techniques/PBR/PBRNormal.xml
@@ -1,5 +1,3 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-
 <technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP" psdefines="NORMALMAP PBR IBL">
     <pass name="base" />
     <pass name="light" depthtest="equal" depthwrite="false" blend="add" />

--- a/bin/CoreData/Techniques/PBR/PBRNormalAO.xml
+++ b/bin/CoreData/Techniques/PBR/PBRNormalAO.xml
@@ -1,4 +1,4 @@
-<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP" psdefines="DIFFMAP NORMALMAP PBR IBL METALLIC ROUGHNESS">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP AO" psdefines="NORMALMAP AO PBR IBL">
     <pass name="base" />
     <pass name="light" depthtest="equal" depthwrite="false" blend="add" />
     <pass name="material" psdefines="MATERIAL" depthtest="equal" depthwrite="false" />

--- a/bin/CoreData/Techniques/PBR/PBRNormalAOAlpha.xml
+++ b/bin/CoreData/Techniques/PBR/PBRNormalAOAlpha.xml
@@ -1,4 +1,4 @@
-<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP" psdefines="DIFFMAP NORMALMAP PBR IBL METALLIC ROUGHNESS">
+<technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP AO" psdefines="NORMALMAP AO PBR IBL">
     <pass name="alpha" depthwrite="false" blend="alpha" />
     <pass name="litalpha" depthwrite="false" blend="addalpha" />
     <pass name="shadow" vs="Shadow" ps="Shadow" psexcludes="PACKEDNORMAL" />

--- a/bin/CoreData/Techniques/PBR/PBRNormalAlpha.xml
+++ b/bin/CoreData/Techniques/PBR/PBRNormalAlpha.xml
@@ -1,5 +1,3 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-
 <technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP" psdefines="NORMALMAP PBR IBL">
     <pass name="alpha" depthwrite="false" blend="alpha" />
     <pass name="litalpha" depthwrite="false" blend="addalpha" />

--- a/bin/CoreData/Techniques/PBR/PBRNormalEmissive.xml
+++ b/bin/CoreData/Techniques/PBR/PBRNormalEmissive.xml
@@ -1,5 +1,3 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-
 <technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP" psdefines="NORMALMAP EMISSIVEMAP PBR IBL">
     <pass name="base" />
     <pass name="light" depthtest="equal" depthwrite="false" blend="add" />

--- a/bin/CoreData/Techniques/PBR/PBRNormalEmissiveAlpha.xml
+++ b/bin/CoreData/Techniques/PBR/PBRNormalEmissiveAlpha.xml
@@ -1,5 +1,3 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-
 <technique vs="PBRLitSolid" ps="PBRLitSolid" vsdefines="NORMALMAP" psdefines="NORMALMAP EMISSIVEMAP PBR IBL">
     <pass name="alpha" depthwrite="false" blend="alpha" />
     <pass name="litalpha" depthwrite="false" blend="addalpha" />


### PR DESCRIPTION
PBR techniques generated via script https://gist.github.com/gleblebedev/c01fa7c9a1c5bff273c9cbd3020d3b89
It adds all possible permutations and fix existing techniques.
Also AO made to use same texture coordinates as all other textures except lightmap texture.