### PR TITLE
Fix build bugs for OSX and when dot dependency is missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,7 @@ configure*
 *.bak
 Thumbs.db
 .directory
+
+# Doxygen mess from absence of 'dot' dependency
+CMakeDoxyFile.in
+CMakeDoxygenDefaults.cmake

--- a/Source/ThirdParty/SDL/src/video/cocoa/SDL_cocoavideo.h
+++ b/Source/ThirdParty/SDL/src/video/cocoa/SDL_cocoavideo.h
@@ -18,6 +18,9 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
+
+// Modified by UkoeHB for Urho3D
+
 #include "../../SDL_internal.h"
 
 #ifndef SDL_cocoavideo_h_
@@ -116,6 +119,11 @@ extern NSImage * Cocoa_CreateImage(SDL_Surface * surface);
 /* Fix build with the 10.10 SDK */
 #if MAC_OS_X_VERSION_MAX_ALLOWED < 101100
 #define NSEventSubtypeTouch NSTouchEventSubtype
+// Urho3D: begin edit (fixes build failure on El Capitan, OSX 10.12)
+#endif
+/* Fix build with the 10.11 SDK */
+#if MAC_OS_X_VERSION_MAX_ALLOWED < 101200
+// Urho3D: end edit
 #define NSEventSubtypeMouseEvent NSMouseEventSubtype
 #endif
 


### PR DESCRIPTION
Fix bug in third party library that prevents the engine from building on El Capitan. [edit: [context](https://discourse.libsdl.org/t/sdl-2-0-10-old-mac-os-el-capitan-10-11-and-xcode7-3/26554/7) and [the patch](https://gist.githubusercontent.com/illume/ac2eb4daa1bd805255d5355806acf822/raw/7e3c83f760fe5bf61a9f6bcc196ed9be6f6e22da/sdl2-mac-10-11.patch)]

Also updates the gitignore for some temporary files that aren't consumed if the 'dot' dependency is missing.