### PR TITLE
News article about Bit Champs

### DIFF
--- a/website/news/2021-06-06-Bit-Champs.mdx
+++ b/website/news/2021-06-06-Bit-Champs.mdx
@@ -1,0 +1,48 @@
+---
+title: Bit Champs
+description: Bit Champs is a 3D fantasy fighting action game inspired in first gen consoles aesthetics and retro arcade games mechanics.
+author: Carbon Copycat Games
+author_title: Indie developer
+author_url: https://linktr.ee/carboncopycatgames
+author_image_url: https://d1fdloi71mui9q.cloudfront.net/kV3fsVWTqQbuO4eQ3hDg_b7C20ED5w2DpJv7n
+tags: [arcade, fighting, fight, retro, psx]
+---
+
+import EmbedResponsive from "../src/components/EmbedResponsive";
+
+Bit Champs is a free 3D fantasy fighting action game inspired in first gen consoles aesthetics and fighting retro arcade games mechanics, powered by Urho3D Game Engine.
+
+<EmbedResponsive wide={true}>
+  <iframe width="560" height="315" src="https://www.youtube.com/watch?v=v5lxPzuj_O0" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen/>
+</EmbedResponsive>
+
+<!--truncate-->
+
+It features seven heroes and four game modes which unlocks many features, including new heroes and skins.
+
+Includes these game modes:
+
+- Mission will introduce you to the game mechanics with different single battles.
+- Story will let you choose a hero to fight through the main story taking strategic decisions through epic battles to have a battle with the final boss.
+- Arcade set you in four different fights to test your strength.
+- VS will let you test your skills fighting any other hero in a single arcade fight.
+
+Download today and play for free!
+
+FEATURES
+
+- Graphics with first gen consoles aesthetics.
+- Battles with different objectives.
+- Seven selectable heroes to fight with.
+- Action game mechanics.
+- Four different stages for fighting.
+- Includes achievements and leaderboards.
+- 3D environment.
+- Epic music and battle intros.
+- Retro console aesthetics.
+
+[DOWNLOAD LINKS AND MORE](https://linktr.ee/carboncopycatgames)
+
+_Urho3D's Editor for Bit Champs_
+![editor](https://user-images.githubusercontent.com/79669499/121565271-b3c17200-c9f2-11eb-91e4-29d7397105b6.png)
+


### PR DESCRIPTION
Hi,

This is an article about Bit Champs for the News section on Urho3D's website.
[This is the relevant discourse post](https://discourse.urho3d.io/t/new-release-bit-champs-and-our-first-project-with-urho3d/6877).

I tried to follow the guidelines in the other articles.