### PR TITLE
Fix conditional typo in EditorSpawn.as

### DIFF
--- a/bin/Data/Scripts/Editor/EditorSpawn.as
+++ b/bin/Data/Scripts/Editor/EditorSpawn.as
@@ -418,8 +418,8 @@ void SpawnObject()
     if (spawnOnSelection) {
         if (selectedNodes.length > 0) {
             selectedNode = selectedNodes[0];
-		}
 	}
+    }
 	
     if (spawnedObjectsNames.length == 0)
         return;

--- a/bin/Data/Scripts/Editor/EditorSpawn.as
+++ b/bin/Data/Scripts/Editor/EditorSpawn.as
@@ -414,13 +414,10 @@ Vector3 RandomizeSpawnPosition(const Vector3&in position, float randomRadius)
 void SpawnObject()
 {
     Node@ selectedNode = null;
-    
-    if (spawnOnSelection) {
-        if (selectedNodes.length > 0) {
-            selectedNode = selectedNodes[0];
-	}
-    }
-	
+
+    if (selectedNodes.length > 0)
+        selectedNode = selectedNodes[0];
+
     if (spawnedObjectsNames.length == 0)
         return;
         

--- a/bin/Data/Scripts/Editor/EditorSpawn.as
+++ b/bin/Data/Scripts/Editor/EditorSpawn.as
@@ -415,10 +415,12 @@ void SpawnObject()
 {
     Node@ selectedNode = null;
     
-    if (spawnOnSelection)
-    if (selectedNodes.length > 0)
-        selectedNode = selectedNodes[0];
-        
+    if (spawnOnSelection) {
+        if (selectedNodes.length > 0) {
+            selectedNode = selectedNodes[0];
+		}
+	}
+	
     if (spawnedObjectsNames.length == 0)
         return;
         


### PR DESCRIPTION
Simple fix.
Additional thought: The editor spawn menu gives a checkbox that says "Spawn on selected node" when in reality it is more like "ensure all spawn positions are on selected node". Maybe it could be renamed to "Ensure spawning on selected node"?