### PR TITLE
Check if scene exists

### DIFF
--- a/Source/Urho3D/Scene/Node.cpp
+++ b/Source/Urho3D/Scene/Node.cpp
@@ -360,17 +360,16 @@ void Node::AddTag(const String& tag)
 
     // Cache
     if (scene_) {
-       scene_->NodeTagAdded(this, tag);
+        scene_->NodeTagAdded(this, tag);
+    
+        // Send event
+        using namespace NodeTagAdded;
+        VariantMap& eventData = GetEventDataMap();
+        eventData[P_SCENE] = scene_;
+        eventData[P_NODE] = this;
+        eventData[P_TAG] = tag;
+        scene_->SendEvent(E_NODETAGADDED, eventData);
     }
-
-    // Send event
-    using namespace NodeTagAdded;
-    VariantMap& eventData = GetEventDataMap();
-    eventData[P_SCENE] = scene_;
-    eventData[P_NODE] = this;
-    eventData[P_TAG] = tag;
-    scene_->SendEvent(E_NODETAGADDED, eventData);
-
     // Sync
     MarkNetworkUpdate();
 }

--- a/Source/Urho3D/Scene/Node.cpp
+++ b/Source/Urho3D/Scene/Node.cpp
@@ -359,7 +359,9 @@ void Node::AddTag(const String& tag)
     impl_->tags_.Push(tag);
 
     // Cache
-    scene_->NodeTagAdded(this, tag);
+    if (scene_) {
+       scene_->NodeTagAdded(this, tag);
+    }
 
     // Send event
     using namespace NodeTagAdded;


### PR DESCRIPTION
Crash when creating node in memory (not in scene) and setting its tag. Or loading scene from file as prefab. Creating nodes in memory is correct operation afaik and is using to optimize loading process.