### PR TITLE
Allows short names for primitive types

### DIFF
--- a/Source/Tools/BindingGenerator/ASUtils.cpp
+++ b/Source/Tools/BindingGenerator/ASUtils.cpp
@@ -42,28 +42,28 @@ string CppPrimitiveTypeToAS(const string& cppType)
     if (cppType == "bool")
         return "bool";
 
-    if (cppType == "char" || cppType == "signed char")
+    if (cppType == "char" || cppType == "signed char" || cppType == "i8")
         return "int8";
 
-    if (cppType == "unsigned char")
+    if (cppType == "unsigned char" || cppType == "u8")
         return "uint8";
 
-    if (cppType == "short")
+    if (cppType == "short" || cppType == "i16")
         return "int16";
 
-    if (cppType == "unsigned short")
+    if (cppType == "unsigned short" || cppType == "u16")
         return "uint16";
 
-    if (cppType == "int")
+    if (cppType == "int" || cppType == "i32")
         return "int";
 
-    if (cppType == "unsigned" || cppType == "unsigned int")
+    if (cppType == "unsigned" || cppType == "unsigned int" || cppType == "u32")
         return "uint";
 
-    if (cppType == "long long")
+    if (cppType == "long long" || cppType == "i64")
         return "int64";
 
-    if (cppType == "unsigned long long")
+    if (cppType == "unsigned long long" || cppType == "u64")
         return "uint64";
 
     if (cppType == "float")
@@ -165,16 +165,24 @@ bool IsKnownCppType(const string& name)
         "size_t",
         "char",
         "signed char",
+        "i8",
         "unsigned char",
+        "u8",
         "short",
+        "i16",
         "unsigned short",
+        "u16",
         "int",
-        "long",
+        "i32",
+        "long", // Size is compiler-dependent
         "unsigned",
         "unsigned int",
-        "unsigned long",
+        "u32",
+        "unsigned long", // Size is compiler-dependent
         "long long",
+        "i64",
         "unsigned long long",
+        "u64",
         "float",
         "double",
         "SDL_JoystickID",

