### PR TITLE
Website News Bit Champ Fix for embed Youtube player

### DIFF
--- a/website/news/2021-06-06-Bit-Champs.mdx
+++ b/website/news/2021-06-06-Bit-Champs.mdx
@@ -13,7 +13,7 @@ import EmbedResponsive from "../src/components/EmbedResponsive";
 Bit Champs is a free 3D fantasy fighting action game inspired in first gen consoles aesthetics and fighting retro arcade games mechanics, powered by Urho3D Game Engine.
 
 <EmbedResponsive wide={true}>
-  <iframe width="560" height="315" src="https://www.youtube.com/watch?v=v5lxPzuj_O0" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen/>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/v5lxPzuj_O0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </EmbedResponsive>
 
 <!--truncate-->


### PR DESCRIPTION
Hi,

I did a mistake by copy & paste.
The embed youtube player won't show up.
This new pr replaces the **iframe** tag with a valid one.

![Screenshot_2021-06-11_09-59-57](https://user-images.githubusercontent.com/79669499/121690125-d2c80e80-ca9b-11eb-8803-9969601d1dfb.png)