### PR TITLE
Vector: replace size, index & capacity types from unsigned to signed

### DIFF
--- a/Source/Urho3D/AngelScript/Generated_GlobalVariables.cpp
+++ b/Source/Urho3D/AngelScript/Generated_GlobalVariables.cpp
@@ -376,6 +376,9 @@ void ASRegisterGeneratedGlobalVariables(asIScriptEngine* engine)
     // constexpr float M_RADTODEG | File: ../Math/MathDefs.h
     engine->RegisterGlobalProperty("const float M_RADTODEG", (void*)&M_RADTODEG);
 
+    // constexpr i32 NINDEX | File: ../Container/Vector.h
+    engine->RegisterGlobalProperty("const int NINDEX", (void*)&NINDEX);
+
     // static const unsigned NUM_FRUSTUM_PLANES | File: ../Math/Frustum.h
     engine->RegisterGlobalProperty("const uint NUM_FRUSTUM_PLANES", (void*)&NUM_FRUSTUM_PLANES);
 

--- a/Source/Urho3D/AngelScript/Generated_Includes.h
+++ b/Source/Urho3D/AngelScript/Generated_Includes.h
@@ -18,6 +18,7 @@
 #include "../Container/RefCounted.h"
 #include "../Container/Sort.h"
 #include "../Container/Str.h"
+#include "../Container/Vector.h"
 #include "../Container/VectorBase.h"
 #include "../Core/Attribute.h"
 #include "../Core/Condition.h"

--- a/Source/Urho3D/AngelScript/Generated_Members.h
+++ b/Source/Urho3D/AngelScript/Generated_Members.h
@@ -15423,8 +15423,8 @@ template <class T> void RegisterMembers_Node(asIScriptEngine* engine, const char
     // void Node::SetOwner(Connection* owner)
     // Not registered because have @manualbind mark
 
-    // void Node::AddChild(Node* node, unsigned index = M_MAX_UNSIGNED)
-    engine->RegisterObjectMethod(className, "void AddChild(Node@+, uint = M_MAX_UNSIGNED)", AS_METHODPR(T, AddChild, (Node*, unsigned), void), AS_CALL_THISCALL);
+    // void Node::AddChild(Node* node, i32 index = NINDEX)
+    engine->RegisterObjectMethod(className, "void AddChild(Node@+, int = NINDEX)", AS_METHODPR(T, AddChild, (Node*, i32), void), AS_CALL_THISCALL);
 
     // void Node::AddComponent(Component* component, unsigned id, CreateMode mode)
     engine->RegisterObjectMethod(className, "void AddComponent(Component@+, uint, CreateMode)", AS_METHODPR(T, AddComponent, (Component*, unsigned, CreateMode), void), AS_CALL_THISCALL);

--- a/Source/Urho3D/Container/VectorBase.cpp
+++ b/Source/Urho3D/Container/VectorBase.cpp
@@ -10,9 +10,9 @@
 namespace Urho3D
 {
 
-unsigned char* VectorBase::AllocateBuffer(unsigned size)
+u8* VectorBase::AllocateBuffer(i32 size)
 {
-    return new unsigned char[size];
+    return new u8[size];
 }
 
 }

--- a/Source/Urho3D/Container/VectorBase.h
+++ b/Source/Urho3D/Container/VectorBase.h
@@ -39,12 +39,12 @@ public:
     }
 
 protected:
-    static unsigned char* AllocateBuffer(unsigned size);
+    static u8* AllocateBuffer(i32 size);
 
     /// Size of vector.
-    u32 size_;
+    i32 size_;
     /// Buffer capacity.
-    u32 capacity_;
+    i32 capacity_;
     /// Buffer.
     u8* buffer_;
 };

