### PR TITLE
Increase CMake minumum version to 3.15 [cache clear]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # License: MIT
 
 # Set CMake minimum version
-cmake_minimum_required (VERSION 3.10.2)
+cmake_minimum_required (VERSION 3.15)
 
 # Set project name
 project (Urho3D)


### PR DESCRIPTION
## Motivation

CMake < 3.15 use `/w3` by default. This cause the huge number of warnings in ThirdParty libs in VS. Owerriding `/w3` by `/w` cause another warning, which can also be disabled in CMake >= 3.15. CMake 3.15 is old enough to usage.

https://cmake.org/cmake/help/latest/policy/CMP0092.html
