### PR TITLE
StableSort for UIElement::SortChildren

### DIFF
--- a/Source/Urho3D/Container/Sort.h
+++ b/Source/Urho3D/Container/Sort.h
@@ -141,4 +141,234 @@ template <class T, class U> void Sort(RandomAccessIterator<T> begin, RandomAcces
     InsertionSort(begin, end, compare);
 }
 
+
+/// Stable sort is based on http://thomas.baudel.name/Visualisation/VisuTri/inplacestablesort.html
+/// Benchmark https://www.codeproject.com/Articles/26048/Fastest-In-Place-Stable-Sort
+template <class T> void StableSortRotate(RandomAccessIterator<T> begin, RandomAccessIterator<T> mid, 
+    RandomAccessIterator<T> end)
+{
+/*  a less sophisticated but costlier version:
+  reverse(from, mid-1);
+  reverse(mid, to-1);
+  reverse(from, to-1);
+*/
+    if(begin == mid || mid == end) return;
+
+    //int n = gcd(end - begin, mid - begin);
+    int n1 = end - begin;
+    int n2 = mid - begin;
+    while (n2 != 0)
+    {
+        int t = n1 % n2;
+        n1 = n2;
+        n2 = t;
+    }
+    int n = n1;
+
+    while(n-- != 0)
+    {
+        T val = *(begin + n);
+        int shift = mid - begin;
+        RandomAccessIterator<T> p1 = begin + n;
+        RandomAccessIterator<T> p2 = begin + n + shift;
+        while(p2 != begin + n)
+        {
+            *p1 = *p2;
+            p1 = p2;
+            if(end - p2 > shift)
+            {
+                p2 += shift;
+            }
+            else
+            {
+                p2 = begin + (shift - (end - p2));
+            }
+        }
+        *p1 = val;
+    }
+}
+
+template <class T> RandomAccessIterator<T> StableSortLower(RandomAccessIterator<T> begin, RandomAccessIterator<T> end, 
+    RandomAccessIterator<T> val)
+{
+    int len = end - begin, half;
+    while(len > 0)
+    {
+        half = len / 2;
+        RandomAccessIterator<T> mid = begin + half;
+        if(*mid < *val)
+        {
+            begin = mid + 1;
+            len = len - half -1;
+        }
+        else
+        {
+            len = half;
+        }
+    }
+    return begin;
+}
+
+template <class T> RandomAccessIterator<T> StableSortUpper(RandomAccessIterator<T> begin, RandomAccessIterator<T> end, 
+    RandomAccessIterator<T> val)
+{
+    int len = end - begin, half;
+    while(len > 0)
+    {
+        half = len / 2;
+        RandomAccessIterator<T> mid = begin + half;
+        if(*val < *mid)
+        {
+            len = half;
+        }
+        else
+        {
+            begin = mid + 1;
+            len = len - half - 1;
+        }
+    }
+    return begin;
+}
+
+template <class T> void StableSortMerge(RandomAccessIterator<T> begin, RandomAccessIterator<T> pivot, 
+    RandomAccessIterator<T> end, int len1, int len2)
+{
+    if(len1 == 0 || len2 == 0)
+        return;
+
+    if(len1+len2 == 2)
+    {
+        if(*pivot < *begin)
+            Swap(*pivot, *begin);
+        return;
+    }
+    
+    RandomAccessIterator<T> first_cut, second_cut;
+    int len11, len22;
+    if(len1 > len2)
+    {
+        len11 = len1 / 2;
+        first_cut = begin + len11;
+        second_cut = StableSortLower(pivot, end, first_cut);
+        len22 = second_cut - pivot;
+    }
+    else
+    {
+        len22 = len2 / 2;
+        second_cut = pivot + len22;
+        first_cut = StableSortUpper(begin, pivot, second_cut);
+        len11 = first_cut - begin;
+    }
+
+    StableSortRotate(first_cut, pivot, second_cut);
+    RandomAccessIterator<T> new_mid = first_cut + len22;
+    StableSortMerge(begin, first_cut, new_mid, len11, len22);
+    StableSortMerge(new_mid, second_cut, end, len1 - len11, len2 - len22);
+}
+
+template <class T> void StableSort(RandomAccessIterator<T> begin, RandomAccessIterator<T> end)
+{
+    if(end - begin < 12)
+    {
+        InsertionSort(begin, end);
+        return;
+    }
+    RandomAccessIterator<T> middle = begin + (end - begin) / 2;
+    StableSort(begin, middle);
+    StableSort(middle, end);
+    StableSortMerge(begin, middle, end, middle - begin, end - middle);
+}
+
+template <class T, class U> RandomAccessIterator<T> StableSortLower(RandomAccessIterator<T> begin, RandomAccessIterator<T> end, 
+    RandomAccessIterator<T> val, U compare)
+{
+    int len = end - begin, half;
+    while(len > 0)
+    {
+        half = len / 2;
+        RandomAccessIterator<T> mid = begin + half;
+        if(compare(*mid, *val))
+        {
+            begin = mid + 1;
+            len = len - half -1;
+        }
+        else
+        {
+            len = half;
+        }
+    }
+    return begin;
+}
+
+template <class T, class U> RandomAccessIterator<T> StableSortUpper(RandomAccessIterator<T> begin, RandomAccessIterator<T> end, 
+    RandomAccessIterator<T> val, U compare)
+{
+    int len = end - begin, half;
+    while(len > 0)
+    {
+        half = len / 2;
+        RandomAccessIterator<T> mid = begin + half;
+        if(compare(*val, *mid))
+        {
+            len = half;
+        }
+        else
+        {
+            begin = mid + 1;
+            len = len - half - 1;
+        }
+    }
+    return begin;
+}
+
+template <class T, class U> void StableSortMerge(RandomAccessIterator<T> begin, RandomAccessIterator<T> pivot, 
+    RandomAccessIterator<T> end, int len1, int len2, U compare)
+{
+    if(len1 == 0 || len2 == 0)
+        return;
+
+    if(len1 + len2 == 2)
+    {
+        if(compare(*pivot, *begin))
+            Swap(*pivot, *begin);
+        return;
+    }
+    
+    RandomAccessIterator<T> first_cut, second_cut;
+    int len11, len22;
+    if(len1 > len2)
+    {
+        len11 = len1 / 2;
+        first_cut = begin + len11;
+        second_cut = StableSortLower(pivot, end, first_cut, compare);
+        len22 = second_cut - pivot;
+    }
+    else
+    {
+        len22 = len2 / 2;
+        second_cut = pivot + len22;
+        first_cut = StableSortUpper(begin, pivot, second_cut, compare);
+        len11 = first_cut - begin;
+    }
+
+    StableSortRotate(first_cut, pivot, second_cut);
+    RandomAccessIterator<T> new_mid = first_cut + len22;
+    StableSortMerge(begin, first_cut, new_mid, len11, len22, compare);
+    StableSortMerge(new_mid, second_cut, end, len1 - len11, len2 - len22, compare);
+}
+
+template <class T, class U> void StableSort(RandomAccessIterator<T> begin, RandomAccessIterator<T> end,
+    U compare)
+{
+    if(end - begin < 12)
+    {
+        InsertionSort(begin, end, compare);
+        return;
+    }
+    RandomAccessIterator<T> middle = begin + (end - begin) / 2;
+    StableSort(begin, middle, compare);
+    StableSort(middle, end, compare);
+    StableSortMerge(begin, middle, end, middle - begin, end - middle, compare);
+}
+
 }

--- a/Source/Urho3D/UI/UIElement.cpp
+++ b/Source/Urho3D/UI/UIElement.cpp
@@ -1790,9 +1790,8 @@ void UIElement::SortChildren()
     if (sortChildren_ && sortOrderDirty_)
     {
         // Only sort when there is no layout
-        /// \todo Order is not stable when children have same priorities
         if (layoutMode_ == LM_FREE)
-            Sort(children_.Begin(), children_.End(), CompareUIElements);
+            StableSort(children_.Begin(), children_.End(), CompareUIElements);
         sortOrderDirty_ = false;
     }
 }


### PR DESCRIPTION
UIElements of equal priority will keep their existing order. Primarily avoids messing up the TAB selection order of elements.

Credit goes to @ab4daa who implemented this a while back
https://gist.github.com/ab4daa/5932716ef369f110ef31b95ca94d6564