### PR TITLE
Don't define WriteMiniDump when URHO3D_MINIDUMPS is not defined

### DIFF
--- a/Source/Urho3D/Core/MiniDump.cpp
+++ b/Source/Urho3D/Core/MiniDump.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2008-2022 the Urho3D project
 // License: MIT
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && defined(URHO3D_MINIDUMPS)
 
 #include "../Precompiled.h"
 


### PR DESCRIPTION
dbghelp not linking, when URHO3D_MINIDUMPS not defined, so MiniDumpWriteDump() used in WriteMiniDump() is not implemented