### PR TITLE
UI/LineEdit: enforce length limit on paste

### DIFF
--- a/Source/Urho3D/UI/LineEdit.cpp
+++ b/Source/Urho3D/UI/LineEdit.cpp
@@ -238,8 +238,9 @@ void LineEdit::OnKey(Key key, MouseButtonFlags buttons, QualifierFlags qualifier
         if (editable_ && textCopyable_ && qualifiers & QUAL_CTRL)
         {
             const String& clipBoard = GetSubsystem<UI>()->GetClipboardText();
-            if (!clipBoard.Empty())
-            {
+            if (!clipBoard.Empty() &&
+                (line_.LengthUTF8() - text_->GetSelectionLength() + clipBoard.LengthUTF8() <= maxLength_))
+	    {
                 // Remove selected text first
                 if (text_->GetSelectionLength() > 0)
                 {


### PR DESCRIPTION
created for https://github.com/urho3d/Urho3D/issues/2725

This is the obvious way and also very conservative. I don't truncate any characters, just do nothing (prevent the paste) if length would be exceeded.  Would be more complex to truncate text. In this patch I have kept things as simple as possible by only adding 1 line, and the behavior meets my use case.