### PR TITLE
Fixed texture loading failure caused by Heightmap typo

### DIFF
--- a/bin/Data/Scenes/PBRExample.xml
+++ b/bin/Data/Scenes/PBRExample.xml
@@ -4826,7 +4826,7 @@
 		<attribute name="Scale" value="1 1 1" />
 		<attribute name="Variables" />
 		<component type="Terrain" id="16778998">
-			<attribute name="Height Map" value="Image;Textures/Heightmap.png" />
+			<attribute name="Height Map" value="Image;Textures/HeightMap.png" />
 			<attribute name="Material" value="Material;Materials/PBRTerrain.xml" />
 			<attribute name="Cast Shadows" value="true" />
 		</component>


### PR DESCRIPTION
There is a case issue with the heightmap texture name in `PBRExample.xml` scene file. Texture loading fails due to this issue.

https://github.com/urho3d/Urho3D/blob/master/bin/Data/Textures/HeightMap.png