### PR TITLE
Logging speedup

### DIFF
--- a/Source/Urho3D/IO/Log.cpp
+++ b/Source/Urho3D/IO/Log.cpp
@@ -22,6 +22,7 @@
 
 #include "../Precompiled.h"
 
+#include "../Container/Str.h"
 #include "../Core/Context.h"
 #include "../Core/CoreEvents.h"
 #include "../Core/ProcessUtils.h"
@@ -133,6 +134,21 @@ void Log::SetTimeStamp(bool enable)
 void Log::SetQuiet(bool quiet)
 {
     quiet_ = quiet;
+}
+
+void Log::WriteFormat(int level, const char* format, ...)
+{
+    if (!logInstance || logInstance->level_ > level)
+        return;
+
+    // Forward to normal Write() after formatting the input
+    String message;
+    va_list args;
+    va_start(args, format);
+    message.AppendWithFormatArgs(format, args);
+    va_end(args);
+
+    Write(level, message);
 }
 
 void Log::Write(int level, const String& message)

--- a/Source/Urho3D/IO/Log.h
+++ b/Source/Urho3D/IO/Log.h
@@ -105,6 +105,8 @@ public:
 
     /// Write to the log. If logging level is higher than the level of the message, the message is ignored.
     static void Write(int level, const String& message);
+    /// Write formatted message to the log. If logging level is higher than the level of the message, the message is ignored.
+    static void WriteFormat(int level, const char* format, ...);
     /// Write raw output to the log.
     static void WriteRaw(const String& message, bool error = false);
 
@@ -131,25 +133,32 @@ private:
 };
 
 #ifdef URHO3D_LOGGING
+#define URHO3D_LOG(level, message) Urho3D::Log::Write(level, message)
 #define URHO3D_LOGTRACE(message) Urho3D::Log::Write(Urho3D::LOG_TRACE, message)
 #define URHO3D_LOGDEBUG(message) Urho3D::Log::Write(Urho3D::LOG_DEBUG, message)
 #define URHO3D_LOGINFO(message) Urho3D::Log::Write(Urho3D::LOG_INFO, message)
 #define URHO3D_LOGWARNING(message) Urho3D::Log::Write(Urho3D::LOG_WARNING, message)
 #define URHO3D_LOGERROR(message) Urho3D::Log::Write(Urho3D::LOG_ERROR, message)
-#define URHO3D_LOGRAW(message) Urho3D::Log::WriteRaw(message)
-#define URHO3D_LOGTRACEF(format, ...) Urho3D::Log::Write(Urho3D::LOG_TRACE, Urho3D::ToString(format, ##__VA_ARGS__))
-#define URHO3D_LOGDEBUGF(format, ...) Urho3D::Log::Write(Urho3D::LOG_DEBUG, Urho3D::ToString(format, ##__VA_ARGS__))
-#define URHO3D_LOGINFOF(format, ...) Urho3D::Log::Write(Urho3D::LOG_INFO, Urho3D::ToString(format, ##__VA_ARGS__))
-#define URHO3D_LOGWARNINGF(format, ...) Urho3D::Log::Write(Urho3D::LOG_WARNING, Urho3D::ToString(format, ##__VA_ARGS__))
-#define URHO3D_LOGERRORF(format, ...) Urho3D::Log::Write(Urho3D::LOG_ERROR, Urho3D::ToString(format, ##__VA_ARGS__))
-#define URHO3D_LOGRAWF(format, ...) Urho3D::Log::WriteRaw(Urho3D::ToString(format, ##__VA_ARGS__))
+#define URHO3D_LOGRAW(message) Urho3D::Log::Write(Urho3D::LOG_RAW, message)
+
+#define URHO3D_LOGF(level, format, ...) Urho3D::Log::WriteFormat(level, format, ##__VA_ARGS__)
+#define URHO3D_LOGTRACEF(format, ...) Urho3D::Log::WriteFormat(Urho3D::LOG_TRACE, format, ##__VA_ARGS__)
+#define URHO3D_LOGDEBUGF(format, ...) Urho3D::Log::WriteFormat(Urho3D::LOG_DEBUG, format, ##__VA_ARGS__)
+#define URHO3D_LOGINFOF(format, ...) Urho3D::Log::WriteFormat(Urho3D::LOG_INFO, format, ##__VA_ARGS__)
+#define URHO3D_LOGWARNINGF(format, ...) Urho3D::Log::WriteFormat(Urho3D::LOG_WARNING, format, ##__VA_ARGS__)
+#define URHO3D_LOGERRORF(format, ...) Urho3D::Log::WriteFormat(Urho3D::LOG_ERROR, format, ##__VA_ARGS__)
+#define URHO3D_LOGRAWF(format, ...) Urho3D::Log::WriteFormat(Urho3D::LOG_RAW, format, ##__VA_ARGS__)
+
 #else
+#define URHO3D_LOG(message) ((void)0)
 #define URHO3D_LOGTRACE(message) ((void)0)
 #define URHO3D_LOGDEBUG(message) ((void)0)
 #define URHO3D_LOGINFO(message) ((void)0)
 #define URHO3D_LOGWARNING(message) ((void)0)
 #define URHO3D_LOGERROR(message) ((void)0)
 #define URHO3D_LOGRAW(message) ((void)0)
+
+#define URHO3D_LOGF(...) ((void)0)
 #define URHO3D_LOGTRACEF(...) ((void)0)
 #define URHO3D_LOGDEBUGF(...) ((void)0)
 #define URHO3D_LOGINFOF(...) ((void)0)


### PR DESCRIPTION
Speeds up logging by only constructing formatted messages when the log level justifies it. Previously all formatted log macros were calling `Urho3D::ToString()` regardless of log level, which is expensive. This patch completely solves performance issues that I had encountered in a test case where trace log messages were being created needlessly.

Also reduces duplication in the logging macros by adding two new macros that take log level as input instead of putting it in the macro name.
```
URHO3D_LOG(level, message)
URHO3D_LOGF(level, format, ...)
```

edit: I am not sure if this is thread safe... anyone have an opinion/idea?