### PR TITLE
Silence compiler warnings

### DIFF
--- a/Source/Urho3D/Graphics/CustomGeometry.cpp
+++ b/Source/Urho3D/Graphics/CustomGeometry.cpp
@@ -321,7 +321,7 @@ void CustomGeometry::FillShape(const Vector<Vector3>& shapeList, bool connectTai
         auto nextIt = it;
         while (it != shapeList.End()) {
             nextIt = it + 1;
-            if (connectTail && nextIt == shapeList.End() || nextIt != shapeList.End())
+            if ((connectTail && nextIt == shapeList.End()) || nextIt != shapeList.End())
             {
                 current = (*it);
 

--- a/Source/Urho3D/UI/Sprite.cpp
+++ b/Source/Urho3D/UI/Sprite.cpp
@@ -247,6 +247,9 @@ const Matrix3x4& Sprite::GetTransform() const
             case HA_RIGHT:
                 pos.x_ += (float)parent_->GetSize().x_;
                 break;
+
+            case HA_CUSTOM:
+                break;
             }
             switch (GetVerticalAlignment())
             {
@@ -259,6 +262,9 @@ const Matrix3x4& Sprite::GetTransform() const
 
             case VA_BOTTOM:
                 pos.y_ += (float)(parent_->GetSize().y_);
+                break;
+
+            case VA_CUSTOM:
                 break;
             }
         }

--- a/Source/Urho3D/UI/Text.cpp
+++ b/Source/Urho3D/UI/Text.cpp
@@ -779,6 +779,8 @@ int Text::GetRowStartPosition(unsigned rowIndex) const
     case HA_RIGHT:
         ret += GetSize().x_ - rowWidth;
         break;
+    case HA_CUSTOM:
+        break;
     }
 
     return ret;

--- a/Source/Urho3D/UI/Text3D.cpp
+++ b/Source/Urho3D/UI/Text3D.cpp
@@ -589,6 +589,9 @@ void Text3D::UpdateTextBatches()
     case HA_RIGHT:
         offset.x_ -= (float)text_.GetWidth();
         break;
+
+    case HA_CUSTOM:
+        break;
     }
 
     switch (text_.GetVerticalAlignment())
@@ -602,6 +605,9 @@ void Text3D::UpdateTextBatches()
 
     case VA_BOTTOM:
         offset.y_ -= (float)text_.GetHeight();
+        break;
+
+    case VA_CUSTOM:
         break;
     }
 

--- a/Source/Urho3D/UI/ToolTip.cpp
+++ b/Source/Urho3D/UI/ToolTip.cpp
@@ -74,10 +74,15 @@ void ToolTip::Update(float timeStep)
             SharedPtr<UIElement> target = it->Lock();
             if (!target)
                 it = altTargets_.Erase(it);
-            else if (hovering = target->IsHovering() && target->IsVisibleEffective())
-                break;
             else
-                ++it;
+            {
+                hovering = target->IsHovering() && target->IsVisibleEffective();
+
+                if (hovering)
+                    break;
+                else
+                    ++it;
+            }
         }
     }
 


### PR DESCRIPTION
Silences various compiler warnings... missing enums in switch statement, esoteric associativity, intention safety. There are a few other warnings but these are the low hanging fruit.