### PR TITLE
Fix Connection support JSON scene format on a client side

### DIFF
--- a/Source/Urho3D/Network/Connection.cpp
+++ b/Source/Urho3D/Network/Connection.cpp
@@ -1619,6 +1619,8 @@ void Connection::OnPackagesReady()
 
         if (extension == ".xml")
             success = scene_->LoadAsyncXML(file);
+        else if (extension == ".json")
+            success = scene_->LoadAsyncJSON(file);
         else
             success = scene_->LoadAsync(file);
 


### PR DESCRIPTION
As we know, Urho3D supports the scenes in the JSON format (even the standard editor can export the scenes in JSON), but after connecting to the server when the scene is loading on the client side, the engine gives an error like "ERROR: Scene.json is not a valid scene file". This fix solves this problem. 