### PR TITLE
Issue 2718 bugfix

### DIFF
--- a/Source/Urho3D/Audio/Audio.cpp
+++ b/Source/Urho3D/Audio/Audio.cpp
@@ -85,7 +85,6 @@ bool Audio::SetMode(int bufferLengthMSec, int mixRate, bool stereo, bool interpo
     desired.freq = mixRate;
 
     desired.format = AUDIO_S16;
-    desired.channels = (Uint8)(stereo ? 2 : 1);
     desired.callback = SDLAudioCallback;
     desired.userdata = this;
 
@@ -96,22 +95,23 @@ bool Audio::SetMode(int bufferLengthMSec, int mixRate, bool stereo, bool interpo
         desired.samples /= 2;
 
     // Intentionally disallow format change so that the obtained format will always be the desired format, even though that format
-    // is not matching the device format, however in doing it will enable the SDL's internal audio stream with audio conversion
-    deviceID_ = SDL_OpenAudioDevice(nullptr, SDL_FALSE, &desired, &obtained, SDL_AUDIO_ALLOW_ANY_CHANGE & ~SDL_AUDIO_ALLOW_FORMAT_CHANGE & ~SDL_AUDIO_ALLOW_CHANNELS_CHANGE);
-    if (!deviceID_)
+    // is not matching the device format, however in doing it will enable the SDL's internal audio stream with audio conversio.
+    // Also disallow channels change to avoid issues on multichannel audio device (5.1, 7.1, etc)
+    int allowedChanges = SDL_AUDIO_ALLOW_ANY_CHANGE & ~SDL_AUDIO_ALLOW_FORMAT_CHANGE & ~SDL_AUDIO_ALLOW_CHANNELS_CHANGE;
+
+    if (stereo)
     {
-        // If stereo requested but not available then fall back into mono
-        if (stereo)
-        {
-            desired.channels = 1;
-            deviceID_ = SDL_OpenAudioDevice(nullptr, SDL_FALSE, &desired, &obtained, SDL_AUDIO_ALLOW_ANY_CHANGE & ~SDL_AUDIO_ALLOW_FORMAT_CHANGE & ~SDL_AUDIO_ALLOW_CHANNELS_CHANGE);
-            if (!deviceID_)
-            {
-                URHO3D_LOGERROR("Could not initialize audio output");
-                return false;
-            }
-        }
-        else
+        desired.channels = 2;
+        deviceID_ = SDL_OpenAudioDevice(nullptr, SDL_FALSE, &desired, &obtained, allowedChanges);
+    }
+
+    // If stereo requested but not available then fall back into mono
+    if (!stereo || !deviceID_)
+    {
+        desired.channels = 1;
+        deviceID_ = SDL_OpenAudioDevice(nullptr, SDL_FALSE, &desired, &obtained, allowedChanges);
+
+        if (!deviceID_)
         {
             URHO3D_LOGERROR("Could not initialize audio output");
             return false;
@@ -134,8 +134,7 @@ bool Audio::SetMode(int bufferLengthMSec, int mixRate, bool stereo, bool interpo
     interpolation_ = interpolation;
     clipBuffer_ = new int[stereo ? fragmentSize_ << 1u : fragmentSize_];
 
-    URHO3D_LOGINFO("Set audio mode " + String(mixRate_) + " Hz " + (stereo_ ? "stereo" : "mono") + " " +
-            (interpolation_ ? "interpolated" : ""));
+    URHO3D_LOGINFO("Set audio mode " + String(mixRate_) + " Hz " + (stereo_ ? "stereo" : "mono") + (interpolation_ ? " interpolated" : ""));
 
     return Play();
 }

--- a/Source/Urho3D/Audio/Audio.cpp
+++ b/Source/Urho3D/Audio/Audio.cpp
@@ -97,22 +97,21 @@ bool Audio::SetMode(int bufferLengthMSec, int mixRate, bool stereo, bool interpo
 
     // Intentionally disallow format change so that the obtained format will always be the desired format, even though that format
     // is not matching the device format, however in doing it will enable the SDL's internal audio stream with audio conversion
-    deviceID_ = SDL_OpenAudioDevice(nullptr, SDL_FALSE, &desired, &obtained, SDL_AUDIO_ALLOW_ANY_CHANGE & ~SDL_AUDIO_ALLOW_FORMAT_CHANGE);
+    deviceID_ = SDL_OpenAudioDevice(nullptr, SDL_FALSE, &desired, &obtained, SDL_AUDIO_ALLOW_ANY_CHANGE & ~SDL_AUDIO_ALLOW_FORMAT_CHANGE & ~SDL_AUDIO_ALLOW_CHANNELS_CHANGE);
     if (!deviceID_)
     {
-        URHO3D_LOGERROR("Could not initialize audio output");
-        return false;
-    }
-
-    // If device was created with greater number of channels then requested (for instance 5.1 channels when only 2 stereo channels were requested) then limit the number to requested one.
-    if (obtained.channels > desired.channels)
-    {
-        // Close previously created device.
-        SDL_CloseAudioDevice(deviceID_);
-
-        // Create new device with limited number of channels.
-        deviceID_ = SDL_OpenAudioDevice(nullptr, SDL_FALSE, &desired, &obtained, SDL_AUDIO_ALLOW_ANY_CHANGE & ~SDL_AUDIO_ALLOW_FORMAT_CHANGE & ~SDL_AUDIO_ALLOW_CHANNELS_CHANGE);
-        if (!deviceID_)
+        // If stereo requested but not available then fall back into mono
+        if (stereo)
+        {
+            desired.channels = 1;
+            deviceID_ = SDL_OpenAudioDevice(nullptr, SDL_FALSE, &desired, &obtained, SDL_AUDIO_ALLOW_ANY_CHANGE & ~SDL_AUDIO_ALLOW_FORMAT_CHANGE & ~SDL_AUDIO_ALLOW_CHANNELS_CHANGE);
+            if (!deviceID_)
+            {
+                URHO3D_LOGERROR("Could not initialize audio output");
+                return false;
+            }
+        }
+        else
         {
             URHO3D_LOGERROR("Could not initialize audio output");
             return false;


### PR DESCRIPTION
@1vanK updated version as requested.

https://github.com/urho3d/Urho3D/issues/2718

Limit number of channels to avoid issues on multichannel audio device (5.1, 7.1, etc)

The issue is present on, for example, Logitech G933 headphones with surround sound enabled.