### PR TITLE
Fix Chinese input problems on Windows and Android platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,8 @@ configure*
 *.bak
 Thumbs.db
 .directory
+
+
+#vscode
+/.vscode/**
+

--- a/Source/ThirdParty/SDL/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/Source/ThirdParty/SDL/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -2098,7 +2098,7 @@ class DummyEdit extends View implements View.OnKeyListener {
     public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
         ic = new SDLInputConnection(this, true);
 
-        outAttrs.inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD;
+        outAttrs.inputType = InputType.TYPE_CLASS_TEXT;//| InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD;
         outAttrs.imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI
                 | EditorInfo.IME_FLAG_NO_FULLSCREEN /* API 11 */;
 

--- a/Source/ThirdParty/SDL/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/Source/ThirdParty/SDL/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -2097,7 +2097,7 @@ class DummyEdit extends View implements View.OnKeyListener {
     @Override
     public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
         ic = new SDLInputConnection(this, true);
-
+        // Urho3D - Has TYPE_TEXT_VARIATION_VISIBLE_PASSWORD Android IME will be disabled input wide byte characters. For example, Chinese.
         outAttrs.inputType = InputType.TYPE_CLASS_TEXT;//| InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD;
         outAttrs.imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI
                 | EditorInfo.IME_FLAG_NO_FULLSCREEN /* API 11 */;

--- a/Source/ThirdParty/SDL/src/video/windows/SDL_windowskeyboard.c
+++ b/Source/ThirdParty/SDL/src/video/windows/SDL_windowskeyboard.c
@@ -881,9 +881,9 @@ IME_HandleMessage(HWND hwnd, UINT msg, WPARAM wParam, LPARAM *lParam, SDL_VideoD
     case WM_INPUTLANGCHANGE:
         IME_InputLangChanged(videodata);
         break;
-    case WM_IME_SETCONTEXT:
-        *lParam = 0;
-        break;
+    //case WM_IME_SETCONTEXT:
+    //    *lParam = 0;
+    //    break;
     case WM_IME_STARTCOMPOSITION:
         trap = SDL_TRUE;
         break;

--- a/Source/ThirdParty/SDL/src/video/windows/SDL_windowskeyboard.c
+++ b/Source/ThirdParty/SDL/src/video/windows/SDL_windowskeyboard.c
@@ -881,9 +881,9 @@ IME_HandleMessage(HWND hwnd, UINT msg, WPARAM wParam, LPARAM *lParam, SDL_VideoD
     case WM_INPUTLANGCHANGE:
         IME_InputLangChanged(videodata);
         break;
-    //case WM_IME_SETCONTEXT:
-    //    *lParam = 0;
-    //    break;
+    case WM_IME_SETCONTEXT:
+        *lParam = 0;
+        break;
     case WM_IME_STARTCOMPOSITION:
         trap = SDL_TRUE;
         break;


### PR DESCRIPTION
Fix Input Chinese on Windows will lose the candidate word selection box.
Fix Only input English on Android.
Ignore .vscode