### PR TITLE
Material unsubscribe from animation events on ResetToDefault

### DIFF
--- a/Source/Urho3D/Graphics/Material.cpp
+++ b/Source/Urho3D/Graphics/Material.cpp
@@ -1279,6 +1279,7 @@ void Material::ResetToDefaults()
     renderOrder_ = DEFAULT_RENDER_ORDER;
     occlusion_ = true;
 
+    UpdateEventSubscription();
     RefreshShaderParameterHash();
     RefreshMemoryUse();
 }


### PR DESCRIPTION
I believe Material should also unsubscribe from the update events when we clear the shader animations in addition to clearing them. An additional fix for #2826