### PR TITLE
99_Benchmark: use standart way for source grouping

### DIFF
--- a/Source/Samples/99_Benchmark/CMakeLists.txt
+++ b/Source/Samples/99_Benchmark/CMakeLists.txt
@@ -24,7 +24,7 @@
 set (TARGET_NAME 99_Benchmark)
 
 # Define source files
-define_source_files ()
+define_source_files (GROUP)
 
 # Setup target with resource copying
 setup_main_executable ()
@@ -32,5 +32,3 @@ setup_main_executable ()
 # Setup test cases
 setup_test ()
 
-# Preventing VS from placing cpp and h files to different groups 
-source_group (TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCE_FILES})


### PR DESCRIPTION
Fix for

```
CMake Error at Source/Samples/99_Benchmark/CMakeLists.txt:36 (source_group):
  source_group ROOT:
  /home/runner/work/Urho3D/Urho3D/Source/Samples/99_Benchmark is not a prefix
  of file: /home/runner/work/Urho3D/Urho3D/build/ci/bin/Urho3D.js
```

in web builds