### PR TITLE
E2K: added use of x86 SIMD instruction set on MCST Elbrus 2000 CPU architecture

### DIFF
--- a/CMake/Modules/CheckCompilerToolchain.cmake
+++ b/CMake/Modules/CheckCompilerToolchain.cmake
@@ -42,6 +42,8 @@
 #  HAVE_SSE4
 #  HAVE_AVX
 #  HAVE_AVX2
+#
+# CPU SIMD instruction extension support for powerpc/powerpc64 archs:
 #  HAVE_ALTIVEC
 #
 # CPU SIMD instruction extension support for arm/arm64 archs:

--- a/CMake/Modules/CheckCompilerToolchain.cmake
+++ b/CMake/Modules/CheckCompilerToolchain.cmake
@@ -33,7 +33,7 @@
 #  X86
 #  E2K
 #
-# CPU SIMD instruction extensions support for x86/x86_64 archs:
+# CPU SIMD instruction extensions support for x86/x86_64/e2k archs:
 #  HAVE_MMX
 #  HAVE_3DNOW
 #  HAVE_SSE
@@ -225,7 +225,7 @@ else ()
         endif ()
     elseif (POWERPC)
         check_extension (altivec)
-    elseif (X86)
+    elseif (X86 OR E2K)
         foreach (ext sse sse2 sse3 sse4 avx avx2)
             check_extension (${ext})
         endforeach ()

--- a/CMake/Modules/UrhoCommon.cmake
+++ b/CMake/Modules/UrhoCommon.cmake
@@ -176,7 +176,7 @@ if (CMAKE_PROJECT_NAME STREQUAL Urho3D)
     # On Windows platform Direct3D11 can be optionally chosen
     # Using Direct3D11 on non-MSVC compiler may require copying and renaming Microsoft official libraries (.lib to .a), else link failures or non-functioning graphics may result
     cmake_dependent_option (URHO3D_D3D11 "Use Direct3D11 instead of Direct3D9 (Windows platform only); overrides URHO3D_OPENGL option" FALSE "WIN32" FALSE)
-    if (X86 OR WEB)
+    if (X86 OR E2K OR WEB)
         # TODO: Rename URHO3D_SSE to URHO3D_SIMD
         if (MINGW AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9.1)
             if (NOT DEFINED URHO3D_SSE)     # Only give the warning once during initial configuration
@@ -192,8 +192,8 @@ if (CMAKE_PROJECT_NAME STREQUAL Urho3D)
         cmake_dependent_option (URHO3D_SSE "Enable SIMD instruction set (32-bit Web and Intel platforms only, including Android on Intel Atom); default to true on Intel and false on Web platform; the effective SSE level could be higher, see also URHO3D_DEPLOYMENT_TARGET and CMAKE_OSX_DEPLOYMENT_TARGET build options" "${URHO3D_DEFAULT_SIMD}" "NOT URHO3D_64BIT" TRUE)
     endif ()
     cmake_dependent_option (URHO3D_HASH_DEBUG "Enable StringHash reversing and hash collision detection at the expense of memory and performance penalty" FALSE "NOT CMAKE_BUILD_TYPE STREQUAL Release" FALSE)
-    cmake_dependent_option (URHO3D_3DNOW "Enable 3DNow! instruction set (Linux platform only); should only be used for older CPU with (legacy) 3DNow! support" "${HAVE_3DNOW}" "X86 AND CMAKE_SYSTEM_NAME STREQUAL Linux AND NOT URHO3D_SSE" FALSE)
-    cmake_dependent_option (URHO3D_MMX "Enable MMX instruction set (32-bit Linux platform only); the MMX is effectively enabled when 3DNow! or SSE is enabled; should only be used for older CPU with MMX support" "${HAVE_MMX}" "X86 AND CMAKE_SYSTEM_NAME STREQUAL Linux AND NOT URHO3D_64BIT AND NOT URHO3D_SSE AND NOT URHO3D_3DNOW" FALSE)
+    cmake_dependent_option (URHO3D_3DNOW "Enable 3DNow! instruction set (Linux platform only); should only be used for older CPU with (legacy) 3DNow! support" "${HAVE_3DNOW}" "X86 OR E2K AND CMAKE_SYSTEM_NAME STREQUAL Linux AND NOT URHO3D_SSE" FALSE)
+    cmake_dependent_option (URHO3D_MMX "Enable MMX instruction set (32-bit Linux platform only); the MMX is effectively enabled when 3DNow! or SSE is enabled; should only be used for older CPU with MMX support" "${HAVE_MMX}" "X86 OR E2K AND CMAKE_SYSTEM_NAME STREQUAL Linux AND NOT URHO3D_64BIT AND NOT URHO3D_SSE AND NOT URHO3D_3DNOW" FALSE)
     # For completeness sake - this option is intentionally not documented as we do not officially support PowerPC (yet)
     cmake_dependent_option (URHO3D_ALTIVEC "Enable AltiVec instruction set (PowerPC only)" "${HAVE_ALTIVEC}" POWERPC FALSE)
     cmake_dependent_option (URHO3D_LUAJIT "Enable Lua scripting support using LuaJIT (check LuaJIT's CMakeLists.txt for more options)" FALSE "NOT WEB" FALSE)


### PR DESCRIPTION
MCST e2k (Elbrus 2000) architecture has half native / half software support of most Intel/AMD SIMD
e.g. MMX/SSE/SSE2/SSE3/SSSE3/SSE4.1/SSE4.2/AES/AVX/AVX2 & 3DNow!/SSE4a/XOP/FMA4

- https://en.wikipedia.org/wiki/Elbrus_2000