--- a/Source/Urho3D/AngelScript/Generated_Members.h
+++ b/Source/Urho3D/AngelScript/Generated_Members.h
@@ -8961,7 +8961,7 @@ template <class T> void RegisterMembers_Audio(asIScriptEngine* engine, const cha
 {
     RegisterMembers_Object<T>(engine, className);
 
-    // void Audio::MixOutput(void* dest, unsigned samples)
+    // void Audio::MixOutput(void* dest, u32 samples)
     // Error: type "void*" can not automatically bind
 
     // void Audio::AddSoundSource(SoundSource* soundSource)
@@ -8979,16 +8979,16 @@ template <class T> void RegisterMembers_Audio(asIScriptEngine* engine, const cha
     engine->RegisterObjectMethod(className, "float GetMasterGain(const String&in) const", AS_METHODPR(T, GetMasterGain, (const String&) const, float), AS_CALL_THISCALL);
     engine->RegisterObjectMethod(className, "float get_masterGain(const String&in) const", AS_METHODPR(T, GetMasterGain, (const String&) const, float), AS_CALL_THISCALL);
 
-    // int Audio::GetMixRate() const
-    engine->RegisterObjectMethod(className, "int GetMixRate() const", AS_METHODPR(T, GetMixRate, () const, int), AS_CALL_THISCALL);
-    engine->RegisterObjectMethod(className, "int get_mixRate() const", AS_METHODPR(T, GetMixRate, () const, int), AS_CALL_THISCALL);
+    // i32 Audio::GetMixRate() const
+    engine->RegisterObjectMethod(className, "int GetMixRate() const", AS_METHODPR(T, GetMixRate, () const, i32), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "int get_mixRate() const", AS_METHODPR(T, GetMixRate, () const, i32), AS_CALL_THISCALL);
 
     // Mutex& Audio::GetMutex()
     engine->RegisterObjectMethod(className, "Mutex& GetMutex()", AS_METHODPR(T, GetMutex, (), Mutex&), AS_CALL_THISCALL);
 
-    // unsigned Audio::GetSampleSize() const
-    engine->RegisterObjectMethod(className, "uint GetSampleSize() const", AS_METHODPR(T, GetSampleSize, () const, unsigned), AS_CALL_THISCALL);
-    engine->RegisterObjectMethod(className, "uint get_sampleSize() const", AS_METHODPR(T, GetSampleSize, () const, unsigned), AS_CALL_THISCALL);
+    // u32 Audio::GetSampleSize() const
+    engine->RegisterObjectMethod(className, "uint GetSampleSize() const", AS_METHODPR(T, GetSampleSize, () const, u32), AS_CALL_THISCALL);
+    engine->RegisterObjectMethod(className, "uint get_sampleSize() const", AS_METHODPR(T, GetSampleSize, () const, u32), AS_CALL_THISCALL);
 
     // float Audio::GetSoundSourceMasterGain(StringHash typeHash) const
     engine->RegisterObjectMethod(className, "float GetSoundSourceMasterGain(StringHash) const", AS_METHODPR(T, GetSoundSourceMasterGain, (StringHash) const, float), AS_CALL_THISCALL);
@@ -9037,8 +9037,8 @@ template <class T> void RegisterMembers_Audio(asIScriptEngine* engine, const cha
     engine->RegisterObjectMethod(className, "void SetMasterGain(const String&in, float)", AS_METHODPR(T, SetMasterGain, (const String&, float), void), AS_CALL_THISCALL);
     engine->RegisterObjectMethod(className, "void set_masterGain(const String&in, float)", AS_METHODPR(T, SetMasterGain, (const String&, float), void), AS_CALL_THISCALL);
 
-    // bool Audio::SetMode(int bufferLengthMSec, int mixRate, bool stereo, bool interpolation = true)
-    engine->RegisterObjectMethod(className, "bool SetMode(int, int, bool, bool = true)", AS_METHODPR(T, SetMode, (int, int, bool, bool), bool), AS_CALL_THISCALL);
+    // bool Audio::SetMode(i32 bufferLengthMSec, i32 mixRate, bool stereo, bool interpolation = true)
+    engine->RegisterObjectMethod(className, "bool SetMode(int, int, bool, bool = true)", AS_METHODPR(T, SetMode, (i32, i32, bool, bool), bool), AS_CALL_THISCALL);
 
     // void Audio::Stop()
     engine->RegisterObjectMethod(className, "void Stop()", AS_METHODPR(T, Stop, (), void), AS_CALL_THISCALL);

--- a/Source/Urho3D/Audio/Audio.h
+++ b/Source/Urho3D/Audio/Audio.h
@@ -48,7 +48,7 @@ public:
     ~Audio() override;
 
     /// Initialize sound output with specified buffer length and output mode.
-    bool SetMode(int bufferLengthMSec, int mixRate, bool stereo, bool interpolation = true);
+    bool SetMode(i32 bufferLengthMSec, i32 mixRate, bool stereo, bool interpolation = true);
     /// Run update on sound sources. Not required for continued playback, but frees unused sound sources & sounds and updates 3D positions.
     void Update(float timeStep);
     /// Restart sound output.
@@ -72,11 +72,11 @@ public:
 
     /// Return byte size of one sample.
     /// @property
-    unsigned GetSampleSize() const { return sampleSize_; }
+    u32 GetSampleSize() const { return sampleSize_; }
 
     /// Return mixing rate.
     /// @property
-    int GetMixRate() const { return mixRate_; }
+    i32 GetMixRate() const { return mixRate_; }
 
     /// Return whether output is interpolated.
     /// @property
@@ -123,7 +123,7 @@ public:
     float GetSoundSourceMasterGain(StringHash typeHash) const;
 
     /// Mix sound sources into the buffer.
-    void MixOutput(void* dest, unsigned samples);
+    void MixOutput(void* dest, u32 samples);
 
 private:
     /// Handle render update event.
@@ -134,17 +134,17 @@ private:
     void UpdateInternal(float timeStep);
 
     /// Clipping buffer for mixing.
-    SharedArrayPtr<int> clipBuffer_;
+    SharedArrayPtr<i32> clipBuffer_;
     /// Audio thread mutex.
     Mutex audioMutex_;
     /// SDL audio device ID.
-    unsigned deviceID_{};
+    u32 deviceID_{};
     /// Sample size.
-    unsigned sampleSize_{};
+    u32 sampleSize_{};
     /// Clip buffer size in samples.
-    unsigned fragmentSize_{};
+    u32 fragmentSize_{};
     /// Mixing rate.
-    int mixRate_{};
+    i32 mixRate_{};
     /// Mixing interpolation flag.
     bool interpolation_{};
     /// Stereo flag.

--- a/Source/Urho3D/Base/PrimitiveTypes.h
+++ b/Source/Urho3D/Base/PrimitiveTypes.h
@@ -1,0 +1,41 @@
+//
+// Copyright (c) 2008-2022 the Urho3D project.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+#include <cstdint>
+
+// https://en.cppreference.com/w/cpp/language/types
+static_assert(sizeof(char) == 1);
+static_assert(sizeof(int) == 4);
+static_assert(sizeof(long) == 4 || sizeof(long) == 8); // (Win32, Win64, Unix32) || Unix64
+static_assert(sizeof(long long) == 8);
+
+// https://en.cppreference.com/w/cpp/types/integer
+typedef int8_t   i8;
+typedef uint8_t  u8;
+typedef int16_t  i16;
+typedef uint16_t u16;
+typedef int32_t  i32;
+typedef uint32_t u32;
+typedef int64_t  i64;
+typedef uint64_t u64;

--- a/Source/Urho3D/Container/VectorBase.h
+++ b/Source/Urho3D/Container/VectorBase.h
@@ -29,6 +29,7 @@
 #endif
 
 #include "../Base/Iter.h"
+#include "../Base/PrimitiveTypes.h"
 #include "../Container/Swap.h"
 
 namespace Urho3D
@@ -61,11 +62,11 @@ protected:
     static unsigned char* AllocateBuffer(unsigned size);
 
     /// Size of vector.
-    unsigned size_;
+    u32 size_;
     /// Buffer capacity.
-    unsigned capacity_;
+    u32 capacity_;
     /// Buffer.
-    unsigned char* buffer_;
+    u8* buffer_;
 };
 
 }


### PR DESCRIPTION
# Motivation

1) In most modern compilers, the size of primitive types is same (except `long`), but not in the C++ standard. Therefore, it is common practice to use types with a fixed size (Uint32 in SDL for example).
2) C++11 define [fixed width integer types](https://en.cppreference.com/w/cpp/types/integer), but this type names are too long (`uint32_t` has the same length as `unsigned`).
3) `i4` is even shorter than `i32` but I don't use this variant because it can be confusing (i8 - 8 bits or 64 bits?). So I used [this variant](https://doc.rust-lang.org/book/ch03-02-data-types.html).
4) I'm not going to change type names whole the engine at once, I just added the ability to use new types when writing new code or changing old one.