### PR TITLE
Remove FakeAddRef and FakeReleaseRef

### DIFF
--- a/Source/Tools/BindingGenerator/ASResult.cpp
+++ b/Source/Tools/BindingGenerator/ASResult.cpp
@@ -671,20 +671,6 @@ namespace Result
                 needGap = true;
             }
 
-            if (needGap && processedClass.fakeRefBehaviors_.size())
-                ofs << '\n';
-
-            for (const SpecialMethodRegistration& fakeRefBehavior : processedClass.fakeRefBehaviors_)
-            {
-                if (fakeRefBehavior.comment_.size())
-                    ofs << "    // " << fakeRefBehavior.comment_ << '\n';
-
-                ofs << "    " + fakeRefBehavior.registration_ << '\n';
-
-                needGap = true;
-            }
-
-
             if (needGap && processedClass.subclassRegistrations_.size())
                 ofs << '\n';
 

--- a/Source/Tools/BindingGenerator/ASResult.h
+++ b/Source/Tools/BindingGenerator/ASResult.h
@@ -227,8 +227,6 @@ struct ProcessedClass
 
     shared_ptr<SpecialMethodRegistration> destructor_;
 
-    vector<SpecialMethodRegistration> fakeRefBehaviors_;
-
     vector<MemberRegistrationError> unregisteredSpecialMethods_;
 
     //vector<MethodRegistration> methods_;

