### PR TITLE
Fix bug in Ray::HitDistance functions for geometry.

### DIFF
--- a/Source/Urho3D/Math/Ray.cpp
+++ b/Source/Urho3D/Math/Ray.cpp
@@ -250,16 +250,27 @@ float Ray::HitDistance(const void* vertexData, unsigned vertexStride, unsigned v
     const unsigned char* vertices = ((const unsigned char*)vertexData) + vertexStart * vertexStride;
     unsigned index = 0, nearestIdx = M_MAX_UNSIGNED;
     Vector3 barycentric;
-    Vector3* outBary = outUV ? &barycentric : nullptr;
+
+    Vector3 tempNormal_, tempBary_; 
+    Vector3* tempNormal = outNormal ? &tempNormal_ : nullptr;
+    Vector3* tempBary = outUV ? &tempBary_ : nullptr;
 
     while (index + 2 < vertexCount)
     {
         const Vector3& v0 = *((const Vector3*)(&vertices[index * vertexStride]));
         const Vector3& v1 = *((const Vector3*)(&vertices[(index + 1) * vertexStride]));
         const Vector3& v2 = *((const Vector3*)(&vertices[(index + 2) * vertexStride]));
-        float distance = HitDistance(v0, v1, v2, outNormal, outBary);
+        float distance = HitDistance(v0, v1, v2, tempNormal, tempBary);
         if (distance < nearest)
         {
+            if (outNormal)
+            {
+                *outNormal = *tempNormal;
+            }
+            if (outUV)
+            {
+                barycentric = *tempBary;
+            }
             nearestIdx = index;
             nearest = distance;
         }
@@ -290,7 +301,10 @@ float Ray::HitDistance(const void* vertexData, unsigned vertexStride, const void
     float nearest = M_INFINITY;
     const auto* vertices = (const unsigned char*)vertexData;
     Vector3 barycentric;
-    Vector3* outBary = outUV ? &barycentric : nullptr;
+
+    Vector3 tempNormal_, tempBary_; 
+    Vector3* tempNormal = outNormal ? &tempNormal_ : nullptr;
+    Vector3* tempBary = outUV ? &tempBary_ : nullptr;
 
     // 16-bit indices
     if (indexSize == sizeof(unsigned short))
@@ -304,9 +318,17 @@ float Ray::HitDistance(const void* vertexData, unsigned vertexStride, const void
             const Vector3& v0 = *((const Vector3*)(&vertices[indices[0] * vertexStride]));
             const Vector3& v1 = *((const Vector3*)(&vertices[indices[1] * vertexStride]));
             const Vector3& v2 = *((const Vector3*)(&vertices[indices[2] * vertexStride]));
-            float distance = HitDistance(v0, v1, v2, outNormal, outBary);
+            float distance = HitDistance(v0, v1, v2, tempNormal, tempBary);
             if (distance < nearest)
             {
+                if (outNormal)
+                {
+                    *outNormal = *tempNormal;
+                }
+                if (outUV)
+                {
+                    barycentric = *tempBary;
+                }
                 nearestIndices = indices;
                 nearest = distance;
             }
@@ -340,9 +362,17 @@ float Ray::HitDistance(const void* vertexData, unsigned vertexStride, const void
             const Vector3& v0 = *((const Vector3*)(&vertices[indices[0] * vertexStride]));
             const Vector3& v1 = *((const Vector3*)(&vertices[indices[1] * vertexStride]));
             const Vector3& v2 = *((const Vector3*)(&vertices[indices[2] * vertexStride]));
-            float distance = HitDistance(v0, v1, v2, outNormal, outBary);
+            float distance = HitDistance(v0, v1, v2, tempNormal, tempBary);
             if (distance < nearest)
             {
+                if (outNormal)
+                {
+                    *outNormal = *tempNormal;
+                }
+                if (outUV)
+                {
+                    barycentric = *tempBary;
+                }
                 nearestIndices = indices;
                 nearest = distance;
             }


### PR DESCRIPTION
Fixes bug in Ray::HitDistance functions which may return incorrect normal and UV when encountering multiple geometry triangle hits.

Essentially the fix is simply ensuring that the normal and UV returned by RayHitDistance belongs to the nearest triangle rather than for the last intersection encountered.

Fixes #2862 Closes #2862
Fixes #2702 Closes #2702