--- a/Source/Urho3D/Network/Connection.h
+++ b/Source/Urho3D/Network/Connection.h
@@ -14,7 +14,7 @@
 
 namespace SLNet
 {
-    class SystemAddress;
+    struct SystemAddress;
     struct AddressOrGUID;
     struct RakNetGUID;
     struct Packet;

--- a/Source/Urho3D/Resource/Image.cpp
+++ b/Source/Urho3D/Resource/Image.cpp
@@ -926,13 +926,13 @@ void Image::SetPixelInt(int x, int y, int z, unsigned uintColor)
     {
     case 4:
         dest[3] = src[3];
-        // Fall through
+        [[fallthrough]];
     case 3:
         dest[2] = src[2];
-        // Fall through
+        [[fallthrough]];
     case 2:
         dest[1] = src[1];
-        // Fall through
+        [[fallthrough]];
     default:
         dest[0] = src[0];
         break;
@@ -1172,13 +1172,13 @@ bool Image::Resize(int width, int height)
             {
             case 4:
                 dest[3] = src[3];
-                // Fall through
+                [[fallthrough]];
             case 3:
                 dest[2] = src[2];
-                // Fall through
+                [[fallthrough]];
             case 2:
                 dest[1] = src[1];
-                // Fall through
+                [[fallthrough]];
             default:
                 dest[0] = src[0];
                 break;
@@ -1472,10 +1472,10 @@ Color Image::GetPixel(int x, int y, int z) const
     {
     case 4:
         ret.a_ = (float)src[3] / 255.0f;
-        // Fall through
+        [[fallthrough]];
     case 3:
         ret.b_ = (float)src[2] / 255.0f;
-        // Fall through
+        [[fallthrough]];
     case 2:
         ret.g_ = (float)src[1] / 255.0f;
         ret.r_ = (float)src[0] / 255.0f;
@@ -1509,10 +1509,10 @@ unsigned Image::GetPixelInt(int x, int y, int z) const
     {
     case 4:
         ret |= (unsigned)src[3] << 24;
-        // Fall through
+        [[fallthrough]];
     case 3:
         ret |= (unsigned)src[2] << 16;
-        // Fall through
+        [[fallthrough]];
     case 2:
         ret |= (unsigned)src[1] << 8;
         ret |= (unsigned)src[0];

--- a/Source/Urho3D/Resource/JSONValue.cpp
+++ b/Source/Urho3D/Resource/JSONValue.cpp
@@ -136,6 +136,7 @@ JSONValue& JSONValue::operator =(const JSONValue& rhs)
 
     case JSON_OBJECT:
         *objectValue_ = *rhs.objectValue_;
+        break;
 
     default:
         break;

--- a/Source/Urho3D/Scene/Node.cpp
+++ b/Source/Urho3D/Scene/Node.cpp
@@ -784,8 +784,10 @@ Node* Node::CreateTemporaryChild(const String& name, CreateMode mode, unsigned i
     return CreateChild(name, mode, id, true);
 }
 
-void Node::AddChild(Node* node, unsigned index)
+void Node::AddChild(Node* node, i32 index)
 {
+    assert((index >= 0 && index <= children_.Size()) || index == NINDEX);
+
     // Check for illegal or redundant parent assignment
     if (!node || node == this || node->parent_ == this)
         return;

--- a/Source/Urho3D/Scene/Node.h
+++ b/Source/Urho3D/Scene/Node.h
@@ -290,8 +290,10 @@ public:
     Node* CreateChild(const String& name = String::EMPTY, CreateMode mode = REPLICATED, unsigned id = 0, bool temporary = false);
     /// Create a temporary child scene node (with specified ID if provided).
     Node* CreateTemporaryChild(const String& name = String::EMPTY, CreateMode mode = REPLICATED, unsigned id = 0);
-    /// Add a child scene node at a specific index. If index is not explicitly specified or is greater than current children size, append the new child at the end.
-    void AddChild(Node* node, unsigned index = M_MAX_UNSIGNED);
+    
+    /// Add a child scene node at a specific index. If index is not explicitly specified or is NINDEX, append the new child at the end.
+    void AddChild(Node* node, i32 index = NINDEX);
+    
     /// Remove a child scene node.
     void RemoveChild(Node* node);
     /// Remove all child scene nodes.

--- a/Source/Urho3D/Scene/ValueAnimationInfo.cpp
+++ b/Source/Urho3D/Scene/ValueAnimationInfo.cpp
@@ -124,7 +124,7 @@ float ValueAnimationInfo::CalculateScaledTime(float currentTime, bool& finished)
 
     case WM_ONCE:
         finished = (currentTime >= endTime);
-        // Fallthrough
+        [[fallthrough]];
 
     case WM_CLAMP:
         return Clamp(currentTime, beginTime, endTime);

--- a/Source/Urho3D/UI/LineEdit.cpp
+++ b/Source/Urho3D/UI/LineEdit.cpp
@@ -245,7 +245,7 @@ void LineEdit::OnKey(Key key, MouseButtonFlags buttons, QualifierFlags qualifier
 
     case KEY_HOME:
         qualifiers |= QUAL_CTRL;
-        // Fallthru
+        [[fallthrough]];
 
     case KEY_LEFT:
         if (cursorMovable_ && cursorPosition_ > 0)
@@ -277,7 +277,7 @@ void LineEdit::OnKey(Key key, MouseButtonFlags buttons, QualifierFlags qualifier
 
     case KEY_END:
         qualifiers |= QUAL_CTRL;
-        // Fallthru
+        [[fallthrough]];
 
     case KEY_RIGHT:
         if (cursorMovable_ && cursorPosition_ < line_.LengthUTF8())

--- a/Source/Urho3D/UI/ListView.cpp
+++ b/Source/Urho3D/UI/ListView.cpp
@@ -234,7 +234,7 @@ void ListView::OnKey(Key key, MouseButtonFlags buttons, QualifierFlags qualifier
 
         case KEY_PAGEUP:
             pageDirection = -1;
-            // Fallthru
+            [[fallthrough]];
 
         case KEY_PAGEDOWN:
             {

--- a/Source/Urho3D/UI/ScrollView.cpp
+++ b/Source/Urho3D/UI/ScrollView.cpp
@@ -201,7 +201,7 @@ void ScrollView::OnKey(Key key, MouseButtonFlags buttons, QualifierFlags qualifi
 
     case KEY_HOME:
         qualifiers |= QUAL_CTRL;
-        // Fallthru
+        [[fallthrough]];
 
     case KEY_UP:
         if (verticalScrollBar_->IsVisible())
@@ -215,7 +215,7 @@ void ScrollView::OnKey(Key key, MouseButtonFlags buttons, QualifierFlags qualifi
 
     case KEY_END:
         qualifiers |= QUAL_CTRL;
-        // Fallthru
+        [[fallthrough]];
 
     case KEY_DOWN:
         if (verticalScrollBar_->IsVisible())


### PR DESCRIPTION
Related: https://github.com/urho3d/Urho3D/issues/2940

This creates a huge number of warnings, but everything seems to remain in working order. Warnings will be gradually fixed

NINDEX is analog of String::NPOS, but for vectors