### PR TITLE
Fix clicks on retina display

### DIFF
--- a/Source/Urho3D/UI/UI.cpp
+++ b/Source/Urho3D/UI/UI.cpp
@@ -1321,9 +1321,6 @@ void UI::GetCursorPositionAndVisible(IntVector2& pos, bool& visible)
         if (!visible && cursor_)
             pos = cursor_->GetPosition();
     }
-
-    pos.x_ = (int)(pos.x_ / uiScale_);
-    pos.y_ = (int)(pos.y_ / uiScale_);
 }
 
 void UI::SetCursorShape(CursorShape shape)


### PR DESCRIPTION
Remove division by 2 for cursor position because it is already in correct metrics

Issue on my mac:
![Image](https://i.gyazo.com/256fb9261332ef517b6d0ade85326c59.gif)