### PR TITLE
Fix output obj file on linux system.

### DIFF
--- a/Source/Urho3D/Graphics/Drawable.cpp
+++ b/Source/Urho3D/Graphics/Drawable.cpp
@@ -583,7 +583,7 @@ bool WriteDrawablesToOBJ(const PODVector<Drawable*>& drawables, File* outputFile
                     String output = "f ";
                     if (hasNormals)
                     {
-                        output.AppendWithFormat("%l/%l/%l %l/%l/%l %l/%l/%l",
+                        output.AppendWithFormat("%u/%u/%u %u/%u/%u %u/%u/%u",
                             currentPositionIndex + longIndices[0],
                             currentUVIndex + longIndices[0],
                             currentNormalIndex + longIndices[0],
@@ -597,7 +597,7 @@ bool WriteDrawablesToOBJ(const PODVector<Drawable*>& drawables, File* outputFile
                     else if (hasNormals || hasUV)
                     {
                         unsigned secondTraitIndex = hasNormals ? currentNormalIndex : currentUVIndex;
-                        output.AppendWithFormat("%l%s%l %l%s%l %l%s%l",
+                        output.AppendWithFormat("%u%s%u %u%s%u %u%s%u",
                             currentPositionIndex + longIndices[0],
                             slashCharacter.CString(),
                             secondTraitIndex + longIndices[0],
@@ -610,7 +610,7 @@ bool WriteDrawablesToOBJ(const PODVector<Drawable*>& drawables, File* outputFile
                     }
                     else
                     {
-                        output.AppendWithFormat("%l %l %l",
+                        output.AppendWithFormat("%u %u %u",
                             currentPositionIndex + longIndices[0],
                             currentPositionIndex + longIndices[1],
                             currentPositionIndex + longIndices[2]);


### PR DESCRIPTION
Fix format dismatch error in WriteDrawablesToOBJ,.

When  use Drawable::WriteDrawablesToOBJ to produce an obj file in posix system, one of the face indice value will be deadly wrong, in my system environment(linux), it comes a super huge number that makes an error when trying to import that file with assimp.

On windows system, both  unsigned and unsigned long takes the same size, so everything goes in a right way with lucky. But on posix system, unsigned long takes double size than unsigned, which makes a memory reading problem. So modify "%l" to "%u" to ensure the type matching fixes this issue.