--- a/Source/Tools/BindingGenerator/ASUtils.cpp
+++ b/Source/Tools/BindingGenerator/ASUtils.cpp
@@ -513,8 +513,8 @@ ConvertedVariable CppVariableToAS(const TypeAnalyzer& type, VariableUsage usage,
     {
         shared_ptr<ClassAnalyzer> analyzer = FindClassByName(cppTypeName);
 
-        if (analyzer && (analyzer->IsRefCounted() || Contains(analyzer->GetComment(), "FAKE_REF")))
-            result.asDeclaration_ += "@+";
+        if (analyzer && (analyzer->IsRefCounted() || analyzer->IsFakeRef()))
+            result.asDeclaration_ = result.asDeclaration_  + "@" + (analyzer->IsFakeRef() ? "" : "+");
         else
             throw Exception("Error: type \"" + type.ToString() + "\" can not automatically bind");
     }
@@ -597,8 +597,8 @@ string CppTypeToAS(const TypeAnalyzer& type, TypeUsage typeUsage)
     {
         shared_ptr<ClassAnalyzer> analyzer = FindClassByName(type.GetNameWithTemplateParams());
 
-        if (analyzer && (analyzer->IsRefCounted() || Contains(analyzer->GetComment(), "FAKE_REF")))
-            result += "@+";
+        if (analyzer && (analyzer->IsRefCounted() || analyzer->IsFakeRef()))
+            result = result + "@" + (analyzer->IsFakeRef() ? "" : "+");
         else
             throw Exception("Error: type \"" + type.ToString() + "\" can not automatically bind");
     }

--- a/Source/Tools/BindingGenerator/XmlAnalyzer.h
+++ b/Source/Tools/BindingGenerator/XmlAnalyzer.h
@@ -304,6 +304,7 @@ public:
     bool AllFloats() const;
     bool AllInts() const;
     bool IsPod() const;
+    bool IsFakeRef() const { return Contains(GetComment(), "FAKE_REF"); }
     shared_ptr<ClassAnalyzer> GetBaseClass() const;
     vector<ClassAnalyzer> GetBaseClasses() const;
     vector<ClassAnalyzer> GetAllBaseClasses() const;

--- a/Source/Urho3D/AngelScript/APITemplates.h
+++ b/Source/Urho3D/AngelScript/APITemplates.h
@@ -232,19 +232,22 @@ template <class BaseType, class DerivedType> void RegisterSubclass(asIScriptEngi
 {
     if (!strcmp(baseClassName, derivedClassName))
         return;
-
-    String declReturnBase(String(baseClassName) + "@+ opImplCast()");
+    String declReturnBase = String(baseClassName) +
+                            ((engine->GetTypeInfoByName(baseClassName)->GetFlags() & asOBJ_NOCOUNT) ? "@" : "@+") +
+                            " opImplCast()";
     engine->RegisterObjectMethod(derivedClassName, declReturnBase.CString(), AS_FUNCTION_OBJLAST((RefCast<DerivedType, BaseType>)), AS_CALL_CDECL_OBJLAST);
 
-    String declReturnBaseConst("const " + String(baseClassName) + "@+ opImplCast() const");
+    String declReturnBaseConst("const " + declReturnBase + " const");
     engine->RegisterObjectMethod(derivedClassName, declReturnBaseConst.CString(), AS_FUNCTION_OBJLAST((RefCast<DerivedType, BaseType>)), AS_CALL_CDECL_OBJLAST);
 
     //String declReturnDerived(String(derivedClassName) + "@+ opCast()");
-    String declReturnDerived(String(derivedClassName) + "@+ opImplCast()");
+    String declReturnDerived(String(derivedClassName) +
+              ((engine->GetTypeInfoByName(derivedClassName)->GetFlags() & asOBJ_NOCOUNT) ? "@" : "@+") +
+              " opImplCast()");
     engine->RegisterObjectMethod(baseClassName, declReturnDerived.CString(), AS_FUNCTION_OBJLAST((RefCast<BaseType, DerivedType>)), AS_CALL_CDECL_OBJLAST);
 
     //String declReturnDerivedConst("const " + String(derivedClassName) + "@+ opCast() const");
-    String declReturnDerivedConst("const " + String(derivedClassName) + "@+ opImplCast() const");
+    String declReturnDerivedConst("const " + declReturnDerived + " const");
     engine->RegisterObjectMethod(baseClassName, declReturnDerivedConst.CString(), AS_FUNCTION_OBJLAST((RefCast<BaseType, DerivedType>)), AS_CALL_CDECL_OBJLAST);
 }
 

--- a/Source/Urho3D/AngelScript/Generated_Classes.cpp
+++ b/Source/Urho3D/AngelScript/Generated_Classes.cpp
@@ -48,9 +48,6 @@ static void Register_AllocatorNode(asIScriptEngine* engine)
 // struct AnimationControl | File: ../Graphics/AnimationController.h
 static void Register_AnimationControl(asIScriptEngine* engine)
 {
-    engine->RegisterObjectBehaviour("AnimationControl", asBEHAVE_ADDREF, "void f()", AS_FUNCTION_OBJLAST(FakeAddRef), AS_CALL_CDECL_OBJLAST);
-    engine->RegisterObjectBehaviour("AnimationControl", asBEHAVE_RELEASE, "void f()", AS_FUNCTION_OBJLAST(FakeReleaseRef), AS_CALL_CDECL_OBJLAST);
-
     RegisterMembers_AnimationControl<AnimationControl>(engine, "AnimationControl");
 
     #ifdef REGISTER_CLASS_MANUAL_PART_AnimationControl
@@ -96,9 +93,6 @@ static void Register_AnimationStateTrack(asIScriptEngine* engine)
 // struct AnimationTrack | File: ../Graphics/Animation.h
 static void Register_AnimationTrack(asIScriptEngine* engine)
 {
-    engine->RegisterObjectBehaviour("AnimationTrack", asBEHAVE_ADDREF, "void f()", AS_FUNCTION_OBJLAST(FakeAddRef), AS_CALL_CDECL_OBJLAST);
-    engine->RegisterObjectBehaviour("AnimationTrack", asBEHAVE_RELEASE, "void f()", AS_FUNCTION_OBJLAST(FakeReleaseRef), AS_CALL_CDECL_OBJLAST);
-
     RegisterMembers_AnimationTrack<AnimationTrack>(engine, "AnimationTrack");
 
     #ifdef REGISTER_CLASS_MANUAL_PART_AnimationTrack
@@ -300,9 +294,6 @@ static void Register_BiasParameters(asIScriptEngine* engine)
 // struct Billboard | File: ../Graphics/BillboardSet.h
 static void Register_Billboard(asIScriptEngine* engine)
 {
-    engine->RegisterObjectBehaviour("Billboard", asBEHAVE_ADDREF, "void f()", AS_FUNCTION_OBJLAST(FakeAddRef), AS_CALL_CDECL_OBJLAST);
-    engine->RegisterObjectBehaviour("Billboard", asBEHAVE_RELEASE, "void f()", AS_FUNCTION_OBJLAST(FakeReleaseRef), AS_CALL_CDECL_OBJLAST);
-
     RegisterMembers_Billboard<Billboard>(engine, "Billboard");
 
     #ifdef REGISTER_CLASS_MANUAL_PART_Billboard
@@ -316,9 +307,6 @@ static void Register_Billboard(asIScriptEngine* engine)
 // struct Bone | File: ../Graphics/Skeleton.h
 static void Register_Bone(asIScriptEngine* engine)
 {
-    engine->RegisterObjectBehaviour("Bone", asBEHAVE_ADDREF, "void f()", AS_FUNCTION_OBJLAST(FakeAddRef), AS_CALL_CDECL_OBJLAST);
-    engine->RegisterObjectBehaviour("Bone", asBEHAVE_RELEASE, "void f()", AS_FUNCTION_OBJLAST(FakeReleaseRef), AS_CALL_CDECL_OBJLAST);
-
     RegisterMembers_Bone<Bone>(engine, "Bone");
 
     #ifdef REGISTER_CLASS_MANUAL_PART_Bone
@@ -517,12 +505,9 @@ static ColorFrame* ColorFrame__ColorFrame_constspColoramp_float(const Color& col
 static void Register_ColorFrame(asIScriptEngine* engine)
 {
     // explicit ColorFrame::ColorFrame(const Color& color)
-    engine->RegisterObjectBehaviour("ColorFrame", asBEHAVE_FACTORY, "ColorFrame@+ f(const Color&in)", AS_FUNCTION(ColorFrame__ColorFrame_constspColoramp) , AS_CALL_CDECL);
+    engine->RegisterObjectBehaviour("ColorFrame", asBEHAVE_FACTORY, "ColorFrame@ f(const Color&in)", AS_FUNCTION(ColorFrame__ColorFrame_constspColoramp) , AS_CALL_CDECL);
     // ColorFrame::ColorFrame(const Color& color, float time)
-    engine->RegisterObjectBehaviour("ColorFrame", asBEHAVE_FACTORY, "ColorFrame@+ f(const Color&in, float)", AS_FUNCTION(ColorFrame__ColorFrame_constspColoramp_float) , AS_CALL_CDECL);
-
-    engine->RegisterObjectBehaviour("ColorFrame", asBEHAVE_ADDREF, "void f()", AS_FUNCTION_OBJLAST(FakeAddRef), AS_CALL_CDECL_OBJLAST);
-    engine->RegisterObjectBehaviour("ColorFrame", asBEHAVE_RELEASE, "void f()", AS_FUNCTION_OBJLAST(FakeReleaseRef), AS_CALL_CDECL_OBJLAST);
+    engine->RegisterObjectBehaviour("ColorFrame", asBEHAVE_FACTORY, "ColorFrame@ f(const Color&in, float)", AS_FUNCTION(ColorFrame__ColorFrame_constspColoramp_float) , AS_CALL_CDECL);
 
     RegisterMembers_ColorFrame<ColorFrame>(engine, "ColorFrame");
 
@@ -610,9 +595,6 @@ static void Register_CursorShapeInfo(asIScriptEngine* engine)
 // struct CustomGeometryVertex | File: ../Graphics/CustomGeometry.h
 static void Register_CustomGeometryVertex(asIScriptEngine* engine)
 {
-    engine->RegisterObjectBehaviour("CustomGeometryVertex", asBEHAVE_ADDREF, "void f()", AS_FUNCTION_OBJLAST(FakeAddRef), AS_CALL_CDECL_OBJLAST);
-    engine->RegisterObjectBehaviour("CustomGeometryVertex", asBEHAVE_RELEASE, "void f()", AS_FUNCTION_OBJLAST(FakeReleaseRef), AS_CALL_CDECL_OBJLAST);
-
     RegisterMembers_CustomGeometryVertex<CustomGeometryVertex>(engine, "CustomGeometryVertex");
 
     #ifdef REGISTER_CLASS_MANUAL_PART_CustomGeometryVertex
@@ -733,9 +715,6 @@ static void Register_DepthValue(asIScriptEngine* engine)
 // class Deserializer | File: ../IO/Deserializer.h
 static void Register_Deserializer(asIScriptEngine* engine)
 {
-    engine->RegisterObjectBehaviour("Deserializer", asBEHAVE_ADDREF, "void f()", AS_FUNCTION_OBJLAST(FakeAddRef), AS_CALL_CDECL_OBJLAST);
-    engine->RegisterObjectBehaviour("Deserializer", asBEHAVE_RELEASE, "void f()", AS_FUNCTION_OBJLAST(FakeReleaseRef), AS_CALL_CDECL_OBJLAST);
-
     RegisterMembers_Deserializer<Deserializer>(engine, "Deserializer");
 
     #ifdef REGISTER_CLASS_MANUAL_PART_Deserializer
@@ -1181,9 +1160,6 @@ static void Register_JSONValue(asIScriptEngine* engine)
 // struct JoystickState | File: ../Input/Input.h
 static void Register_JoystickState(asIScriptEngine* engine)
 {
-    engine->RegisterObjectBehaviour("JoystickState", asBEHAVE_ADDREF, "void f()", AS_FUNCTION_OBJLAST(FakeAddRef), AS_CALL_CDECL_OBJLAST);
-    engine->RegisterObjectBehaviour("JoystickState", asBEHAVE_RELEASE, "void f()", AS_FUNCTION_OBJLAST(FakeReleaseRef), AS_CALL_CDECL_OBJLAST);
-
     RegisterMembers_JoystickState<JoystickState>(engine, "JoystickState");
 
     #ifdef REGISTER_CLASS_MANUAL_PART_JoystickState
@@ -2156,9 +2132,6 @@ static void Register_ScreenModeParams(asIScriptEngine* engine)
 // class Serializer | File: ../IO/Serializer.h
 static void Register_Serializer(asIScriptEngine* engine)
 {
-    engine->RegisterObjectBehaviour("Serializer", asBEHAVE_ADDREF, "void f()", AS_FUNCTION_OBJLAST(FakeAddRef), AS_CALL_CDECL_OBJLAST);
-    engine->RegisterObjectBehaviour("Serializer", asBEHAVE_RELEASE, "void f()", AS_FUNCTION_OBJLAST(FakeReleaseRef), AS_CALL_CDECL_OBJLAST);
-
     RegisterMembers_Serializer<Serializer>(engine, "Serializer");
 
     #ifdef REGISTER_CLASS_MANUAL_PART_Serializer
@@ -2229,9 +2202,6 @@ static void Register_ShadowBatchQueue(asIScriptEngine* engine)
 // class Skeleton | File: ../Graphics/Skeleton.h
 static void Register_Skeleton(asIScriptEngine* engine)
 {
-    engine->RegisterObjectBehaviour("Skeleton", asBEHAVE_ADDREF, "void f()", AS_FUNCTION_OBJLAST(FakeAddRef), AS_CALL_CDECL_OBJLAST);
-    engine->RegisterObjectBehaviour("Skeleton", asBEHAVE_RELEASE, "void f()", AS_FUNCTION_OBJLAST(FakeReleaseRef), AS_CALL_CDECL_OBJLAST);
-
     RegisterMembers_Skeleton<Skeleton>(engine, "Skeleton");
 
     #ifdef REGISTER_CLASS_MANUAL_PART_Skeleton
@@ -2614,9 +2584,6 @@ static void Register_TechniqueEntry(asIScriptEngine* engine)
 // struct TextureFrame | File: ../Graphics/ParticleEffect.h
 static void Register_TextureFrame(asIScriptEngine* engine)
 {
-    engine->RegisterObjectBehaviour("TextureFrame", asBEHAVE_ADDREF, "void f()", AS_FUNCTION_OBJLAST(FakeAddRef), AS_CALL_CDECL_OBJLAST);
-    engine->RegisterObjectBehaviour("TextureFrame", asBEHAVE_RELEASE, "void f()", AS_FUNCTION_OBJLAST(FakeReleaseRef), AS_CALL_CDECL_OBJLAST);
-
     RegisterMembers_TextureFrame<TextureFrame>(engine, "TextureFrame");
 
     #ifdef REGISTER_CLASS_MANUAL_PART_TextureFrame
@@ -2643,9 +2610,6 @@ static void Register_Timer(asIScriptEngine* engine)
 // struct TouchState | File: ../Input/Input.h
 static void Register_TouchState(asIScriptEngine* engine)
 {
-    engine->RegisterObjectBehaviour("TouchState", asBEHAVE_ADDREF, "void f()", AS_FUNCTION_OBJLAST(FakeAddRef), AS_CALL_CDECL_OBJLAST);
-    engine->RegisterObjectBehaviour("TouchState", asBEHAVE_RELEASE, "void f()", AS_FUNCTION_OBJLAST(FakeReleaseRef), AS_CALL_CDECL_OBJLAST);
-
     RegisterMembers_TouchState<TouchState>(engine, "TouchState");
 
     #ifdef REGISTER_CLASS_MANUAL_PART_TouchState
@@ -3576,9 +3540,6 @@ static void Register_SourceBatch2D(asIScriptEngine* engine)
 // struct TileMapInfo2D | File: ../Urho2D/TileMapDefs2D.h
 static void Register_TileMapInfo2D(asIScriptEngine* engine)
 {
-    engine->RegisterObjectBehaviour("TileMapInfo2D", asBEHAVE_ADDREF, "void f()", AS_FUNCTION_OBJLAST(FakeAddRef), AS_CALL_CDECL_OBJLAST);
-    engine->RegisterObjectBehaviour("TileMapInfo2D", asBEHAVE_RELEASE, "void f()", AS_FUNCTION_OBJLAST(FakeReleaseRef), AS_CALL_CDECL_OBJLAST);
-
     RegisterMembers_TileMapInfo2D<TileMapInfo2D>(engine, "TileMapInfo2D");
 
     #ifdef REGISTER_CLASS_MANUAL_PART_TileMapInfo2D

--- a/Source/Urho3D/AngelScript/Generated_DefaultConstructors.cpp
+++ b/Source/Urho3D/AngelScript/Generated_DefaultConstructors.cpp
@@ -19,7 +19,7 @@ void ASRegisterGeneratedDefaultConstructors(asIScriptEngine* engine)
     engine->RegisterObjectBehaviour("AllocatorNode", asBEHAVE_CONSTRUCT, "void f()", asFUNCTION(ASCompatibleConstructor<AllocatorNode>), AS_CALL_CDECL_OBJFIRST);
 
     // AnimationControl::AnimationControl() | File: ../Graphics/AnimationController.h
-    engine->RegisterObjectBehaviour("AnimationControl", asBEHAVE_FACTORY, "AnimationControl@+ f()", asFUNCTION(ASCompatibleFactory<AnimationControl>), AS_CALL_CDECL);
+    engine->RegisterObjectBehaviour("AnimationControl", asBEHAVE_FACTORY, "AnimationControl@ f()", asFUNCTION(ASCompatibleFactory<AnimationControl>), AS_CALL_CDECL);
 
     // AnimationKeyFrame::AnimationKeyFrame() | File: ../Graphics/Animation.h
     engine->RegisterObjectBehaviour("AnimationKeyFrame", asBEHAVE_CONSTRUCT, "void f()", asFUNCTION(ASCompatibleConstructor<AnimationKeyFrame>), AS_CALL_CDECL_OBJFIRST);
@@ -28,7 +28,7 @@ void ASRegisterGeneratedDefaultConstructors(asIScriptEngine* engine)
     engine->RegisterObjectBehaviour("AnimationStateTrack", asBEHAVE_CONSTRUCT, "void f()", asFUNCTION(ASCompatibleConstructor<AnimationStateTrack>), AS_CALL_CDECL_OBJFIRST);
 
     // AnimationTrack::AnimationTrack() | File: ../Graphics/Animation.h
-    engine->RegisterObjectBehaviour("AnimationTrack", asBEHAVE_FACTORY, "AnimationTrack@+ f()", asFUNCTION(ASCompatibleFactory<AnimationTrack>), AS_CALL_CDECL);
+    engine->RegisterObjectBehaviour("AnimationTrack", asBEHAVE_FACTORY, "AnimationTrack@ f()", asFUNCTION(ASCompatibleFactory<AnimationTrack>), AS_CALL_CDECL);
 
     // AnimationTriggerPoint::AnimationTriggerPoint() | File: ../Graphics/Animation.h
     engine->RegisterObjectBehaviour("AnimationTriggerPoint", asBEHAVE_CONSTRUCT, "void f()", asFUNCTION(ASCompatibleConstructor<AnimationTriggerPoint>), AS_CALL_CDECL_OBJFIRST);
@@ -58,7 +58,7 @@ void ASRegisterGeneratedDefaultConstructors(asIScriptEngine* engine)
     engine->RegisterObjectBehaviour("BiasParameters", asBEHAVE_CONSTRUCT, "void f()", asFUNCTION(ASCompatibleConstructor<BiasParameters>), AS_CALL_CDECL_OBJFIRST);
 
     // Bone::Bone() | File: ../Graphics/Skeleton.h
-    engine->RegisterObjectBehaviour("Bone", asBEHAVE_FACTORY, "Bone@+ f()", asFUNCTION(ASCompatibleFactory<Bone>), AS_CALL_CDECL);
+    engine->RegisterObjectBehaviour("Bone", asBEHAVE_FACTORY, "Bone@ f()", asFUNCTION(ASCompatibleFactory<Bone>), AS_CALL_CDECL);
 
     // BoundingBox::BoundingBox() noexcept | File: ../Math/BoundingBox.h
     engine->RegisterObjectBehaviour("BoundingBox", asBEHAVE_CONSTRUCT, "void f()", asFUNCTION(ASCompatibleConstructor<BoundingBox>), AS_CALL_CDECL_OBJFIRST);
@@ -73,7 +73,7 @@ void ASRegisterGeneratedDefaultConstructors(asIScriptEngine* engine)
     engine->RegisterObjectBehaviour("Color", asBEHAVE_CONSTRUCT, "void f()", asFUNCTION(ASCompatibleConstructor<Color>), AS_CALL_CDECL_OBJFIRST);
 
     // ColorFrame::ColorFrame() | File: ../Graphics/ParticleEffect.h
-    engine->RegisterObjectBehaviour("ColorFrame", asBEHAVE_FACTORY, "ColorFrame@+ f()", asFUNCTION(ASCompatibleFactory<ColorFrame>), AS_CALL_CDECL);
+    engine->RegisterObjectBehaviour("ColorFrame", asBEHAVE_FACTORY, "ColorFrame@ f()", asFUNCTION(ASCompatibleFactory<ColorFrame>), AS_CALL_CDECL);
 
     // CompressedLevel::CompressedLevel() | Implicitly-declared
     engine->RegisterObjectBehaviour("CompressedLevel", asBEHAVE_CONSTRUCT, "void f()", asFUNCTION(ASCompatibleConstructor<CompressedLevel>), AS_CALL_CDECL_OBJFIRST);
@@ -271,7 +271,7 @@ void ASRegisterGeneratedDefaultConstructors(asIScriptEngine* engine)
     engine->RegisterObjectBehaviour("ShadowBatchQueue", asBEHAVE_CONSTRUCT, "void f()", asFUNCTION(ASCompatibleConstructor<ShadowBatchQueue>), AS_CALL_CDECL_OBJFIRST);
 
     // Skeleton::Skeleton() | File: ../Graphics/Skeleton.h
-    engine->RegisterObjectBehaviour("Skeleton", asBEHAVE_FACTORY, "Skeleton@+ f()", asFUNCTION(ASCompatibleFactory<Skeleton>), AS_CALL_CDECL);
+    engine->RegisterObjectBehaviour("Skeleton", asBEHAVE_FACTORY, "Skeleton@ f()", asFUNCTION(ASCompatibleFactory<Skeleton>), AS_CALL_CDECL);
 
     // SourceBatch::SourceBatch() | File: ../Graphics/Drawable.h
     engine->RegisterObjectBehaviour("SourceBatch", asBEHAVE_CONSTRUCT, "void f()", asFUNCTION(ASCompatibleConstructor<SourceBatch>), AS_CALL_CDECL_OBJFIRST);
@@ -298,7 +298,7 @@ void ASRegisterGeneratedDefaultConstructors(asIScriptEngine* engine)
     engine->RegisterObjectBehaviour("TechniqueEntry", asBEHAVE_CONSTRUCT, "void f()", asFUNCTION(ASCompatibleConstructor<TechniqueEntry>), AS_CALL_CDECL_OBJFIRST);
 
     // TextureFrame::TextureFrame() | File: ../Graphics/ParticleEffect.h
-    engine->RegisterObjectBehaviour("TextureFrame", asBEHAVE_FACTORY, "TextureFrame@+ f()", asFUNCTION(ASCompatibleFactory<TextureFrame>), AS_CALL_CDECL);
+    engine->RegisterObjectBehaviour("TextureFrame", asBEHAVE_FACTORY, "TextureFrame@ f()", asFUNCTION(ASCompatibleFactory<TextureFrame>), AS_CALL_CDECL);
 
     // Timer::Timer() | File: ../Core/Timer.h
     engine->RegisterObjectBehaviour("Timer", asBEHAVE_CONSTRUCT, "void f()", asFUNCTION(ASCompatibleConstructor<Timer>), AS_CALL_CDECL_OBJFIRST);

--- a/Source/Urho3D/AngelScript/Generated_Members.h
+++ b/Source/Urho3D/AngelScript/Generated_Members.h
@@ -4511,14 +4511,14 @@ template <class T> void RegisterMembers_Skeleton(asIScriptEngine* engine, const 
     engine->RegisterObjectMethod(className, "void Define(const Skeleton&in)", AS_METHODPR(T, Define, (const Skeleton&), void), AS_CALL_THISCALL);
 
     // Bone* Skeleton::GetBone(unsigned index)
-    engine->RegisterObjectMethod(className, "Bone@+ GetBone(uint)", AS_METHODPR(T, GetBone, (unsigned), Bone*), AS_CALL_THISCALL);
-    engine->RegisterObjectMethod(className, "Bone@+ get_bones(uint)", AS_METHODPR(T, GetBone, (unsigned), Bone*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "Bone@ GetBone(uint)", AS_METHODPR(T, GetBone, (unsigned), Bone*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "Bone@ get_bones(uint)", AS_METHODPR(T, GetBone, (unsigned), Bone*), AS_CALL_THISCALL);
 
     // Bone* Skeleton::GetBone(const String& name)
-    engine->RegisterObjectMethod(className, "Bone@+ GetBone(const String&in)", AS_METHODPR(T, GetBone, (const String&), Bone*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "Bone@ GetBone(const String&in)", AS_METHODPR(T, GetBone, (const String&), Bone*), AS_CALL_THISCALL);
 
     // Bone* Skeleton::GetBone(const StringHash& boneNameHash)
-    engine->RegisterObjectMethod(className, "Bone@+ GetBone(const StringHash&in)", AS_METHODPR(T, GetBone, (const StringHash&), Bone*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "Bone@ GetBone(const StringHash&in)", AS_METHODPR(T, GetBone, (const StringHash&), Bone*), AS_CALL_THISCALL);
 
     // unsigned Skeleton::GetBoneIndex(const String& boneName) const
     engine->RegisterObjectMethod(className, "uint GetBoneIndex(const String&in) const", AS_METHODPR(T, GetBoneIndex, (const String&) const, unsigned), AS_CALL_THISCALL);
@@ -4527,18 +4527,18 @@ template <class T> void RegisterMembers_Skeleton(asIScriptEngine* engine, const 
     engine->RegisterObjectMethod(className, "uint GetBoneIndex(const StringHash&in) const", AS_METHODPR(T, GetBoneIndex, (const StringHash&) const, unsigned), AS_CALL_THISCALL);
 
     // unsigned Skeleton::GetBoneIndex(const Bone* bone) const
-    engine->RegisterObjectMethod(className, "uint GetBoneIndex(Bone@+) const", AS_METHODPR(T, GetBoneIndex, (const Bone*) const, unsigned), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "uint GetBoneIndex(Bone@) const", AS_METHODPR(T, GetBoneIndex, (const Bone*) const, unsigned), AS_CALL_THISCALL);
 
     // Bone* Skeleton::GetBoneParent(const Bone* bone)
-    engine->RegisterObjectMethod(className, "Bone@+ GetBoneParent(Bone@+)", AS_METHODPR(T, GetBoneParent, (const Bone*), Bone*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "Bone@ GetBoneParent(Bone@)", AS_METHODPR(T, GetBoneParent, (const Bone*), Bone*), AS_CALL_THISCALL);
 
     // unsigned Skeleton::GetNumBones() const
     engine->RegisterObjectMethod(className, "uint GetNumBones() const", AS_METHODPR(T, GetNumBones, () const, unsigned), AS_CALL_THISCALL);
     engine->RegisterObjectMethod(className, "uint get_numBones() const", AS_METHODPR(T, GetNumBones, () const, unsigned), AS_CALL_THISCALL);
 
     // Bone* Skeleton::GetRootBone()
-    engine->RegisterObjectMethod(className, "Bone@+ GetRootBone()", AS_METHODPR(T, GetRootBone, (), Bone*), AS_CALL_THISCALL);
-    engine->RegisterObjectMethod(className, "Bone@+ get_rootBone()", AS_METHODPR(T, GetRootBone, (), Bone*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "Bone@ GetRootBone()", AS_METHODPR(T, GetRootBone, (), Bone*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "Bone@ get_rootBone()", AS_METHODPR(T, GetRootBone, (), Bone*), AS_CALL_THISCALL);
 
     // bool Skeleton::Load(Deserializer& source)
     engine->RegisterObjectMethod(className, "bool Load(Deserializer&)", AS_METHODPR(T, Load, (Deserializer&), bool), AS_CALL_THISCALL);
@@ -7501,8 +7501,8 @@ template <class T> void RegisterMembers_AnimationState(asIScriptEngine* engine, 
     engine->RegisterObjectMethod(className, "Node@+ get_node() const", AS_METHODPR(T, GetNode, () const, Node*), AS_CALL_THISCALL);
 
     // Bone* AnimationState::GetStartBone() const
-    engine->RegisterObjectMethod(className, "Bone@+ GetStartBone() const", AS_METHODPR(T, GetStartBone, () const, Bone*), AS_CALL_THISCALL);
-    engine->RegisterObjectMethod(className, "Bone@+ get_startBone() const", AS_METHODPR(T, GetStartBone, () const, Bone*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "Bone@ GetStartBone() const", AS_METHODPR(T, GetStartBone, () const, Bone*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "Bone@ get_startBone() const", AS_METHODPR(T, GetStartBone, () const, Bone*), AS_CALL_THISCALL);
 
     // float AnimationState::GetTime() const
     engine->RegisterObjectMethod(className, "float GetTime() const", AS_METHODPR(T, GetTime, () const, float), AS_CALL_THISCALL);
@@ -7551,8 +7551,8 @@ template <class T> void RegisterMembers_AnimationState(asIScriptEngine* engine, 
     engine->RegisterObjectMethod(className, "void set_looped(bool)", AS_METHODPR(T, SetLooped, (bool), void), AS_CALL_THISCALL);
 
     // void AnimationState::SetStartBone(Bone* startBone)
-    engine->RegisterObjectMethod(className, "void SetStartBone(Bone@+)", AS_METHODPR(T, SetStartBone, (Bone*), void), AS_CALL_THISCALL);
-    engine->RegisterObjectMethod(className, "void set_startBone(Bone@+)", AS_METHODPR(T, SetStartBone, (Bone*), void), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "void SetStartBone(Bone@)", AS_METHODPR(T, SetStartBone, (Bone*), void), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "void set_startBone(Bone@)", AS_METHODPR(T, SetStartBone, (Bone*), void), AS_CALL_THISCALL);
 
     // void AnimationState::SetTime(float time)
     engine->RegisterObjectMethod(className, "void SetTime(float)", AS_METHODPR(T, SetTime, (float), void), AS_CALL_THISCALL);
@@ -10598,16 +10598,16 @@ template <class T> void RegisterMembers_Input(asIScriptEngine* engine, const cha
     engine->RegisterObjectMethod(className, "Vector2 get_inputScale() const", AS_METHODPR(T, GetInputScale, () const, Vector2), AS_CALL_THISCALL);
 
     // JoystickState* Input::GetJoystick(SDL_JoystickID id)
-    engine->RegisterObjectMethod(className, "JoystickState@+ GetJoystick(SDL_JoystickID)", AS_METHODPR(T, GetJoystick, (SDL_JoystickID), JoystickState*), AS_CALL_THISCALL);
-    engine->RegisterObjectMethod(className, "JoystickState@+ get_joysticks(SDL_JoystickID)", AS_METHODPR(T, GetJoystick, (SDL_JoystickID), JoystickState*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "JoystickState@ GetJoystick(SDL_JoystickID)", AS_METHODPR(T, GetJoystick, (SDL_JoystickID), JoystickState*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "JoystickState@ get_joysticks(SDL_JoystickID)", AS_METHODPR(T, GetJoystick, (SDL_JoystickID), JoystickState*), AS_CALL_THISCALL);
 
     // JoystickState* Input::GetJoystickByIndex(unsigned index)
-    engine->RegisterObjectMethod(className, "JoystickState@+ GetJoystickByIndex(uint)", AS_METHODPR(T, GetJoystickByIndex, (unsigned), JoystickState*), AS_CALL_THISCALL);
-    engine->RegisterObjectMethod(className, "JoystickState@+ get_joysticksByIndex(uint)", AS_METHODPR(T, GetJoystickByIndex, (unsigned), JoystickState*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "JoystickState@ GetJoystickByIndex(uint)", AS_METHODPR(T, GetJoystickByIndex, (unsigned), JoystickState*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "JoystickState@ get_joysticksByIndex(uint)", AS_METHODPR(T, GetJoystickByIndex, (unsigned), JoystickState*), AS_CALL_THISCALL);
 
     // JoystickState* Input::GetJoystickByName(const String& name)
-    engine->RegisterObjectMethod(className, "JoystickState@+ GetJoystickByName(const String&in)", AS_METHODPR(T, GetJoystickByName, (const String&), JoystickState*), AS_CALL_THISCALL);
-    engine->RegisterObjectMethod(className, "JoystickState@+ get_joysticksByName(const String&in)", AS_METHODPR(T, GetJoystickByName, (const String&), JoystickState*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "JoystickState@ GetJoystickByName(const String&in)", AS_METHODPR(T, GetJoystickByName, (const String&), JoystickState*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "JoystickState@ get_joysticksByName(const String&in)", AS_METHODPR(T, GetJoystickByName, (const String&), JoystickState*), AS_CALL_THISCALL);
 
     // bool Input::GetKeyDown(Key key) const
     engine->RegisterObjectMethod(className, "bool GetKeyDown(Key) const", AS_METHODPR(T, GetKeyDown, (Key) const, bool), AS_CALL_THISCALL);
@@ -10704,8 +10704,8 @@ template <class T> void RegisterMembers_Input(asIScriptEngine* engine, const cha
     engine->RegisterObjectMethod(className, "bool get_toggleFullscreen() const", AS_METHODPR(T, GetToggleFullscreen, () const, bool), AS_CALL_THISCALL);
 
     // TouchState* Input::GetTouch(unsigned index) const
-    engine->RegisterObjectMethod(className, "TouchState@+ GetTouch(uint) const", AS_METHODPR(T, GetTouch, (unsigned) const, TouchState*), AS_CALL_THISCALL);
-    engine->RegisterObjectMethod(className, "TouchState@+ get_touches(uint) const", AS_METHODPR(T, GetTouch, (unsigned) const, TouchState*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "TouchState@ GetTouch(uint) const", AS_METHODPR(T, GetTouch, (unsigned) const, TouchState*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "TouchState@ get_touches(uint) const", AS_METHODPR(T, GetTouch, (unsigned) const, TouchState*), AS_CALL_THISCALL);
 
     // bool Input::GetTouchEmulation() const
     engine->RegisterObjectMethod(className, "bool GetTouchEmulation() const", AS_METHODPR(T, GetTouchEmulation, () const, bool), AS_CALL_THISCALL);
@@ -13897,7 +13897,7 @@ template <class T> void RegisterMembers_ParticleEffect(asIScriptEngine* engine, 
     engine->RegisterObjectMethod(className, "float get_animationLodBias() const", AS_METHODPR(T, GetAnimationLodBias, () const, float), AS_CALL_THISCALL);
 
     // const ColorFrame* ParticleEffect::GetColorFrame(unsigned index) const
-    engine->RegisterObjectMethod(className, "ColorFrame@+ GetColorFrame(uint) const", AS_METHODPR(T, GetColorFrame, (unsigned) const, const ColorFrame*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "ColorFrame@ GetColorFrame(uint) const", AS_METHODPR(T, GetColorFrame, (unsigned) const, const ColorFrame*), AS_CALL_THISCALL);
 
     // const Vector3& ParticleEffect::GetConstantForce() const
     engine->RegisterObjectMethod(className, "const Vector3& GetConstantForce() const", AS_METHODPR(T, GetConstantForce, () const, const Vector3&), AS_CALL_THISCALL);
@@ -14022,7 +14022,7 @@ template <class T> void RegisterMembers_ParticleEffect(asIScriptEngine* engine, 
     engine->RegisterObjectMethod(className, "float get_sizeMul() const", AS_METHODPR(T, GetSizeMul, () const, float), AS_CALL_THISCALL);
 
     // const TextureFrame* ParticleEffect::GetTextureFrame(unsigned index) const
-    engine->RegisterObjectMethod(className, "TextureFrame@+ GetTextureFrame(uint) const", AS_METHODPR(T, GetTextureFrame, (unsigned) const, const TextureFrame*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "TextureFrame@ GetTextureFrame(uint) const", AS_METHODPR(T, GetTextureFrame, (unsigned) const, const TextureFrame*), AS_CALL_THISCALL);
 
     // bool ParticleEffect::GetUpdateInvisible() const
     engine->RegisterObjectMethod(className, "bool GetUpdateInvisible() const", AS_METHODPR(T, GetUpdateInvisible, () const, bool), AS_CALL_THISCALL);
@@ -14962,7 +14962,7 @@ template <class T> void RegisterMembers_Animation(asIScriptEngine* engine, const
     engine->RegisterObjectMethod(className, "Animation@+ Clone(const String&in = String::EMPTY) const", AS_FUNCTION_OBJFIRST(Animation_SharedPtrlesAnimationgre_Clone_constspStringamp_template<Animation>), AS_CALL_CDECL_OBJFIRST);
 
     // AnimationTrack* Animation::CreateTrack(const String& name)
-    engine->RegisterObjectMethod(className, "AnimationTrack@+ CreateTrack(const String&in)", AS_METHODPR(T, CreateTrack, (const String&), AnimationTrack*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "AnimationTrack@ CreateTrack(const String&in)", AS_METHODPR(T, CreateTrack, (const String&), AnimationTrack*), AS_CALL_THISCALL);
 
     // const String& Animation::GetAnimationName() const
     engine->RegisterObjectMethod(className, "const String& GetAnimationName() const", AS_METHODPR(T, GetAnimationName, () const, const String&), AS_CALL_THISCALL);
@@ -14984,14 +14984,14 @@ template <class T> void RegisterMembers_Animation(asIScriptEngine* engine, const
     engine->RegisterObjectMethod(className, "uint get_numTriggers() const", AS_METHODPR(T, GetNumTriggers, () const, unsigned), AS_CALL_THISCALL);
 
     // AnimationTrack* Animation::GetTrack(unsigned index)
-    engine->RegisterObjectMethod(className, "AnimationTrack@+ GetTrack(uint)", AS_METHODPR(T, GetTrack, (unsigned), AnimationTrack*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "AnimationTrack@ GetTrack(uint)", AS_METHODPR(T, GetTrack, (unsigned), AnimationTrack*), AS_CALL_THISCALL);
 
     // AnimationTrack* Animation::GetTrack(const String& name)
-    engine->RegisterObjectMethod(className, "AnimationTrack@+ GetTrack(const String&in)", AS_METHODPR(T, GetTrack, (const String&), AnimationTrack*), AS_CALL_THISCALL);
-    engine->RegisterObjectMethod(className, "AnimationTrack@+ get_tracks(const String&in)", AS_METHODPR(T, GetTrack, (const String&), AnimationTrack*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "AnimationTrack@ GetTrack(const String&in)", AS_METHODPR(T, GetTrack, (const String&), AnimationTrack*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "AnimationTrack@ get_tracks(const String&in)", AS_METHODPR(T, GetTrack, (const String&), AnimationTrack*), AS_CALL_THISCALL);
 
     // AnimationTrack* Animation::GetTrack(StringHash nameHash)
-    engine->RegisterObjectMethod(className, "AnimationTrack@+ GetTrack(StringHash)", AS_METHODPR(T, GetTrack, (StringHash), AnimationTrack*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "AnimationTrack@ GetTrack(StringHash)", AS_METHODPR(T, GetTrack, (StringHash), AnimationTrack*), AS_CALL_THISCALL);
 
     // void Animation::RemoveAllTracks()
     engine->RegisterObjectMethod(className, "void RemoveAllTracks()", AS_METHODPR(T, RemoveAllTracks, (), void), AS_CALL_THISCALL);
@@ -17003,7 +17003,7 @@ template <class T> void RegisterMembers_AnimationController(asIScriptEngine* eng
     engine->RegisterObjectMethod(className, "float GetSpeed(const String&in) const", AS_METHODPR(T, GetSpeed, (const String&) const, float), AS_CALL_THISCALL);
 
     // Bone* AnimationController::GetStartBone(const String& name) const
-    engine->RegisterObjectMethod(className, "Bone@+ GetStartBone(const String&in) const", AS_METHODPR(T, GetStartBone, (const String&) const, Bone*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "Bone@ GetStartBone(const String&in) const", AS_METHODPR(T, GetStartBone, (const String&) const, Bone*), AS_CALL_THISCALL);
 
     // const String& AnimationController::GetStartBoneName(const String& name) const
     engine->RegisterObjectMethod(className, "const String& GetStartBoneName(const String&in) const", AS_METHODPR(T, GetStartBoneName, (const String&) const, const String&), AS_CALL_THISCALL);
@@ -21548,8 +21548,8 @@ template <class T> void RegisterMembers_BillboardSet(asIScriptEngine* engine, co
     engine->RegisterObjectMethod(className, "float get_animationLodBias() const", AS_METHODPR(T, GetAnimationLodBias, () const, float), AS_CALL_THISCALL);
 
     // Billboard* BillboardSet::GetBillboard(unsigned index)
-    engine->RegisterObjectMethod(className, "Billboard@+ GetBillboard(uint)", AS_METHODPR(T, GetBillboard, (unsigned), Billboard*), AS_CALL_THISCALL);
-    engine->RegisterObjectMethod(className, "Billboard@+ get_billboards(uint)", AS_METHODPR(T, GetBillboard, (unsigned), Billboard*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "Billboard@ GetBillboard(uint)", AS_METHODPR(T, GetBillboard, (unsigned), Billboard*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "Billboard@ get_billboards(uint)", AS_METHODPR(T, GetBillboard, (unsigned), Billboard*), AS_CALL_THISCALL);
 
     // FaceCameraMode BillboardSet::GetFaceCameraMode() const
     engine->RegisterObjectMethod(className, "FaceCameraMode GetFaceCameraMode() const", AS_METHODPR(T, GetFaceCameraMode, () const, FaceCameraMode), AS_CALL_THISCALL);
@@ -21815,7 +21815,7 @@ template <class T> void RegisterMembers_CustomGeometry(asIScriptEngine* engine, 
     engine->RegisterObjectMethod(className, "uint get_numVertices(uint) const", AS_METHODPR(T, GetNumVertices, (unsigned) const, unsigned), AS_CALL_THISCALL);
 
     // CustomGeometryVertex* CustomGeometry::GetVertex(unsigned geometryIndex, unsigned vertexNum)
-    engine->RegisterObjectMethod(className, "CustomGeometryVertex@+ GetVertex(uint, uint)", AS_METHODPR(T, GetVertex, (unsigned, unsigned), CustomGeometryVertex*), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "CustomGeometryVertex@ GetVertex(uint, uint)", AS_METHODPR(T, GetVertex, (unsigned, unsigned), CustomGeometryVertex*), AS_CALL_THISCALL);
 
     // bool CustomGeometry::IsDynamic() const
     engine->RegisterObjectMethod(className, "bool IsDynamic() const", AS_METHODPR(T, IsDynamic, () const, bool), AS_CALL_THISCALL);

--- a/Source/Urho3D/AngelScript/Generated_ObjectTypes.cpp
+++ b/Source/Urho3D/AngelScript/Generated_ObjectTypes.cpp
@@ -19,7 +19,7 @@ void ASRegisterGeneratedObjectTypes(asIScriptEngine* engine)
     engine->RegisterObjectType("AllocatorNode", sizeof(AllocatorNode), asOBJ_VALUE | asGetTypeTraits<AllocatorNode>());
 
     // struct AnimationControl | File: ../Graphics/AnimationController.h
-    engine->RegisterObjectType("AnimationControl", 0, asOBJ_REF);
+    engine->RegisterObjectType("AnimationControl", 0, asOBJ_REF | asOBJ_NOCOUNT);
 
     // struct AnimationKeyFrame | File: ../Graphics/Animation.h
     engine->RegisterObjectType("AnimationKeyFrame", sizeof(AnimationKeyFrame), asOBJ_VALUE | asGetTypeTraits<AnimationKeyFrame>());
@@ -28,7 +28,7 @@ void ASRegisterGeneratedObjectTypes(asIScriptEngine* engine)
     engine->RegisterObjectType("AnimationStateTrack", sizeof(AnimationStateTrack), asOBJ_VALUE | asGetTypeTraits<AnimationStateTrack>());
 
     // struct AnimationTrack | File: ../Graphics/Animation.h
-    engine->RegisterObjectType("AnimationTrack", 0, asOBJ_REF);
+    engine->RegisterObjectType("AnimationTrack", 0, asOBJ_REF | asOBJ_NOCOUNT);
 
     // struct AnimationTriggerPoint | File: ../Graphics/Animation.h
     engine->RegisterObjectType("AnimationTriggerPoint", sizeof(AnimationTriggerPoint), asOBJ_VALUE | asGetTypeTraits<AnimationTriggerPoint>());
@@ -64,10 +64,10 @@ void ASRegisterGeneratedObjectTypes(asIScriptEngine* engine)
     engine->RegisterObjectType("BiasParameters", sizeof(BiasParameters), asOBJ_VALUE | asGetTypeTraits<BiasParameters>() | asOBJ_POD | asOBJ_APP_CLASS_ALLFLOATS);
 
     // struct Billboard | File: ../Graphics/BillboardSet.h
-    engine->RegisterObjectType("Billboard", 0, asOBJ_REF);
+    engine->RegisterObjectType("Billboard", 0, asOBJ_REF | asOBJ_NOCOUNT);
 
     // struct Bone | File: ../Graphics/Skeleton.h
-    engine->RegisterObjectType("Bone", 0, asOBJ_REF);
+    engine->RegisterObjectType("Bone", 0, asOBJ_REF | asOBJ_NOCOUNT);
 
     // class BoundingBox | File: ../Math/BoundingBox.h
     engine->RegisterObjectType("BoundingBox", sizeof(BoundingBox), asOBJ_VALUE | asGetTypeTraits<BoundingBox>() | asOBJ_POD | asOBJ_APP_CLASS_ALLFLOATS);
@@ -82,7 +82,7 @@ void ASRegisterGeneratedObjectTypes(asIScriptEngine* engine)
     engine->RegisterObjectType("Color", sizeof(Color), asOBJ_VALUE | asGetTypeTraits<Color>() | asOBJ_POD | asOBJ_APP_CLASS_ALLFLOATS);
 
     // struct ColorFrame | File: ../Graphics/ParticleEffect.h
-    engine->RegisterObjectType("ColorFrame", 0, asOBJ_REF);
+    engine->RegisterObjectType("ColorFrame", 0, asOBJ_REF | asOBJ_NOCOUNT);
 
     // struct CompressedLevel | File: ../Resource/Image.h
     engine->RegisterObjectType("CompressedLevel", sizeof(CompressedLevel), asOBJ_VALUE | asGetTypeTraits<CompressedLevel>());
@@ -97,7 +97,7 @@ void ASRegisterGeneratedObjectTypes(asIScriptEngine* engine)
     engine->RegisterObjectType("CursorShapeInfo", sizeof(CursorShapeInfo), asOBJ_VALUE | asGetTypeTraits<CursorShapeInfo>());
 
     // struct CustomGeometryVertex | File: ../Graphics/CustomGeometry.h
-    engine->RegisterObjectType("CustomGeometryVertex", 0, asOBJ_REF);
+    engine->RegisterObjectType("CustomGeometryVertex", 0, asOBJ_REF | asOBJ_NOCOUNT);
 
     // class CustomVariantValue | File: ../Core/Variant.h
     // Not registered because have @nobind mark
@@ -118,7 +118,7 @@ void ASRegisterGeneratedObjectTypes(asIScriptEngine* engine)
     engine->RegisterObjectType("DepthValue", sizeof(DepthValue), asOBJ_VALUE | asGetTypeTraits<DepthValue>() | asOBJ_POD | asOBJ_APP_CLASS_ALLINTS);
 
     // class Deserializer | File: ../IO/Deserializer.h
-    engine->RegisterObjectType("Deserializer", 0, asOBJ_REF);
+    engine->RegisterObjectType("Deserializer", 0, asOBJ_REF | asOBJ_NOCOUNT);
 
     // struct DirtyBits | File: ../Scene/ReplicationState.h
     engine->RegisterObjectType("DirtyBits", sizeof(DirtyBits), asOBJ_VALUE | asGetTypeTraits<DirtyBits>());
@@ -178,7 +178,7 @@ void ASRegisterGeneratedObjectTypes(asIScriptEngine* engine)
     engine->RegisterObjectType("JSONValue", sizeof(JSONValue), asOBJ_VALUE | asGetTypeTraits<JSONValue>());
 
     // struct JoystickState | File: ../Input/Input.h
-    engine->RegisterObjectType("JoystickState", 0, asOBJ_REF);
+    engine->RegisterObjectType("JoystickState", 0, asOBJ_REF | asOBJ_NOCOUNT);
 
     // struct LightBatchQueue | File: ../Graphics/Batch.h
     engine->RegisterObjectType("LightBatchQueue", sizeof(LightBatchQueue), asOBJ_VALUE | asGetTypeTraits<LightBatchQueue>());
@@ -313,7 +313,7 @@ void ASRegisterGeneratedObjectTypes(asIScriptEngine* engine)
     engine->RegisterObjectType("ScreenModeParams", sizeof(ScreenModeParams), asOBJ_VALUE | asGetTypeTraits<ScreenModeParams>());
 
     // class Serializer | File: ../IO/Serializer.h
-    engine->RegisterObjectType("Serializer", 0, asOBJ_REF);
+    engine->RegisterObjectType("Serializer", 0, asOBJ_REF | asOBJ_NOCOUNT);
 
     // struct ShaderParameter | File: ../Graphics/ShaderVariation.h
     engine->RegisterObjectType("ShaderParameter", sizeof(ShaderParameter), asOBJ_VALUE | asGetTypeTraits<ShaderParameter>());
@@ -322,7 +322,7 @@ void ASRegisterGeneratedObjectTypes(asIScriptEngine* engine)
     engine->RegisterObjectType("ShadowBatchQueue", sizeof(ShadowBatchQueue), asOBJ_VALUE | asGetTypeTraits<ShadowBatchQueue>());
 
     // class Skeleton | File: ../Graphics/Skeleton.h
-    engine->RegisterObjectType("Skeleton", 0, asOBJ_REF);
+    engine->RegisterObjectType("Skeleton", 0, asOBJ_REF | asOBJ_NOCOUNT);
 
     // struct SourceBatch | File: ../Graphics/Drawable.h
     engine->RegisterObjectType("SourceBatch", sizeof(SourceBatch), asOBJ_VALUE | asGetTypeTraits<SourceBatch>());
@@ -352,7 +352,7 @@ void ASRegisterGeneratedObjectTypes(asIScriptEngine* engine)
     engine->RegisterObjectType("TechniqueEntry", sizeof(TechniqueEntry), asOBJ_VALUE | asGetTypeTraits<TechniqueEntry>());
 
     // struct TextureFrame | File: ../Graphics/ParticleEffect.h
-    engine->RegisterObjectType("TextureFrame", 0, asOBJ_REF);
+    engine->RegisterObjectType("TextureFrame", 0, asOBJ_REF | asOBJ_NOCOUNT);
 
     // class Thread | File: ../Core/Thread.h
     // Not registered because value types can not be abstract
@@ -361,7 +361,7 @@ void ASRegisterGeneratedObjectTypes(asIScriptEngine* engine)
     engine->RegisterObjectType("Timer", sizeof(Timer), asOBJ_VALUE | asGetTypeTraits<Timer>() | asOBJ_POD | asOBJ_APP_CLASS_ALLINTS);
 
     // struct TouchState | File: ../Input/Input.h
-    engine->RegisterObjectType("TouchState", 0, asOBJ_REF);
+    engine->RegisterObjectType("TouchState", 0, asOBJ_REF | asOBJ_NOCOUNT);
 
     // struct TrailPoint | File: ../Graphics/RibbonTrail.h
     engine->RegisterObjectType("TrailPoint", sizeof(TrailPoint), asOBJ_VALUE | asGetTypeTraits<TrailPoint>());
@@ -473,7 +473,7 @@ void ASRegisterGeneratedObjectTypes(asIScriptEngine* engine)
     engine->RegisterObjectType("SourceBatch2D", sizeof(SourceBatch2D), asOBJ_VALUE | asGetTypeTraits<SourceBatch2D>());
 
     // struct TileMapInfo2D | File: ../Urho2D/TileMapDefs2D.h
-    engine->RegisterObjectType("TileMapInfo2D", 0, asOBJ_REF);
+    engine->RegisterObjectType("TileMapInfo2D", 0, asOBJ_REF | asOBJ_NOCOUNT);
 
     // struct Vertex2D | File: ../Urho2D/Drawable2D.h
     engine->RegisterObjectType("Vertex2D", sizeof(Vertex2D), asOBJ_VALUE | asGetTypeTraits<Vertex2D>());

--- a/Source/Urho3D/AngelScript/Manual_Graphics.h
+++ b/Source/Urho3D/AngelScript/Manual_Graphics.h
@@ -335,7 +335,7 @@ template <class T> const AnimationControl* AnimationController_GetAnimation(unsi
     engine->RegisterObjectMethod(className, "uint get_numAnimations() const", AS_FUNCTION_OBJLAST(AnimationController_GetNumAnimations<T>), AS_CALL_CDECL_OBJLAST); \
     \
     /* const Vector<AnimationControl>& AnimationController::GetAnimations() const | File: ../Graphics/AnimationController.h */ \
-    engine->RegisterObjectMethod(className, "const AnimationControl@+ get_animations(uint) const", AS_FUNCTION_OBJLAST(AnimationController_GetAnimation<T>), AS_CALL_CDECL_OBJLAST);
+    engine->RegisterObjectMethod(className, "const AnimationControl@ get_animations(uint) const", AS_FUNCTION_OBJLAST(AnimationController_GetAnimation<T>), AS_CALL_CDECL_OBJLAST);
 
 // ========================================================================================
 


### PR DESCRIPTION
Registration in AngelScript of classes marked as @fakeref with the flag "asOBJ_NOCOUNT", without registration empty AddRef and Release. This optimizes the AngelScript code, as it disables the call to reference counting for such objects. In general, I think that for such objects, the registration of the factory should also be removed, since the objects created in the script through the factory will never be deleted.