### PR TITLE
Remove PODVector alias [cache clear]

### DIFF
--- a/Source/Samples/07_Billboards/Billboards.cpp
+++ b/Source/Samples/07_Billboards/Billboards.cpp
@@ -270,8 +270,8 @@ void Billboards::MoveCamera(float timeStep)
 void Billboards::AnimateScene(float timeStep)
 {
     // Get the light and billboard scene nodes
-    PODVector<Node*> lightNodes;
-    PODVector<Node*> billboardNodes;
+    Vector<Node*> lightNodes;
+    Vector<Node*> billboardNodes;
     scene_->GetChildrenWithComponent<Light>(lightNodes);
     scene_->GetChildrenWithComponent<BillboardSet>(billboardNodes);
 

--- a/Source/Samples/08_Decals/Decals.cpp
+++ b/Source/Samples/08_Decals/Decals.cpp
@@ -271,7 +271,7 @@ bool Decals::Raycast(float maxDistance, Vector3& hitPos, Drawable*& hitDrawable)
     auto* camera = cameraNode_->GetComponent<Camera>();
     Ray cameraRay = camera->GetScreenRay((float)pos.x_ / graphics->GetWidth(), (float)pos.y_ / graphics->GetHeight());
     // Pick only geometry objects, not eg. zones or lights, only get the first (closest) hit
-    PODVector<RayQueryResult> results;
+    Vector<RayQueryResult> results;
     RayOctreeQuery query(results, cameraRay, RAY_TRIANGLE, maxDistance, DRAWABLE_GEOMETRY);
     scene_->GetComponent<Octree>()->RaycastSingle(query);
     if (results.Size())

--- a/Source/Samples/15_Navigation/Navigation.cpp
+++ b/Source/Samples/15_Navigation/Navigation.cpp
@@ -343,7 +343,7 @@ bool Navigation::Raycast(float maxDistance, Vector3& hitPos, Drawable*& hitDrawa
     auto* camera = cameraNode_->GetComponent<Camera>();
     Ray cameraRay = camera->GetScreenRay((float)pos.x_ / graphics->GetWidth(), (float)pos.y_ / graphics->GetHeight());
     // Pick only geometry objects, not eg. zones or lights, only get the first (closest) hit
-    PODVector<RayQueryResult> results;
+    Vector<RayQueryResult> results;
     RayOctreeQuery query(results, cameraRay, RAY_TRIANGLE, maxDistance, DRAWABLE_GEOMETRY);
     scene_->GetComponent<Octree>()->RaycastSingle(query);
     if (results.Size())

--- a/Source/Samples/15_Navigation/Navigation.h
+++ b/Source/Samples/15_Navigation/Navigation.h
@@ -139,7 +139,7 @@ private:
     void HandlePostRenderUpdate(StringHash eventType, VariantMap& eventData);
 
     /// Last calculated path.
-    PODVector<Vector3> currentPath_;
+    Vector<Vector3> currentPath_;
     /// Path end position.
     Vector3 endPos_;
     /// Jack scene node.
@@ -151,7 +151,7 @@ private:
     /// Streaming distance.
     int streamingDistance_;
     /// Tile data.
-    HashMap<IntVector2, PODVector<unsigned char>> tileData_;
+    HashMap<IntVector2, Vector<unsigned char>> tileData_;
     /// Added tiles.
     HashSet<IntVector2> addedTiles_;
 };

--- a/Source/Samples/16_Chat/Chat.cpp
+++ b/Source/Samples/16_Chat/Chat.cpp
@@ -242,7 +242,7 @@ void Chat::HandleNetworkMessage(StringHash /*eventType*/, VariantMap& eventData)
     int msgID = eventData[P_MESSAGEID].GetInt();
     if (msgID == MSG_CHAT)
     {
-        const PODVector<unsigned char>& data = eventData[P_DATA].GetBuffer();
+        const Vector<unsigned char>& data = eventData[P_DATA].GetBuffer();
         // Use a MemoryBuffer to read the message data so that there is no unnecessary copying
         MemoryBuffer msg(data);
         String text = msg.ReadString();

--- a/Source/Samples/32_Physics2DConstraints/Urho2DConstraints.cpp
+++ b/Source/Samples/32_Physics2DConstraints/Urho2DConstraints.cpp
@@ -164,7 +164,7 @@ void Urho2DConstraints::CreateScene()
     auto* polygonBody = polygon->CreateComponent<RigidBody2D>();
     polygonBody->SetBodyType(BT_DYNAMIC);
     auto* polygonShape = polygon->CreateComponent<CollisionPolygon2D>();
-    // TODO: create from PODVector<Vector2> using SetVertices()
+    // TODO: create from Vector<Vector2> using SetVertices()
     polygonShape->SetVertexCount(6); // Set number of vertices (mandatory when using SetVertex())
     polygonShape->SetVertex(0, Vector2(-0.8f, -0.3f));
     polygonShape->SetVertex(1, Vector2(0.5f, -0.8f));

--- a/Source/Samples/34_DynamicGeometry/DynamicGeometry.cpp
+++ b/Source/Samples/34_DynamicGeometry/DynamicGeometry.cpp
@@ -206,7 +206,7 @@ void DynamicGeometry::CreateScene()
         vb->SetShadowed(true);
         // We could use the "legacy" element bitmask to define elements for more compact code, but let's demonstrate
         // defining the vertex elements explicitly to allow any element types and order
-        PODVector<VertexElement> elements;
+        Vector<VertexElement> elements;
         elements.Push(VertexElement(TYPE_VECTOR3, SEM_POSITION));
         elements.Push(VertexElement(TYPE_VECTOR3, SEM_NORMAL));
         vb->SetSize(numVertices, elements);
@@ -230,8 +230,8 @@ void DynamicGeometry::CreateScene()
         vertexBuffers.Push(vb);
         indexBuffers.Push(ib);
         // Morph ranges could also be not defined. Here we simply define a zero range (no morphing) for the vertex buffer
-        PODVector<unsigned> morphRangeStarts;
-        PODVector<unsigned> morphRangeCounts;
+        Vector<unsigned> morphRangeStarts;
+        Vector<unsigned> morphRangeCounts;
         morphRangeStarts.Push(0);
         morphRangeCounts.Push(0);
         fromScratchModel->SetVertexBuffers(vertexBuffers, morphRangeStarts, morphRangeCounts);

--- a/Source/Samples/34_DynamicGeometry/DynamicGeometry.h
+++ b/Source/Samples/34_DynamicGeometry/DynamicGeometry.h
@@ -63,9 +63,9 @@ private:
     /// Cloned models' vertex buffers that we will animate.
     Vector<SharedPtr<VertexBuffer>> animatingBuffers_;
     /// Original vertex positions for the sphere model.
-    PODVector<Vector3> originalVertices_;
+    Vector<Vector3> originalVertices_;
     /// If the vertices are duplicates, indices to the original vertices (to allow seamless animation.)
-    PODVector<unsigned> vertexDuplicates_;
+    Vector<unsigned> vertexDuplicates_;
     /// Animation flag.
     bool animate_;
     /// Animation's elapsed time.

--- a/Source/Samples/37_UIDrag/UIDrag.cpp
+++ b/Source/Samples/37_UIDrag/UIDrag.cpp
@@ -194,9 +194,9 @@ void UIDrag::HandleUpdate(StringHash eventType, VariantMap& eventData)
 
     if (input->GetKeyPress(KEY_SPACE))
     {
-        PODVector<UIElement*> elements;
+        Vector<UIElement*> elements;
         root->GetChildrenWithTag(elements, "SomeTag");
-        for (PODVector<UIElement*>::ConstIterator i = elements.Begin(); i != elements.End(); ++i)
+        for (Vector<UIElement*>::ConstIterator i = elements.Begin(); i != elements.End(); ++i)
         {
             UIElement* element = *i;
             element->SetVisible(!element->IsVisible());

--- a/Source/Samples/39_CrowdNavigation/CrowdNavigation.cpp
+++ b/Source/Samples/39_CrowdNavigation/CrowdNavigation.cpp
@@ -372,7 +372,7 @@ bool CrowdNavigation::Raycast(float maxDistance, Vector3& hitPos, Drawable*& hit
     auto* camera = cameraNode_->GetComponent<Camera>();
     Ray cameraRay = camera->GetScreenRay((float)pos.x_ / graphics->GetWidth(), (float)pos.y_ / graphics->GetHeight());
     // Pick only geometry objects, not eg. zones or lights, only get the first (closest) hit
-    PODVector<RayQueryResult> results;
+    Vector<RayQueryResult> results;
     RayOctreeQuery query(results, cameraRay, RAY_TRIANGLE, maxDistance, DRAWABLE_GEOMETRY);
     scene_->GetComponent<Octree>()->RaycastSingle(query);
     if (results.Size())

--- a/Source/Samples/39_CrowdNavigation/CrowdNavigation.h
+++ b/Source/Samples/39_CrowdNavigation/CrowdNavigation.h
@@ -155,7 +155,7 @@ private:
     /// Streaming distance.
     int streamingDistance_{2};
     /// Tile data.
-    HashMap<IntVector2, PODVector<unsigned char>> tileData_;
+    HashMap<IntVector2, Vector<unsigned char>> tileData_;
     /// Added tiles.
     HashSet<IntVector2> addedTiles_;
     /// Flag for drawing debug geometry.

--- a/Source/Samples/47_Typography/Typography.cpp
+++ b/Source/Samples/47_Typography/Typography.cpp
@@ -204,7 +204,7 @@ void Typography::HandleWhiteBackground(StringHash eventType, VariantMap& eventDa
     Zone* zone = renderer->GetDefaultZone();
     zone->SetFogColor(bg);
 
-    PODVector<UIElement*> text = uielement_->GetChildrenWithTag(TEXT_TAG, true);
+    Vector<UIElement*> text = uielement_->GetChildrenWithTag(TEXT_TAG, true);
     for (int i = 0; i < text.Size(); i++)
     {
         text[i]->SetColor(fg);

--- a/Source/Samples/50_Urho2DPlatformer/Character2D.cpp
+++ b/Source/Samples/50_Urho2DPlatformer/Character2D.cpp
@@ -73,7 +73,7 @@ void Character2D::Update(float timeStep)
     // Collision detection (AABB query)
     Vector2 characterHalfSize = Vector2(0.16f, 0.16f);
     auto* physicsWorld = GetScene()->GetComponent<PhysicsWorld2D>();
-    PODVector<RigidBody2D*> collidingBodies;
+    Vector<RigidBody2D*> collidingBodies;
     physicsWorld->GetRigidBodies(collidingBodies, Rect(node_->GetWorldPosition2D() - characterHalfSize - Vector2(0.0f, 0.1f), node_->GetWorldPosition2D() + characterHalfSize));
 
     if (collidingBodies.Size() > 1 && !isClimbing_)

--- a/Source/Samples/99_Benchmark/Benchmark03_MoleculeLogic.cpp
+++ b/Source/Samples/99_Benchmark/Benchmark03_MoleculeLogic.cpp
@@ -27,7 +27,7 @@ static constexpr float CONTAINER_RADIUS = 9.f;
 
 void Benchmark03_MoleculeLogic::Update(float timeStep)
 {
-    PODVector<Node*> moleculeNodes;
+    Vector<Node*> moleculeNodes;
     GetScene()->GetChildrenWithComponent<Benchmark03_MoleculeLogic>(moleculeNodes);
 
     Vector2 moleculePos = node_->GetPosition2D();

--- a/Source/Samples/Utilities2D/Mover.cpp
+++ b/Source/Samples/Utilities2D/Mover.cpp
@@ -30,7 +30,7 @@ void Mover::RegisterObject(Context* context)
 
     // These macros register the class attribute to the Context for automatic load / save handling.
     // We specify the Default attribute mode which means it will be used both for saving into file, and network replication.
-    URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Path", GetPathAttr, SetPathAttr, PODVector<unsigned char>, Variant::emptyBuffer, AM_DEFAULT);
+    URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Path", GetPathAttr, SetPathAttr, Vector<unsigned char>, Variant::emptyBuffer, AM_DEFAULT);
     URHO3D_ATTRIBUTE("Speed", float, speed_, 0.8f, AM_DEFAULT);
     URHO3D_ATTRIBUTE("Current Path ID", int, currentPathID_, 1, AM_DEFAULT);
     URHO3D_ATTRIBUTE("Emit Time", float, emitTime_, 0.0f, AM_DEFAULT);
@@ -38,7 +38,7 @@ void Mover::RegisterObject(Context* context)
     URHO3D_ATTRIBUTE("Flip Animation", float, flip_, 0.0f, AM_DEFAULT);
 }
 
-void Mover::SetPathAttr(const PODVector<unsigned char>& value)
+void Mover::SetPathAttr(const Vector<unsigned char>& value)
 {
     if (value.Empty())
         return;
@@ -48,7 +48,7 @@ void Mover::SetPathAttr(const PODVector<unsigned char>& value)
         path_.Push(buffer.ReadVector2());
 }
 
-PODVector<unsigned char> Mover::GetPathAttr() const
+Vector<unsigned char> Mover::GetPathAttr() const
 {
     VectorBuffer buffer;
 

--- a/Source/Samples/Utilities2D/Mover.h
+++ b/Source/Samples/Utilities2D/Mover.h
@@ -26,12 +26,12 @@ public:
     /// Handle scene update. Called by LogicComponent base class.
     void Update(float timeStep) override;
     /// Return path attribute.
-    PODVector<unsigned char> GetPathAttr() const;
+    Vector<unsigned char> GetPathAttr() const;
     /// Set path attribute.
-    void SetPathAttr(const PODVector<unsigned char>& value);
+    void SetPathAttr(const Vector<unsigned char>& value);
 
     /// Path.
-    PODVector<Vector2> path_;
+    Vector<Vector2> path_;
     /// Movement speed.
     float speed_;
     /// ID of the current path point.

--- a/Source/Samples/Utilities2D/Sample2D.cpp
+++ b/Source/Samples/Utilities2D/Sample2D.cpp
@@ -295,7 +295,7 @@ void Sample2D::PopulateMovingEntities(TileMapLayer2D* movingEntitiesLayer)
             auto* mover = movingClone->CreateComponent<Mover>();
 
             // Set path from points
-            PODVector<Vector2> path = CreatePathFromPoints(movingObject, offset);
+            Vector<Vector2> path = CreatePathFromPoints(movingObject, offset);
             mover->path_ = path;
 
             // Override default speed
@@ -374,9 +374,9 @@ float Sample2D::Zoom(Camera* camera)
     return zoom_;
 }
 
-PODVector<Vector2> Sample2D::CreatePathFromPoints(TileMapObject2D* object, const Vector2& offset)
+Vector<Vector2> Sample2D::CreatePathFromPoints(TileMapObject2D* object, const Vector2& offset)
 {
-    PODVector<Vector2> path;
+    Vector<Vector2> path;
     for (unsigned i=0; i < object->GetNumPoints(); ++i)
         path.Push(object->GetPoint(i) + offset);
     return path;

--- a/Source/Samples/Utilities2D/Sample2D.h
+++ b/Source/Samples/Utilities2D/Sample2D.h
@@ -72,7 +72,7 @@ public:
     /// Read input and zoom the camera.
     float Zoom(Camera* camera);
     /// Create path from tmx object's points.
-    PODVector<Vector2> CreatePathFromPoints(TileMapObject2D* object, const Vector2& offset);
+    Vector<Vector2> CreatePathFromPoints(TileMapObject2D* object, const Vector2& offset);
     /// Create the UI content.
     void CreateUIContent(const String& demoTitle, int remainingLifes, int remainingCoins);
     /// Handle 'EXIT' button released event.

--- a/Source/Tools/AssetImporter/AssetImporter.cpp
+++ b/Source/Tools/AssetImporter/AssetImporter.cpp
@@ -44,13 +44,13 @@ struct OutModel
     String outName_;
     aiNode* rootNode_{};
     HashSet<unsigned> meshIndices_;
-    PODVector<aiMesh*> meshes_;
-    PODVector<aiNode*> meshNodes_;
-    PODVector<aiNode*> bones_;
-    PODVector<aiNode*> pivotlessBones_;
-    PODVector<aiAnimation*> animations_;
-    PODVector<float> boneRadii_;
-    PODVector<BoundingBox> boneHitboxes_;
+    Vector<aiMesh*> meshes_;
+    Vector<aiNode*> meshNodes_;
+    Vector<aiNode*> bones_;
+    Vector<aiNode*> pivotlessBones_;
+    Vector<aiAnimation*> animations_;
+    Vector<float> boneRadii_;
+    Vector<BoundingBox> boneHitboxes_;
     aiNode* rootBone_{};
     unsigned totalVertices_{};
     unsigned totalIndices_{};
@@ -61,8 +61,8 @@ struct OutScene
     String outName_;
     aiNode* rootNode_{};
     Vector<OutModel> models_;
-    PODVector<aiNode*> nodes_;
-    PODVector<unsigned> nodeModelIndices_;
+    Vector<aiNode*> nodes_;
+    Vector<unsigned> nodeModelIndices_;
 };
 
 // FBX transform chain
@@ -149,7 +149,7 @@ Vector<String> nonSkinningBoneIncludes_;
 Vector<String> nonSkinningBoneExcludes_;
 
 HashSet<aiAnimation*> allAnimations_;
-PODVector<aiAnimation*> sceneAnimations_;
+Vector<aiAnimation*> sceneAnimations_;
 
 float defaultTicksPerSecond_ = 4800.0f;
 // For subset animation import usage
@@ -165,7 +165,7 @@ void ExportModel(const String& outName, bool animationOnly);
 void ExportAnimation(const String& outName, bool animationOnly);
 void CollectMeshes(OutModel& model, aiNode* node);
 void CollectBones(OutModel& model, bool animationOnly = false);
-void CollectBonesFinal(PODVector<aiNode*>& dest, const HashSet<aiNode*>& necessary, aiNode* node);
+void CollectBonesFinal(Vector<aiNode*>& dest, const HashSet<aiNode*>& necessary, aiNode* node);
 void MoveToBindPose(OutModel& model, aiNode* current);
 void CollectAnimations(OutModel* model = nullptr);
 void BuildBoneCollisionInfo(OutModel& model);
@@ -182,15 +182,15 @@ void ExportMaterials(HashSet<String>& usedTextures);
 void BuildAndSaveMaterial(aiMaterial* material, HashSet<String>& usedTextures);
 void CopyTextures(const HashSet<String>& usedTextures, const String& sourcePath);
 
-void CombineLods(const PODVector<float>& lodDistances, const Vector<String>& modelNames, const String& outName);
+void CombineLods(const Vector<float>& lodDistances, const Vector<String>& modelNames, const String& outName);
 
 void GetMeshesUnderNode(Vector<Pair<aiNode*, aiMesh*> >& dest, aiNode* node);
 unsigned GetMeshIndex(aiMesh* mesh);
 unsigned GetBoneIndex(OutModel& model, const String& boneName);
 aiBone* GetMeshBone(OutModel& model, const String& boneName);
 Matrix3x4 GetOffsetMatrix(OutModel& model, const String& boneName);
-void GetBlendData(OutModel& model, aiMesh* mesh, aiNode* meshNode, PODVector<unsigned>& boneMappings, Vector<PODVector<unsigned char> >&
-    blendIndices, Vector<PODVector<float> >& blendWeights);
+void GetBlendData(OutModel& model, aiMesh* mesh, aiNode* meshNode, Vector<unsigned>& boneMappings, Vector<Vector<unsigned char> >&
+    blendIndices, Vector<Vector<float> >& blendWeights);
 String GetMeshMaterialName(aiMesh* mesh);
 String GetMaterialTextureName(const String& nameIn);
 String GenerateMaterialName(aiMaterial* material);
@@ -200,9 +200,9 @@ unsigned GetNumValidFaces(aiMesh* mesh);
 void WriteShortIndices(unsigned short*& dest, aiMesh* mesh, unsigned index, unsigned offset);
 void WriteLargeIndices(unsigned*& dest, aiMesh* mesh, unsigned index, unsigned offset);
 void WriteVertex(float*& dest, aiMesh* mesh, unsigned index, bool isSkinned, BoundingBox& box,
-    const Matrix3x4& vertexTransform, const Matrix3& normalTransform, Vector<PODVector<unsigned char> >& blendIndices,
-    Vector<PODVector<float> >& blendWeights);
-PODVector<VertexElement> GetVertexElements(aiMesh* mesh, bool isSkinned);
+    const Matrix3x4& vertexTransform, const Matrix3& normalTransform, Vector<Vector<unsigned char> >& blendIndices,
+    Vector<Vector<float> >& blendWeights);
+Vector<VertexElement> GetVertexElements(aiMesh* mesh, bool isSkinned);
 
 aiNode* GetNode(const String& name, aiNode* rootNode, bool caseSensitive = true);
 aiMatrix4x4 GetDerivedTransform(aiNode* node, aiNode* rootNode, bool rootInclusive = true);
@@ -556,7 +556,7 @@ void Run(const Vector<String>& arguments)
     }
     else if (command == "lod")
     {
-        PODVector<float> lodDistances;
+        Vector<float> lodDistances;
         Vector<String> modelNames;
         String outFile;
 
@@ -854,7 +854,7 @@ void MoveToBindPose(OutModel& model, aiNode* current)
         MoveToBindPose(model, current->mChildren[i]);
 }
 
-void CollectBonesFinal(PODVector<aiNode*>& dest, const HashSet<aiNode*>& necessary, aiNode* node)
+void CollectBonesFinal(Vector<aiNode*>& dest, const HashSet<aiNode*>& necessary, aiNode* node)
 {
     bool includeBone = necessary.Find(node) != necessary.End();
     String boneName = FromAIString(node->mName);
@@ -981,14 +981,14 @@ void BuildAndSaveModel(OutModel& model)
     PrintLine("Writing model " + rootNodeName);
 
     SharedPtr<Model> outModel(new Model(context_));
-    Vector<PODVector<unsigned> > allBoneMappings;
+    Vector<Vector<unsigned> > allBoneMappings;
     BoundingBox box;
 
     unsigned numValidGeometries = 0;
 
     bool combineBuffers = true;
     // Check if buffers can be combined (same vertex elements, under 65535 vertices)
-    PODVector<VertexElement> elements = GetVertexElements(model.meshes_[0], model.bones_.Size() > 0);
+    Vector<VertexElement> elements = GetVertexElements(model.meshes_[0], model.bones_.Size() > 0);
     for (unsigned i = 0; i < model.meshes_.Size(); ++i)
     {
         if (GetNumValidFaces(model.meshes_[i]))
@@ -1029,7 +1029,7 @@ void BuildAndSaveModel(OutModel& model)
     for (unsigned i = 0; i < model.meshes_.Size(); ++i)
     {
         aiMesh* mesh = model.meshes_[i];
-        PODVector<VertexElement> elements = GetVertexElements(mesh, isSkinned);
+        Vector<VertexElement> elements = GetVertexElements(mesh, isSkinned);
         unsigned validFaces = GetNumValidFaces(mesh);
         if (!validFaces)
             continue;
@@ -1099,9 +1099,9 @@ void BuildAndSaveModel(OutModel& model)
 
         // Build the vertex data
         // If there are bones, get blend data
-        Vector<PODVector<unsigned char> > blendIndices;
-        Vector<PODVector<float> > blendWeights;
-        PODVector<unsigned> boneMappings;
+        Vector<Vector<unsigned char> > blendIndices;
+        Vector<Vector<float> > blendWeights;
+        Vector<unsigned> boneMappings;
         if (model.bones_.Size())
             GetBlendData(model, mesh, model.meshNodes_[i], boneMappings, blendIndices, blendWeights);
 
@@ -1142,7 +1142,7 @@ void BuildAndSaveModel(OutModel& model)
     }
 
     // Define the model buffers and bounding box
-    PODVector<unsigned> emptyMorphRange;
+    Vector<unsigned> emptyMorphRange;
     outModel->SetVertexBuffers(vbVector, emptyMorphRange, emptyMorphRange);
     outModel->SetIndexBuffers(ibVector);
     outModel->SetBoundingBox(box);
@@ -1225,7 +1225,7 @@ void BuildAndSaveAnimations(OutModel* model)
     ExtrapolatePivotlessAnimation(model);
 
     // build and save anim
-    const PODVector<aiAnimation*>& animations = model ? model->animations_ : sceneAnimations_;
+    const Vector<aiAnimation*>& animations = model ? model->animations_ : sceneAnimations_;
 
     for (unsigned i = 0; i < animations.Size(); ++i)
     {
@@ -2029,7 +2029,7 @@ void CopyTextures(const HashSet<String>& usedTextures, const String& sourcePath)
     }
 }
 
-void CombineLods(const PODVector<float>& lodDistances, const Vector<String>& modelNames, const String& outName)
+void CombineLods(const Vector<float>& lodDistances, const Vector<String>& modelNames, const String& outName)
 {
     // Load models
     Vector<SharedPtr<Model> > srcModels;
@@ -2077,7 +2077,7 @@ void CombineLods(const PODVector<float>& lodDistances, const Vector<String>& mod
 
     Vector<SharedPtr<VertexBuffer> > vbVector;
     Vector<SharedPtr<IndexBuffer> > ibVector;
-    PODVector<unsigned> emptyMorphRange;
+    Vector<unsigned> emptyMorphRange;
 
     // Create the final model
     SharedPtr<Model> outModel(new Model(context_));
@@ -2196,8 +2196,8 @@ Matrix3x4 GetOffsetMatrix(OutModel& model, const String& boneName)
     return Matrix3x4::IDENTITY;
 }
 
-void GetBlendData(OutModel& model, aiMesh* mesh, aiNode* meshNode, PODVector<unsigned>& boneMappings, Vector<PODVector<unsigned char> >&
-    blendIndices, Vector<PODVector<float> >& blendWeights)
+void GetBlendData(OutModel& model, aiMesh* mesh, aiNode* meshNode, Vector<unsigned>& boneMappings, Vector<Vector<unsigned char> >&
+    blendIndices, Vector<Vector<float> >& blendWeights)
 {
     blendIndices.Resize(mesh->mNumVertices);
     blendWeights.Resize(mesh->mNumVertices);
@@ -2404,8 +2404,8 @@ void WriteLargeIndices(unsigned*& dest, aiMesh* mesh, unsigned index, unsigned o
 }
 
 void WriteVertex(float*& dest, aiMesh* mesh, unsigned index, bool isSkinned, BoundingBox& box,
-    const Matrix3x4& vertexTransform, const Matrix3& normalTransform, Vector<PODVector<unsigned char> >& blendIndices,
-    Vector<PODVector<float> >& blendWeights)
+    const Matrix3x4& vertexTransform, const Matrix3& normalTransform, Vector<Vector<unsigned char> >& blendIndices,
+    Vector<Vector<float> >& blendWeights)
 {
     Vector3 vertex = vertexTransform * ToVector3(mesh->mVertices[index]);
     box.Merge(vertex);
@@ -2473,9 +2473,9 @@ void WriteVertex(float*& dest, aiMesh* mesh, unsigned index, bool isSkinned, Bou
     }
 }
 
-PODVector<VertexElement> GetVertexElements(aiMesh* mesh, bool isSkinned)
+Vector<VertexElement> GetVertexElements(aiMesh* mesh, bool isSkinned)
 {
-    PODVector<VertexElement> ret;
+    Vector<VertexElement> ret;
 
     // Position must always be first and of type Vector3 for raycasts to work
     ret.Push(VertexElement(TYPE_VECTOR3, SEM_POSITION));
@@ -2772,7 +2772,7 @@ void ExtrapolatePivotlessAnimation(OutModel* model)
         CreatePivotlessFbxBoneStruct(*model);
 
         // Extrapolate anim
-        const PODVector<aiAnimation *> &animations = model->animations_;
+        const Vector<aiAnimation *> &animations = model->animations_;
         for (unsigned i = 0; i < animations.Size(); ++i)
         {
             aiAnimation* anim = animations[i];

--- a/Source/Tools/BindingGenerator/ASUtils.cpp
+++ b/Source/Tools/BindingGenerator/ASUtils.cpp
@@ -363,7 +363,7 @@ ConvertedVariable CppVariableToAS(const TypeAnalyzer& type, VariableUsage usage,
         throw Exception("Error: type \"" + type.ToString() + "\" can not automatically bind");
     }
 
-    regex_match(cppTypeName, match, regex("PODVector<(\\w+)\\*>"));
+    regex_match(cppTypeName, match, regex("Vector<(\\w+)\\*>"));
     if (!match.empty())
     {
         string cppSubtypeName = match[1].str();
@@ -402,7 +402,7 @@ ConvertedVariable CppVariableToAS(const TypeAnalyzer& type, VariableUsage usage,
         throw Exception("Error: type \"" + type.ToString() + "\" can not automatically bind");
     }
 
-    regex_match(cppTypeName, match, regex("PODVector<(\\w+)>"));
+    regex_match(cppTypeName, match, regex("Vector<(\\w+)>"));
     if (!match.empty())
     {
         string cppSubtypeName = match[1].str();

--- a/Source/Tools/OgreImporter/OgreImporter.cpp
+++ b/Source/Tools/OgreImporter/OgreImporter.cpp
@@ -289,7 +289,7 @@ void LoadMesh(const String& inputFileName, bool generateTangents, bool splitSubM
     unsigned vertexStart = 0;
     unsigned subMeshIndex = 0;
 
-    PODVector<unsigned> vertexStarts;
+    Vector<unsigned> vertexStarts;
     vertexStarts.Resize(numSubMeshes_);
 
     while (subMesh)
@@ -486,7 +486,7 @@ void LoadMesh(const String& inputFileName, bool generateTangents, bool splitSubM
                 {
                     HashMap<unsigned, unsigned> usedBoneMap;
                     unsigned remapIndex = 0;
-                    for (HashMap<unsigned, PODVector<BoneWeightAssignment> >::Iterator i =
+                    for (HashMap<unsigned, Vector<BoneWeightAssignment> >::Iterator i =
                         subGeometryLodLevel.boneWeights_.Begin(); i != subGeometryLodLevel.boneWeights_.End(); ++i)
                     {
                         // Sort the bone assigns by weight
@@ -517,7 +517,7 @@ void LoadMesh(const String& inputFileName, bool generateTangents, bool splitSubM
                     sorted = true;
                 }
 
-                for (HashMap<unsigned, PODVector<BoneWeightAssignment> >::Iterator i = subGeometryLodLevel.boneWeights_.Begin();
+                for (HashMap<unsigned, Vector<BoneWeightAssignment> >::Iterator i = subGeometryLodLevel.boneWeights_.Begin();
                     i != subGeometryLodLevel.boneWeights_.End(); ++i)
                 {
                     // Sort the bone assigns by weight, if not sorted yet in bone remapping pass
@@ -1041,8 +1041,8 @@ void WriteOutput(const String& outputFileName, bool exportAnimations, bool rotat
 
 void OptimizeIndices(ModelSubGeometryLodLevel* subGeom, ModelVertexBuffer* vb, ModelIndexBuffer* ib)
 {
-    PODVector<Triangle> oldTriangles;
-    PODVector<Triangle> newTriangles;
+    Vector<Triangle> oldTriangles;
+    Vector<Triangle> newTriangles;
 
     if (subGeom->indexCount_ % 3)
     {
@@ -1068,7 +1068,7 @@ void OptimizeIndices(ModelSubGeometryLodLevel* subGeom, ModelVertexBuffer* vb, M
     for (unsigned i = 0; i < vb->vertices_.Size(); ++i)
         CalculateScore(vb->vertices_[i]);
 
-    PODVector<unsigned> vertexCache;
+    Vector<unsigned> vertexCache;
 
     while (oldTriangles.Size())
     {

--- a/Source/Tools/OgreImporter/OgreImporterUtils.h
+++ b/Source/Tools/OgreImporter/OgreImporterUtils.h
@@ -111,7 +111,7 @@ struct ModelVertexBuffer
     {
         dest.WriteUInt(vertices_.Size());
 
-        PODVector<VertexElement> elements = VertexBuffer::GetElements(elementMask_);
+        Vector<VertexElement> elements = VertexBuffer::GetElements(elementMask_);
         dest.WriteUInt(elements.Size());
         for (unsigned j = 0; j < elements.Size(); ++j)
         {
@@ -191,7 +191,7 @@ struct ModelMorph
 struct ModelIndexBuffer
 {
     unsigned indexSize_;
-    PODVector<unsigned> indices_;
+    Vector<unsigned> indices_;
 
     ModelIndexBuffer() :
         indexSize_(sizeof(unsigned short))
@@ -221,6 +221,6 @@ struct ModelSubGeometryLodLevel
     unsigned indexBuffer_{};
     unsigned indexStart_{};
     unsigned indexCount_{};
-    HashMap<unsigned, PODVector<BoneWeightAssignment> > boneWeights_;
-    PODVector<unsigned> boneMapping_;
+    HashMap<unsigned, Vector<BoneWeightAssignment> > boneWeights_;
+    Vector<unsigned> boneMapping_;
 };

--- a/Source/Tools/RampGenerator/RampGenerator.cpp
+++ b/Source/Tools/RampGenerator/RampGenerator.cpp
@@ -34,8 +34,8 @@ static const float sigma3Kernel9x9[9 * 9] = {
 int main(int argc, char** argv);
 void Run(const Vector<String>& arguments);
 
-bool ReadIES(File* data, PODVector<float>& vertical, PODVector<float>& horizontal, PODVector<float>& luminance);
-void WriteIES(unsigned char* data, unsigned width, unsigned height, PODVector<float>& horizontal, PODVector<float>& vertical, PODVector<float>& luminance);
+bool ReadIES(File* data, Vector<float>& vertical, Vector<float>& horizontal, Vector<float>& luminance);
+void WriteIES(unsigned char* data, unsigned width, unsigned height, Vector<float>& horizontal, Vector<float>& vertical, Vector<float>& luminance);
 void Blur(unsigned char* data, unsigned width, unsigned height, const float* kernel, unsigned kernelWidth);
 
 int main(int argc, char** argv)
@@ -76,9 +76,9 @@ void Run(const Vector<String>& arguments)
         File file(&context);
         file.Open(inputFile);
 
-        PODVector<float> horizontal;
-        PODVector<float> vertical;
-        PODVector<float> luminance;
+        Vector<float> horizontal;
+        Vector<float> vertical;
+        Vector<float> luminance;
         ReadIES(&file, vertical, horizontal, luminance);
 
         SharedArrayPtr<unsigned char> data(new unsigned char[width * height]);
@@ -157,7 +157,7 @@ void Run(const Vector<String>& arguments)
     }
 }
 
-unsigned GetSample(float position, PODVector<float>& inputs)
+unsigned GetSample(float position, Vector<float>& inputs)
 {
     unsigned pos = 0;
     // Early outs
@@ -216,7 +216,7 @@ int PopFirstInt(Vector<String>& words)
     return -1; // < 0 ever valid?
 }
 
-bool ReadIES(File* data, PODVector<float>& vertical, PODVector<float>& horizontal, PODVector<float>& luminance)
+bool ReadIES(File* data, Vector<float>& vertical, Vector<float>& horizontal, Vector<float>& luminance)
 {
     String line = data->ReadLine();
     if (!line.Contains("IESNA:LM-63-1995") && !line.Contains("IESNA:LM-63-2002"))
@@ -287,7 +287,7 @@ bool ReadIES(File* data, PODVector<float>& vertical, PODVector<float>& horizonta
     return true;
 }
 
-void WriteIES(unsigned char* data, unsigned width, unsigned height, PODVector<float>& horizontal, PODVector<float>& vertical, PODVector<float>& luminance)
+void WriteIES(unsigned char* data, unsigned width, unsigned height, Vector<float>& horizontal, Vector<float>& vertical, Vector<float>& luminance)
 {
     // Find maximum luminance value
     float maximum = -1;

--- a/Source/Urho3D/AngelScript/CoreAPI.cpp
+++ b/Source/Urho3D/AngelScript/CoreAPI.cpp
@@ -133,7 +133,7 @@ static void UnsubscribeFromAllEventsExcept(CScriptArray* exceptions)
         return;
 
     unsigned numExceptions = exceptions->GetSize();
-    PODVector<StringHash> destExceptions(numExceptions);
+    Vector<StringHash> destExceptions(numExceptions);
     for (unsigned i = 0; i < numExceptions; ++i)
         destExceptions[i] = StringHash(*(static_cast<String*>(exceptions->At(i))));
 

--- a/Source/Urho3D/AngelScript/Generated_Classes.cpp
+++ b/Source/Urho3D/AngelScript/Generated_Classes.cpp
@@ -1712,8 +1712,8 @@ static void Polyhedron__Polyhedron_constspFrustumamp(Polyhedron* _ptr, const Fru
 // class Polyhedron | File: ../Math/Polyhedron.h
 static void Register_Polyhedron(asIScriptEngine* engine)
 {
-    // explicit Polyhedron::Polyhedron(const Vector<PODVector<Vector3>>& faces)
-    // Error: type "const Vector<PODVector<Vector3>>&" can not automatically bind
+    // explicit Polyhedron::Polyhedron(const Vector<Vector<Vector3>>& faces)
+    // Error: type "const Vector<Vector<Vector3>>&" can not automatically bind
 
     // Polyhedron::Polyhedron(const Polyhedron& polyhedron)
     engine->RegisterObjectBehaviour("Polyhedron", asBEHAVE_CONSTRUCT, "void f(const Polyhedron&in)", AS_FUNCTION_OBJFIRST(Polyhedron__Polyhedron_constspPolyhedronamp), AS_CALL_CDECL_OBJFIRST);
@@ -2318,6 +2318,13 @@ static void Spline__Spline_InterpolationMode(Spline* _ptr, InterpolationMode mod
     new(_ptr) Spline(mode);
 }
 
+// explicit Spline::Spline(const Vector<Variant>& knots, InterpolationMode mode = BEZIER_CURVE)
+static void Spline__Spline_constspVectorlesVariantgreamp_InterpolationMode(Spline* _ptr, CScriptArray* knots_conv, InterpolationMode mode)
+{
+    Vector<Variant> knots = ArrayToVector<Variant>(knots_conv);
+    new(_ptr) Spline(knots, mode);
+}
+
 // Spline::Spline(const Spline& rhs) = default
 static void Spline__Spline_constspSplineamp(Spline* _ptr, const Spline& rhs)
 {
@@ -2327,11 +2334,10 @@ static void Spline__Spline_constspSplineamp(Spline* _ptr, const Spline& rhs)
 // class Spline | File: ../Core/Spline.h
 static void Register_Spline(asIScriptEngine* engine)
 {
-    // explicit Spline::Spline(const Vector<Variant>& knots, InterpolationMode mode = BEZIER_CURVE)
-    // Error: type "const Vector<Variant>&" can not automatically bind
-
     // explicit Spline::Spline(InterpolationMode mode)
     engine->RegisterObjectBehaviour("Spline", asBEHAVE_CONSTRUCT, "void f(InterpolationMode)", AS_FUNCTION_OBJFIRST(Spline__Spline_InterpolationMode), AS_CALL_CDECL_OBJFIRST);
+    // explicit Spline::Spline(const Vector<Variant>& knots, InterpolationMode mode = BEZIER_CURVE)
+    engine->RegisterObjectBehaviour("Spline", asBEHAVE_CONSTRUCT, "void f(Array<Variant>@+, InterpolationMode = BEZIER_CURVE)", AS_FUNCTION_OBJFIRST(Spline__Spline_constspVectorlesVariantgreamp_InterpolationMode), AS_CALL_CDECL_OBJFIRST);
     // Spline::Spline(const Spline& rhs) = default
     engine->RegisterObjectBehaviour("Spline", asBEHAVE_CONSTRUCT, "void f(const Spline&in)", AS_FUNCTION_OBJFIRST(Spline__Spline_constspSplineamp), AS_CALL_CDECL_OBJFIRST);
 
@@ -2675,8 +2681,8 @@ static void Register_TrailPoint(asIScriptEngine* engine)
 // class UIBatch | File: ../UI/UIBatch.h
 static void Register_UIBatch(asIScriptEngine* engine)
 {
-    // UIBatch::UIBatch(UIElement* element, BlendMode blendMode, const IntRect& scissor, Texture* texture, PODVector<float>* vertexData)
-    // Error: type "PODVector<float>*" can not automatically bind
+    // UIBatch::UIBatch(UIElement* element, BlendMode blendMode, const IntRect& scissor, Texture* texture, Vector<float>* vertexData)
+    // Error: type "Vector<float>*" can not automatically bind
 
     // UIBatch::~UIBatch() | Implicitly-declared
     engine->RegisterObjectBehaviour("UIBatch", asBEHAVE_DESTRUCT, "void f()", AS_DESTRUCTOR(UIBatch), AS_CALL_CDECL_OBJFIRST);
@@ -2909,10 +2915,10 @@ static void Register_Variant(asIScriptEngine* engine)
 {
     // Variant::Variant(VariantType type, const char* value)
     // Error: type "const char*" can not automatically bind
-    // Variant::Variant(const PODVector<unsigned char>& value)
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
     // Variant::Variant(const VariantVector& value)
     // Error: type "const VariantVector&" can not automatically bind
+    // Variant::Variant(const Vector<unsigned char>& value)
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
     // Variant::Variant(const char* type, const char* value)
     // Error: type "const char*" can not automatically bind
     // Variant::Variant(const char* value)
@@ -4835,8 +4841,8 @@ static void Register_VectorBuffer(asIScriptEngine* engine)
 {
     // VectorBuffer::VectorBuffer(const void* data, unsigned size)
     // Error: type "const void*" can not automatically bind
-    // explicit VectorBuffer::VectorBuffer(const PODVector<unsigned char>& data)
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
+    // explicit VectorBuffer::VectorBuffer(const Vector<unsigned char>& data)
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
 
     // VectorBuffer::VectorBuffer(Deserializer& source, unsigned size)
     engine->RegisterObjectBehaviour("VectorBuffer", asBEHAVE_CONSTRUCT, "void f(Deserializer&, uint)", AS_FUNCTION_OBJFIRST(VectorBuffer__VectorBuffer_Deserializeramp_unsigned), AS_CALL_CDECL_OBJFIRST);

--- a/Source/Urho3D/AngelScript/Generated_GlobalFunctions.cpp
+++ b/Source/Urho3D/AngelScript/Generated_GlobalFunctions.cpp
@@ -22,10 +22,10 @@ static CScriptArray* constspVectorlesStringgreamp_ParseArguments_constspStringam
     return VectorToArray<String>(result, "Array<String>");
 }
 
-// bool WriteDrawablesToOBJ(const PODVector<Drawable*>& drawables, File* outputFile, bool asZUp, bool asRightHanded, bool writeLightmapUV = false) | File: ../Graphics/Drawable.h
-static bool bool_WriteDrawablesToOBJ_constspPODVectorlesDrawablestargreamp_Filestar_bool_bool_bool(CScriptArray* drawables_conv, File* outputFile, bool asZUp, bool asRightHanded, bool writeLightmapUV)
+// bool WriteDrawablesToOBJ(const Vector<Drawable*>& drawables, File* outputFile, bool asZUp, bool asRightHanded, bool writeLightmapUV = false) | File: ../Graphics/Drawable.h
+static bool bool_WriteDrawablesToOBJ_constspVectorlesDrawablestargreamp_Filestar_bool_bool_bool(CScriptArray* drawables_conv, File* outputFile, bool asZUp, bool asRightHanded, bool writeLightmapUV)
 {
-    PODVector<Drawable*> drawables = ArrayToVector<Drawable*>(drawables_conv);
+    Vector<Drawable*> drawables = ArrayToVector<Drawable*>(drawables_conv);
     bool result = WriteDrawablesToOBJ(drawables, outputFile, asZUp, asRightHanded, writeLightmapUV);
     return result;
 }
@@ -93,8 +93,8 @@ void ASRegisterGeneratedGlobalFunctions(asIScriptEngine* engine)
     // i32 CountSetBits(u32 value) | File: ../Math/MathDefs.h
     engine->RegisterGlobalFunction("int CountSetBits(uint)", AS_FUNCTIONPR(CountSetBits, (u32), i32), AS_CALL_CDECL);
 
-    // PODVector<unsigned char> DecodeBase64(String encodedString) | File: ../Core/StringUtils.h
-    // Error: type "PODVector<unsigned char>" can not automatically bind
+    // Vector<unsigned char> DecodeBase64(String encodedString) | File: ../Core/StringUtils.h
+    // Error: type "Vector<unsigned char>" can not automatically bind
 
     // unsigned DecompressData(void* dest, const void* src, unsigned destSize) | File: ../IO/Compression.h
     // Error: type "void*" can not automatically bind
@@ -405,11 +405,11 @@ void ASRegisterGeneratedGlobalFunctions(asIScriptEngine* engine)
     // float StableRandom(float seed) | File: ../Math/Vector2.h
     engine->RegisterGlobalFunction("float StableRandom(float)", AS_FUNCTIONPR(StableRandom, (float), float), AS_CALL_CDECL);
 
-    // void StringToBuffer(PODVector<unsigned char>& dest, const String& source) | File: ../Core/StringUtils.h
-    // Error: type "PODVector<unsigned char>&" can not automatically bind
+    // void StringToBuffer(Vector<unsigned char>& dest, const String& source) | File: ../Core/StringUtils.h
+    // Error: type "Vector<unsigned char>&" can not automatically bind
 
-    // void StringToBuffer(PODVector<unsigned char>& dest, const char* source) | File: ../Core/StringUtils.h
-    // Error: type "PODVector<unsigned char>&" can not automatically bind
+    // void StringToBuffer(Vector<unsigned char>& dest, const char* source) | File: ../Core/StringUtils.h
+    // Error: type "Vector<unsigned char>&" can not automatically bind
 
     // template <class T> T Tan(T angle) | File: ../Math/MathDefs.h
     engine->RegisterGlobalFunction("float Tan(float)", AS_FUNCTIONPR(Tan, (float), float), AS_CALL_CDECL);
@@ -645,8 +645,8 @@ void ASRegisterGeneratedGlobalFunctions(asIScriptEngine* engine)
     // IntVector3 VectorRoundToInt(const Vector3& vec) | File: ../Math/Vector3.h
     engine->RegisterGlobalFunction("IntVector3 VectorRoundToInt(const Vector3&in)", AS_FUNCTIONPR(VectorRoundToInt, (const Vector3&), IntVector3), AS_CALL_CDECL);
 
-    // bool WriteDrawablesToOBJ(const PODVector<Drawable*>& drawables, File* outputFile, bool asZUp, bool asRightHanded, bool writeLightmapUV = false) | File: ../Graphics/Drawable.h
-    engine->RegisterGlobalFunction("bool WriteDrawablesToOBJ(Array<Drawable@>@, File@+, bool, bool, bool = false)", AS_FUNCTION(bool_WriteDrawablesToOBJ_constspPODVectorlesDrawablestargreamp_Filestar_bool_bool_bool), AS_CALL_CDECL);
+    // bool WriteDrawablesToOBJ(const Vector<Drawable*>& drawables, File* outputFile, bool asZUp, bool asRightHanded, bool writeLightmapUV = false) | File: ../Graphics/Drawable.h
+    engine->RegisterGlobalFunction("bool WriteDrawablesToOBJ(Array<Drawable@>@, File@+, bool, bool, bool = false)", AS_FUNCTION(bool_WriteDrawablesToOBJ_constspVectorlesDrawablestargreamp_Filestar_bool_bool_bool), AS_CALL_CDECL);
 
 #ifdef URHO3D_IK
     // void RegisterIKLibrary(Context* context) | File: ../IK/IK.h

--- a/Source/Urho3D/AngelScript/Generated_Members.h
+++ b/Source/Urho3D/AngelScript/Generated_Members.h
@@ -385,8 +385,8 @@ template <class T> void RegisterMembers_BatchQueue(asIScriptEngine* engine, cons
 {
     // void BatchQueue::SetInstancingData(void* lockedData, unsigned stride, unsigned& freeIndex)
     // Error: type "void*" can not automatically bind
-    // void BatchQueue::SortFrontToBack2Pass(PODVector<Batch*>& batches)
-    // Error: type "PODVector<Batch*>&" can not automatically bind
+    // void BatchQueue::SortFrontToBack2Pass(Vector<Batch*>& batches)
+    // Error: type "Vector<Batch*>&" can not automatically bind
 
     // void BatchQueue::Clear(int maxSortedInstances)
     engine->RegisterObjectMethod(className, "void Clear(int)", AS_METHODPR(T, Clear, (int), void), AS_CALL_THISCALL);
@@ -414,12 +414,12 @@ template <class T> void RegisterMembers_BatchQueue(asIScriptEngine* engine, cons
     // Error: type "HashMap<unsigned short, unsigned short>" can not automatically bind
     // HashMap<unsigned short, unsigned short> BatchQueue::geometryRemapping_
     // Error: type "HashMap<unsigned short, unsigned short>" can not automatically bind
-    // PODVector<Batch> BatchQueue::batches_
-    // Error: type "PODVector<Batch>" can not automatically bind
-    // PODVector<Batch*> BatchQueue::sortedBatches_
-    // Error: type "PODVector<Batch*>" can not automatically bind
-    // PODVector<BatchGroup*> BatchQueue::sortedBatchGroups_
-    // Error: type "PODVector<BatchGroup*>" can not automatically bind
+    // Vector<Batch> BatchQueue::batches_
+    // Error: type "Vector<Batch>" can not automatically bind
+    // Vector<Batch*> BatchQueue::sortedBatches_
+    // Error: type "Vector<Batch*>" can not automatically bind
+    // Vector<BatchGroup*> BatchQueue::sortedBatchGroups_
+    // Error: type "Vector<BatchGroup*>" can not automatically bind
 
     // unsigned BatchQueue::maxSortedInstances_
     engine->RegisterObjectProperty(className, "uint maxSortedInstances", offsetof(T, maxSortedInstances_));
@@ -1239,10 +1239,10 @@ template <class T> void RegisterMembers_Decal(asIScriptEngine* engine, const cha
     // void Decal::CalculateBoundingBox()
     engine->RegisterObjectMethod(className, "void CalculateBoundingBox()", AS_METHODPR(T, CalculateBoundingBox, (), void), AS_CALL_THISCALL);
 
-    // PODVector<DecalVertex> Decal::vertices_
-    // Error: type "PODVector<DecalVertex>" can not automatically bind
-    // PODVector<unsigned short> Decal::indices_
-    // Error: type "PODVector<unsigned short>" can not automatically bind
+    // Vector<DecalVertex> Decal::vertices_
+    // Error: type "Vector<DecalVertex>" can not automatically bind
+    // Vector<unsigned short> Decal::indices_
+    // Error: type "Vector<unsigned short>" can not automatically bind
 
     // float Decal::timer_
     engine->RegisterObjectProperty(className, "float timer", offsetof(T, timer_));
@@ -1309,8 +1309,8 @@ template <class T> void RegisterMembers_Deserializer(asIScriptEngine* engine, co
 {
     // virtual unsigned Deserializer::Read(void* dest, unsigned size) = 0
     // Error: type "void*" can not automatically bind
-    // PODVector<unsigned char> Deserializer::ReadBuffer()
-    // Error: type "PODVector<unsigned char>" can not automatically bind
+    // Vector<unsigned char> Deserializer::ReadBuffer()
+    // Error: type "Vector<unsigned char>" can not automatically bind
     // VariantVector Deserializer::ReadVariantVector()
     // Error: type "VariantVector" can not automatically bind
 
@@ -2432,14 +2432,14 @@ template <class T> void RegisterMembers_JoystickState(asIScriptEngine* engine, c
     // Not registered because pointer
     // UIElement* JoystickState::screenJoystick_
     // Not registered because pointer
-    // PODVector<bool> JoystickState::buttons_
-    // Error: type "PODVector<bool>" can not automatically bind
-    // PODVector<bool> JoystickState::buttonPress_
-    // Error: type "PODVector<bool>" can not automatically bind
-    // PODVector<float> JoystickState::axes_
-    // Error: type "PODVector<float>" can not automatically bind
-    // PODVector<int> JoystickState::hats_
-    // Error: type "PODVector<int>" can not automatically bind
+    // Vector<bool> JoystickState::buttons_
+    // Error: type "Vector<bool>" can not automatically bind
+    // Vector<bool> JoystickState::buttonPress_
+    // Error: type "Vector<bool>" can not automatically bind
+    // Vector<float> JoystickState::axes_
+    // Error: type "Vector<float>" can not automatically bind
+    // Vector<int> JoystickState::hats_
+    // Error: type "Vector<int>" can not automatically bind
 
     // SDL_JoystickID JoystickState::joystickID_
     engine->RegisterObjectProperty(className, "SDL_JoystickID joystickID", offsetof(T, joystickID_));
@@ -2461,10 +2461,10 @@ template <class T> void RegisterMembers_LightBatchQueue(asIScriptEngine* engine,
     // Not registered because pointer
     // Vector<ShadowBatchQueue> LightBatchQueue::shadowSplits_
     // Error: type "Vector<ShadowBatchQueue>" can not automatically bind
-    // PODVector<Light*> LightBatchQueue::vertexLights_
-    // Error: type "PODVector<Light*>" can not automatically bind
-    // PODVector<Batch> LightBatchQueue::volumeBatches_
-    // Error: type "PODVector<Batch>" can not automatically bind
+    // Vector<Light*> LightBatchQueue::vertexLights_
+    // Error: type "Vector<Light*>" can not automatically bind
+    // Vector<Batch> LightBatchQueue::volumeBatches_
+    // Error: type "Vector<Batch>" can not automatically bind
 
     // bool LightBatchQueue::negative_
     engine->RegisterObjectProperty(className, "bool negative", offsetof(T, negative_));
@@ -2485,10 +2485,10 @@ template <class T> void RegisterMembers_LightQueryResult(asIScriptEngine* engine
 {
     // Light* LightQueryResult::light_
     // Not registered because pointer
-    // PODVector<Drawable*> LightQueryResult::litGeometries_
-    // Error: type "PODVector<Drawable*>" can not automatically bind
-    // PODVector<Drawable*> LightQueryResult::shadowCasters_
-    // Error: type "PODVector<Drawable*>" can not automatically bind
+    // Vector<Drawable*> LightQueryResult::litGeometries_
+    // Error: type "Vector<Drawable*>" can not automatically bind
+    // Vector<Drawable*> LightQueryResult::shadowCasters_
+    // Error: type "Vector<Drawable*>" can not automatically bind
     // Camera* LightQueryResult::shadowCameras_[MAX_LIGHT_SPLITS]
     // Not registered because array
     // unsigned LightQueryResult::shadowCasterBegin_[MAX_LIGHT_SPLITS]
@@ -3144,8 +3144,8 @@ template <class T> void RegisterMembers_NetworkState(asIScriptEngine* engine, co
     // Error: type "Vector<Variant>" can not automatically bind
     // Vector<Variant> NetworkState::previousValues_
     // Error: type "Vector<Variant>" can not automatically bind
-    // PODVector<ReplicationState*> NetworkState::replicationStates_
-    // Error: type "PODVector<ReplicationState*>" can not automatically bind
+    // Vector<ReplicationState*> NetworkState::replicationStates_
+    // Error: type "Vector<ReplicationState*>" can not automatically bind
 
     // VariantMap NetworkState::previousVars_
     engine->RegisterObjectProperty(className, "VariantMap previousVars", offsetof(T, previousVars_));
@@ -3161,8 +3161,8 @@ template <class T> void RegisterMembers_NetworkState(asIScriptEngine* engine, co
 // struct NodeImpl | File: ../Scene/Node.h
 template <class T> void RegisterMembers_NodeImpl(asIScriptEngine* engine, const char* className)
 {
-    // PODVector<Node*> NodeImpl::dependencyNodes_
-    // Error: type "PODVector<Node*>" can not automatically bind
+    // Vector<Node*> NodeImpl::dependencyNodes_
+    // Error: type "Vector<Node*>" can not automatically bind
     // Connection* NodeImpl::owner_
     // Not registered because pointer
     // StringVector NodeImpl::tags_
@@ -3288,8 +3288,8 @@ template <class T> void RegisterMembers_OctreeQuery(asIScriptEngine* engine, con
     // OctreeQuery& OctreeQuery::operator =(const OctreeQuery& rhs) = delete
     // Not registered because deleted
 
-    // PODVector<Drawable*>& OctreeQuery::result_
-    // Error: type "PODVector<Drawable*>&" can not automatically bind
+    // Vector<Drawable*>& OctreeQuery::result_
+    // Error: type "Vector<Drawable*>&" can not automatically bind
 
     // unsigned char OctreeQuery::drawableFlags_
     engine->RegisterObjectProperty(className, "uint8 drawableFlags", offsetof(T, drawableFlags_));
@@ -3370,10 +3370,10 @@ template <class T> void RegisterMembers_Particle(asIScriptEngine* engine, const 
 // struct PerThreadSceneResult | File: ../Graphics/View.h
 template <class T> void RegisterMembers_PerThreadSceneResult(asIScriptEngine* engine, const char* className)
 {
-    // PODVector<Drawable*> PerThreadSceneResult::geometries_
-    // Error: type "PODVector<Drawable*>" can not automatically bind
-    // PODVector<Light*> PerThreadSceneResult::lights_
-    // Error: type "PODVector<Light*>" can not automatically bind
+    // Vector<Drawable*> PerThreadSceneResult::geometries_
+    // Error: type "Vector<Drawable*>" can not automatically bind
+    // Vector<Light*> PerThreadSceneResult::lights_
+    // Error: type "Vector<Light*>" can not automatically bind
 
     // float PerThreadSceneResult::minZ_
     engine->RegisterObjectProperty(className, "float minZ", offsetof(T, minZ_));
@@ -3452,10 +3452,10 @@ template <class T> void RegisterMembers_Plane(asIScriptEngine* engine, const cha
     #endif
 }
 
-// void Polyhedron::AddFace(const PODVector<Vector3>& face)
-template <class T> void Polyhedron_void_AddFace_constspPODVectorlesVector3greamp_template(T* _ptr, CScriptArray* face_conv)
+// void Polyhedron::AddFace(const Vector<Vector3>& face)
+template <class T> void Polyhedron_void_AddFace_constspVectorlesVector3greamp_template(T* _ptr, CScriptArray* face_conv)
 {
-    PODVector<Vector3> face = ArrayToVector<Vector3>(face_conv);
+    Vector<Vector3> face = ArrayToVector<Vector3>(face_conv);
     _ptr->AddFace(face);
 }
 
@@ -3468,8 +3468,8 @@ template <class T> void RegisterMembers_Polyhedron(asIScriptEngine* engine, cons
     // void Polyhedron::AddFace(const Vector3& v0, const Vector3& v1, const Vector3& v2, const Vector3& v3)
     engine->RegisterObjectMethod(className, "void AddFace(const Vector3&in, const Vector3&in, const Vector3&in, const Vector3&in)", AS_METHODPR(T, AddFace, (const Vector3&, const Vector3&, const Vector3&, const Vector3&), void), AS_CALL_THISCALL);
 
-    // void Polyhedron::AddFace(const PODVector<Vector3>& face)
-    engine->RegisterObjectMethod(className, "void AddFace(Array<Vector3>@+)", AS_FUNCTION_OBJFIRST(Polyhedron_void_AddFace_constspPODVectorlesVector3greamp_template<Polyhedron>), AS_CALL_CDECL_OBJFIRST);
+    // void Polyhedron::AddFace(const Vector<Vector3>& face)
+    engine->RegisterObjectMethod(className, "void AddFace(Array<Vector3>@+)", AS_FUNCTION_OBJFIRST(Polyhedron_void_AddFace_constspVectorlesVector3greamp_template<Polyhedron>), AS_CALL_CDECL_OBJFIRST);
 
     // void Polyhedron::Clear()
     engine->RegisterObjectMethod(className, "void Clear()", AS_METHODPR(T, Clear, (), void), AS_CALL_THISCALL);
@@ -3507,8 +3507,8 @@ template <class T> void RegisterMembers_Polyhedron(asIScriptEngine* engine, cons
     // Polyhedron Polyhedron::Transformed(const Matrix3x4& transform) const
     engine->RegisterObjectMethod(className, "Polyhedron Transformed(const Matrix3x4&in) const", AS_METHODPR(T, Transformed, (const Matrix3x4&) const, Polyhedron), AS_CALL_THISCALL);
 
-    // Vector<PODVector<Vector3>> Polyhedron::faces_
-    // Error: type "Vector<PODVector<Vector3>>" can not automatically bind
+    // Vector<Vector<Vector3>> Polyhedron::faces_
+    // Error: type "Vector<Vector<Vector3>>" can not automatically bind
 
     #ifdef REGISTER_MEMBERS_MANUAL_PART_Polyhedron
         REGISTER_MEMBERS_MANUAL_PART_Polyhedron();
@@ -3537,8 +3537,8 @@ template <class T> void RegisterMembers_ProfilerBlock(asIScriptEngine* engine, c
     // Not registered because pointer
     // ProfilerBlock* ProfilerBlock::parent_
     // Not registered because pointer
-    // PODVector<ProfilerBlock*> ProfilerBlock::children_
-    // Error: type "PODVector<ProfilerBlock*>" can not automatically bind
+    // Vector<ProfilerBlock*> ProfilerBlock::children_
+    // Error: type "Vector<ProfilerBlock*>" can not automatically bind
 
     // HiresTimer ProfilerBlock::timer_
     engine->RegisterObjectProperty(className, "HiresTimer timer", offsetof(T, timer_));
@@ -3790,8 +3790,8 @@ template <class T> void RegisterMembers_RayOctreeQuery(asIScriptEngine* engine, 
     // RayOctreeQuery& RayOctreeQuery::operator =(const RayOctreeQuery& rhs) = delete
     // Not registered because deleted
 
-    // PODVector<RayQueryResult>& RayOctreeQuery::result_
-    // Error: type "PODVector<RayQueryResult>&" can not automatically bind
+    // Vector<RayQueryResult>& RayOctreeQuery::result_
+    // Error: type "Vector<RayQueryResult>&" can not automatically bind
 
     // Ray RayOctreeQuery::ray_
     engine->RegisterObjectProperty(className, "Ray ray", offsetof(T, ray_));
@@ -4385,8 +4385,8 @@ template <class T> void RegisterMembers_Serializer(asIScriptEngine* engine, cons
 {
     // virtual unsigned Serializer::Write(const void* data, unsigned size) = 0
     // Error: type "const void*" can not automatically bind
-    // bool Serializer::WriteBuffer(const PODVector<unsigned char>& value)
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
+    // bool Serializer::WriteBuffer(const Vector<unsigned char>& value)
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
     // bool Serializer::WriteVariantVector(const VariantVector& value)
     // Error: type "const VariantVector&" can not automatically bind
 
@@ -4580,7 +4580,7 @@ template <class T> void RegisterMembers_Skeleton(asIScriptEngine* engine, const 
     // Bone* Skeleton::GetBone(const char* name)
     // Error: type "const char*" can not automatically bind
     // const Vector<Bone>& Skeleton::GetBones() const
-    // Error: type "const Vector<Bone>&" can not automatically bind
+    // Not registered because have @nobind mark
     // Vector<Bone>& Skeleton::GetModifiableBones()
     // Error: type "Vector<Bone>&" can not automatically bind
 
@@ -4756,6 +4756,13 @@ template <class T> void RegisterMembers_Sphere(asIScriptEngine* engine, const ch
     #endif
 }
 
+// void Spline::SetKnots(const Vector<Variant>& knots)
+template <class T> void Spline_void_SetKnots_constspVectorlesVariantgreamp_template(T* _ptr, CScriptArray* knots_conv)
+{
+    Vector<Variant> knots = ArrayToVector<Variant>(knots_conv);
+    _ptr->SetKnots(knots);
+}
+
 // class Spline | File: ../Core/Spline.h
 template <class T> void RegisterMembers_Spline(asIScriptEngine* engine, const char* className)
 {
@@ -4763,8 +4770,6 @@ template <class T> void RegisterMembers_Spline(asIScriptEngine* engine, const ch
     // Error: type "const VariantVector&" can not automatically bind
     // bool Spline::operator !=(const Spline& rhs) const
     // Only operator == is needed
-    // void Spline::SetKnots(const Vector<Variant>& knots)
-    // Error: type "const Vector<Variant>&" can not automatically bind
 
     // void Spline::AddKnot(const Variant& knot)
     engine->RegisterObjectMethod(className, "void AddKnot(const Variant&in)", AS_METHODPR(T, AddKnot, (const Variant&), void), AS_CALL_THISCALL);
@@ -4804,6 +4809,9 @@ template <class T> void RegisterMembers_Spline(asIScriptEngine* engine, const ch
 
     // void Spline::SetKnot(const Variant& knot, unsigned index)
     engine->RegisterObjectMethod(className, "void SetKnot(const Variant&in, uint)", AS_METHODPR(T, SetKnot, (const Variant&, unsigned), void), AS_CALL_THISCALL);
+
+    // void Spline::SetKnots(const Vector<Variant>& knots)
+    engine->RegisterObjectMethod(className, "void SetKnots(Array<Variant>@+)", AS_FUNCTION_OBJFIRST(Spline_void_SetKnots_constspVectorlesVariantgreamp_template<Spline>), AS_CALL_CDECL_OBJFIRST);
 
     #ifdef REGISTER_MEMBERS_MANUAL_PART_Spline
         REGISTER_MEMBERS_MANUAL_PART_Spline();
@@ -5448,14 +5456,14 @@ template <class T> void RegisterMembers_UIBatch(asIScriptEngine* engine, const c
     // void UIBatch::SetDefaultColor()
     engine->RegisterObjectMethod(className, "void SetDefaultColor()", AS_METHODPR(T, SetDefaultColor, (), void), AS_CALL_THISCALL);
 
-    // static void UIBatch::AddOrMerge(const UIBatch& batch, PODVector<UIBatch>& batches)
-    // Error: type "PODVector<UIBatch>&" can not automatically bind
+    // static void UIBatch::AddOrMerge(const UIBatch& batch, Vector<UIBatch>& batches)
+    // Error: type "Vector<UIBatch>&" can not automatically bind
 
     // UIElement* UIBatch::element_
     // Not registered because pointer
     // Texture* UIBatch::texture_
     // Not registered because pointer
-    // PODVector<float>* UIBatch::vertexData_
+    // Vector<float>* UIBatch::vertexData_
     // Not registered because pointer
     // Material* UIBatch::customMaterial_
     // Not registered because pointer
@@ -5550,10 +5558,10 @@ template <class T> void RegisterMembers_Variant(asIScriptEngine* engine, const c
     // Error: type "const char*" can not automatically bind
     // void Variant::FromString(VariantType type, const char* value)
     // Error: type "const char*" can not automatically bind
-    // const PODVector<unsigned char>& Variant::GetBuffer() const
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
-    // PODVector<unsigned char>* Variant::GetBufferPtr()
-    // Error: type "PODVector<unsigned char>*" can not automatically bind
+    // const Vector<unsigned char>& Variant::GetBuffer() const
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
+    // Vector<unsigned char>* Variant::GetBufferPtr()
+    // Error: type "Vector<unsigned char>*" can not automatically bind
     // CustomVariantValue* Variant::GetCustomVariantValuePtr()
     // Error: type "CustomVariantValue" can not automatically bind bacause have @nobind mark
     // const CustomVariantValue* Variant::GetCustomVariantValuePtr() const
@@ -5594,8 +5602,8 @@ template <class T> void RegisterMembers_Variant(asIScriptEngine* engine, const c
     // Only operator == is needed
     // bool Variant::operator !=(const String& rhs) const
     // Only operator == is needed
-    // bool Variant::operator !=(const PODVector<unsigned char>& rhs) const
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
+    // bool Variant::operator !=(const Vector<unsigned char>& rhs) const
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
     // bool Variant::operator !=(const VectorBuffer& rhs) const
     // Only operator == is needed
     // bool Variant::operator !=(void* rhs) const
@@ -5630,14 +5638,14 @@ template <class T> void RegisterMembers_Variant(asIScriptEngine* engine, const c
     // Only operator == is needed
     // Variant& Variant::operator =(const char* rhs)
     // Error: type "const char*" can not automatically bind
-    // Variant& Variant::operator =(const PODVector<unsigned char>& rhs)
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
+    // Variant& Variant::operator =(const Vector<unsigned char>& rhs)
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
     // Variant& Variant::operator =(void* rhs)
     // Error: type "void*" can not automatically bind
     // Variant& Variant::operator =(const VariantVector& rhs)
     // Error: type "const VariantVector&" can not automatically bind
-    // bool Variant::operator ==(const PODVector<unsigned char>& rhs) const
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
+    // bool Variant::operator ==(const Vector<unsigned char>& rhs) const
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
     // bool Variant::operator ==(void* rhs) const
     // Error: type "void*" can not automatically bind
     // bool Variant::operator ==(const VariantVector& rhs) const
@@ -5965,7 +5973,7 @@ template <class T> void RegisterMembers_Variant(asIScriptEngine* engine, const c
     // Not registered because template
     // template <> const IntVector3& Variant::Get() const
     // Not registered because template
-    // template <> const PODVector<unsigned char>& Variant::Get() const
+    // template <> const Vector<unsigned char>& Variant::Get() const
     // Not registered because template
     // template <> void* Variant::Get() const
     // Not registered because template
@@ -6007,7 +6015,7 @@ template <class T> void RegisterMembers_Variant(asIScriptEngine* engine, const c
     // Not registered because template
     // template <> IntVector3 Variant::Get() const
     // Not registered because template
-    // template <> PODVector<unsigned char> Variant::Get() const
+    // template <> Vector<unsigned char> Variant::Get() const
     // Not registered because template
     // template <> Matrix3 Variant::Get() const
     // Not registered because template
@@ -6034,8 +6042,8 @@ template <class T> void RegisterMembers_Variant(asIScriptEngine* engine, const c
     // static VariantType Variant::GetTypeFromName(const String& typeName)
     engine->SetDefaultNamespace(className);engine->RegisterGlobalFunction("VariantType GetTypeFromName(const String&in)", AS_FUNCTIONPR(T::GetTypeFromName, (const String&), VariantType), AS_CALL_CDECL);engine->SetDefaultNamespace("");
 
-    // static const PODVector<unsigned char> Variant::emptyBuffer
-    // Error: type "const PODVector<unsigned char>" can not automatically bind
+    // static const Vector<unsigned char> Variant::emptyBuffer
+    // Error: type "const Vector<unsigned char>" can not automatically bind
     // static const VariantVector Variant::emptyVariantVector
     // Error: type "const VariantVector" can not automatically bind
     // static const StringVector Variant::emptyStringVector
@@ -6484,8 +6492,8 @@ template <class T> void RegisterMembers_VectorBase(asIScriptEngine* engine, cons
 // struct VertexBufferDesc | File: ../Graphics/Model.h
 template <class T> void RegisterMembers_VertexBufferDesc(asIScriptEngine* engine, const char* className)
 {
-    // PODVector<VertexElement> VertexBufferDesc::vertexElements_
-    // Error: type "PODVector<VertexElement>" can not automatically bind
+    // Vector<VertexElement> VertexBufferDesc::vertexElements_
+    // Error: type "Vector<VertexElement>" can not automatically bind
     // SharedArrayPtr<unsigned char> VertexBufferDesc::data_
     // Error: type "SharedArrayPtr<unsigned char>" can not automatically bind
 
@@ -6629,8 +6637,8 @@ template <class T> void RegisterMembers_XMLElement(asIScriptEngine* engine, cons
     // Error: type "const char*" can not automatically bind
     // String XMLElement::GetAttributeUpper(const char* name) const
     // Error: type "const char*" can not automatically bind
-    // PODVector<unsigned char> XMLElement::GetBuffer(const String& name) const
-    // Error: type "PODVector<unsigned char>" can not automatically bind
+    // Vector<unsigned char> XMLElement::GetBuffer(const String& name) const
+    // Error: type "Vector<unsigned char>" can not automatically bind
     // bool XMLElement::GetBuffer(const String& name, void* dest, unsigned size) const
     // Error: type "void*" can not automatically bind
     // XMLElement XMLElement::GetChild(const char* name) const
@@ -6667,8 +6675,8 @@ template <class T> void RegisterMembers_XMLElement(asIScriptEngine* engine, cons
     // Error: type "const char*" can not automatically bind
     // bool XMLElement::SetBuffer(const String& name, const void* data, unsigned size)
     // Error: type "const void*" can not automatically bind
-    // bool XMLElement::SetBuffer(const String& name, const PODVector<unsigned char>& value)
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
+    // bool XMLElement::SetBuffer(const String& name, const Vector<unsigned char>& value)
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
     // bool XMLElement::SetValue(const char* value)
     // Error: type "const char*" can not automatically bind
     // bool XMLElement::SetVariantVector(const VariantVector& value)
@@ -7093,28 +7101,28 @@ template <class T> void RegisterMembers_NavAreaStub(asIScriptEngine* engine, con
 // struct NavBuildData | File: ../Navigation/NavBuildData.h
 template <class T> void RegisterMembers_NavBuildData(asIScriptEngine* engine, const char* className)
 {
-    // PODVector<Vector3> NavBuildData::vertices_
-    // Error: type "PODVector<Vector3>" can not automatically bind
-    // PODVector<int> NavBuildData::indices_
-    // Error: type "PODVector<int>" can not automatically bind
-    // PODVector<Vector3> NavBuildData::offMeshVertices_
-    // Error: type "PODVector<Vector3>" can not automatically bind
-    // PODVector<float> NavBuildData::offMeshRadii_
-    // Error: type "PODVector<float>" can not automatically bind
-    // PODVector<unsigned short> NavBuildData::offMeshFlags_
-    // Error: type "PODVector<unsigned short>" can not automatically bind
-    // PODVector<unsigned char> NavBuildData::offMeshAreas_
-    // Error: type "PODVector<unsigned char>" can not automatically bind
-    // PODVector<unsigned char> NavBuildData::offMeshDir_
-    // Error: type "PODVector<unsigned char>" can not automatically bind
+    // Vector<Vector3> NavBuildData::vertices_
+    // Error: type "Vector<Vector3>" can not automatically bind
+    // Vector<int> NavBuildData::indices_
+    // Error: type "Vector<int>" can not automatically bind
+    // Vector<Vector3> NavBuildData::offMeshVertices_
+    // Error: type "Vector<Vector3>" can not automatically bind
+    // Vector<float> NavBuildData::offMeshRadii_
+    // Error: type "Vector<float>" can not automatically bind
+    // Vector<unsigned short> NavBuildData::offMeshFlags_
+    // Error: type "Vector<unsigned short>" can not automatically bind
+    // Vector<unsigned char> NavBuildData::offMeshAreas_
+    // Error: type "Vector<unsigned char>" can not automatically bind
+    // Vector<unsigned char> NavBuildData::offMeshDir_
+    // Error: type "Vector<unsigned char>" can not automatically bind
     // rcContext* NavBuildData::ctx_
     // Not registered because pointer
     // rcHeightfield* NavBuildData::heightField_
     // Not registered because pointer
     // rcCompactHeightfield* NavBuildData::compactHeightField_
     // Not registered because pointer
-    // PODVector<NavAreaStub> NavBuildData::navAreas_
-    // Error: type "PODVector<NavAreaStub>" can not automatically bind
+    // Vector<NavAreaStub> NavBuildData::navAreas_
+    // Error: type "Vector<NavAreaStub>" can not automatically bind
 
     // BoundingBox NavBuildData::worldBoundingBox_
     engine->RegisterObjectProperty(className, "BoundingBox worldBoundingBox", offsetof(T, worldBoundingBox_));
@@ -7489,10 +7497,10 @@ template <class T> void RegisterMembers_ViewBatchInfo2D(asIScriptEngine* engine,
 {
     // SharedPtr<VertexBuffer> ViewBatchInfo2D::vertexBuffer_
     // Error: type "SharedPtr<VertexBuffer>" can not automatically bind
-    // PODVector<const SourceBatch2D*> ViewBatchInfo2D::sourceBatches_
-    // Error: type "PODVector<const SourceBatch2D*>" can not automatically bind
-    // PODVector<float> ViewBatchInfo2D::distances_
-    // Error: type "PODVector<float>" can not automatically bind
+    // Vector<const SourceBatch2D*> ViewBatchInfo2D::sourceBatches_
+    // Error: type "Vector<const SourceBatch2D*>" can not automatically bind
+    // Vector<float> ViewBatchInfo2D::distances_
+    // Error: type "Vector<float>" can not automatically bind
     // Vector<SharedPtr<Material>> ViewBatchInfo2D::materials_
     // Error: type "Vector<SharedPtr<Material>>" can not automatically bind
     // Vector<SharedPtr<Geometry>> ViewBatchInfo2D::geometries_
@@ -7710,8 +7718,8 @@ template <class T> void RegisterMembers_BatchGroup(asIScriptEngine* engine, cons
     // void BatchGroup::AddTransforms(const Batch& batch)
     engine->RegisterObjectMethod(className, "void AddTransforms(const Batch&in)", AS_METHODPR(T, AddTransforms, (const Batch&), void), AS_CALL_THISCALL);
 
-    // PODVector<InstanceData> BatchGroup::instances_
-    // Error: type "PODVector<InstanceData>" can not automatically bind
+    // Vector<InstanceData> BatchGroup::instances_
+    // Error: type "Vector<InstanceData>" can not automatically bind
 
     // unsigned BatchGroup::startIndex_
     engine->RegisterObjectProperty(className, "uint startIndex", offsetof(T, startIndex_));
@@ -7933,8 +7941,8 @@ template <class T> void RegisterMembers_EventReceiverGroup(asIScriptEngine* engi
     // void EventReceiverGroup::Remove(Object* object)
     engine->RegisterObjectMethod(className, "void Remove(Object@+)", AS_METHODPR(T, Remove, (Object*), void), AS_CALL_THISCALL);
 
-    // PODVector<Object*> EventReceiverGroup::receivers_
-    // Error: type "PODVector<Object*>" can not automatically bind
+    // Vector<Object*> EventReceiverGroup::receivers_
+    // Error: type "Vector<Object*>" can not automatically bind
 
     #ifdef REGISTER_MEMBERS_MANUAL_PART_EventReceiverGroup
         REGISTER_MEMBERS_MANUAL_PART_EventReceiverGroup();
@@ -8022,10 +8030,10 @@ template <class T> void RegisterMembers_NodeReplicationState(asIScriptEngine* en
     #endif
 }
 
-// void Object::UnsubscribeFromAllEventsExcept(const PODVector<StringHash>& exceptions, bool onlyUserData)
-template <class T> void Object_void_UnsubscribeFromAllEventsExcept_constspPODVectorlesStringHashgreamp_bool_template(T* _ptr, CScriptArray* exceptions_conv, bool onlyUserData)
+// void Object::UnsubscribeFromAllEventsExcept(const Vector<StringHash>& exceptions, bool onlyUserData)
+template <class T> void Object_void_UnsubscribeFromAllEventsExcept_constspVectorlesStringHashgreamp_bool_template(T* _ptr, CScriptArray* exceptions_conv, bool onlyUserData)
 {
-    PODVector<StringHash> exceptions = ArrayToVector<StringHash>(exceptions_conv);
+    Vector<StringHash> exceptions = ArrayToVector<StringHash>(exceptions_conv);
     _ptr->UnsubscribeFromAllEventsExcept(exceptions, onlyUserData);
 }
 
@@ -8114,8 +8122,8 @@ template <class T> void RegisterMembers_Object(asIScriptEngine* engine, const ch
     // void Object::UnsubscribeFromAllEvents()
     engine->RegisterObjectMethod(className, "void UnsubscribeFromAllEvents()", AS_METHODPR(T, UnsubscribeFromAllEvents, (), void), AS_CALL_THISCALL);
 
-    // void Object::UnsubscribeFromAllEventsExcept(const PODVector<StringHash>& exceptions, bool onlyUserData)
-    engine->RegisterObjectMethod(className, "void UnsubscribeFromAllEventsExcept(Array<StringHash>@+, bool)", AS_FUNCTION_OBJFIRST(Object_void_UnsubscribeFromAllEventsExcept_constspPODVectorlesStringHashgreamp_bool_template<Object>), AS_CALL_CDECL_OBJFIRST);
+    // void Object::UnsubscribeFromAllEventsExcept(const Vector<StringHash>& exceptions, bool onlyUserData)
+    engine->RegisterObjectMethod(className, "void UnsubscribeFromAllEventsExcept(Array<StringHash>@+, bool)", AS_FUNCTION_OBJFIRST(Object_void_UnsubscribeFromAllEventsExcept_constspVectorlesStringHashgreamp_bool_template<Object>), AS_CALL_CDECL_OBJFIRST);
 
     // void Object::UnsubscribeFromEvent(StringHash eventType)
     engine->RegisterObjectMethod(className, "void UnsubscribeFromEvent(StringHash)", AS_METHODPR(T, UnsubscribeFromEvent, (StringHash), void), AS_CALL_THISCALL);
@@ -8604,8 +8612,8 @@ template <class T> void RegisterMembers_ShaderVariation(asIScriptEngine* engine,
     RegisterMembers_RefCounted<T>(engine, className);
     RegisterMembers_GPUObject<T>(engine, className);
 
-    // const PODVector<unsigned char>& ShaderVariation::GetByteCode() const
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
+    // const Vector<unsigned char>& ShaderVariation::GetByteCode() const
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
     // const unsigned* ShaderVariation::GetConstantBufferSizes() const
     // Error: type "const unsigned*" can not automatically bind
     // const HashMap<StringHash, ShaderParameter>& ShaderVariation::GetParameters() const
@@ -9040,10 +9048,10 @@ template <class T> void RegisterMembers_AttributeAnimationInfo(asIScriptEngine* 
     #endif
 }
 
-// const PODVector<SoundSource*>& Audio::GetSoundSources() const
-template <class T> CScriptArray* Audio_constspPODVectorlesSoundSourcestargreamp_GetSoundSources_void_template(T* _ptr)
+// const Vector<SoundSource*>& Audio::GetSoundSources() const
+template <class T> CScriptArray* Audio_constspVectorlesSoundSourcestargreamp_GetSoundSources_void_template(T* _ptr)
 {
-    const PODVector<SoundSource*>& result = _ptr->GetSoundSources();
+    const Vector<SoundSource*>& result = _ptr->GetSoundSources();
     return VectorToHandleArray(result, "Array<SoundSource@>");
 }
 
@@ -9084,8 +9092,8 @@ template <class T> void RegisterMembers_Audio(asIScriptEngine* engine, const cha
     // float Audio::GetSoundSourceMasterGain(StringHash typeHash) const
     engine->RegisterObjectMethod(className, "float GetSoundSourceMasterGain(StringHash) const", AS_METHODPR(T, GetSoundSourceMasterGain, (StringHash) const, float), AS_CALL_THISCALL);
 
-    // const PODVector<SoundSource*>& Audio::GetSoundSources() const
-    engine->RegisterObjectMethod(className, "Array<SoundSource@>@ GetSoundSources() const", AS_FUNCTION_OBJFIRST(Audio_constspPODVectorlesSoundSourcestargreamp_GetSoundSources_void_template<Audio>), AS_CALL_CDECL_OBJFIRST);
+    // const Vector<SoundSource*>& Audio::GetSoundSources() const
+    engine->RegisterObjectMethod(className, "Array<SoundSource@>@ GetSoundSources() const", AS_FUNCTION_OBJFIRST(Audio_constspVectorlesSoundSourcestargreamp_GetSoundSources_void_template<Audio>), AS_CALL_CDECL_OBJFIRST);
 
     // bool Audio::HasMasterGain(const String& type) const
     engine->RegisterObjectMethod(className, "bool HasMasterGain(const String&in) const", AS_METHODPR(T, HasMasterGain, (const String&) const, bool), AS_CALL_THISCALL);
@@ -9864,13 +9872,13 @@ template <class T> void RegisterMembers_Geometry(asIScriptEngine* engine, const 
 
     // float Geometry::GetHitDistance(const Ray& ray, Vector3* outNormal = nullptr, Vector2* outUV = nullptr) const
     // Error: type "Vector3*" can not automatically bind
-    // void Geometry::GetRawData(const unsigned char*& vertexData, unsigned& vertexSize, const unsigned char*& indexData, unsigned& indexSize, const PODVector<VertexElement>*& elements) const
+    // void Geometry::GetRawData(const unsigned char*& vertexData, unsigned& vertexSize, const unsigned char*& indexData, unsigned& indexSize, const Vector<VertexElement>*& elements) const
     // Error: type "const unsigned char*&" can not automatically bind
-    // void Geometry::GetRawDataShared(SharedArrayPtr<unsigned char>& vertexData, unsigned& vertexSize, SharedArrayPtr<unsigned char>& indexData, unsigned& indexSize, const PODVector<VertexElement>*& elements) const
+    // void Geometry::GetRawDataShared(SharedArrayPtr<unsigned char>& vertexData, unsigned& vertexSize, SharedArrayPtr<unsigned char>& indexData, unsigned& indexSize, const Vector<VertexElement>*& elements) const
     // Error: type "SharedArrayPtr<unsigned char>&" can not automatically bind
     // void Geometry::SetRawIndexData(const SharedArrayPtr<unsigned char>& data, unsigned indexSize)
     // Error: type "const SharedArrayPtr<unsigned char>&" can not automatically bind
-    // void Geometry::SetRawVertexData(const SharedArrayPtr<unsigned char>& data, const PODVector<VertexElement>& elements)
+    // void Geometry::SetRawVertexData(const SharedArrayPtr<unsigned char>& data, const Vector<VertexElement>& elements)
     // Error: type "const SharedArrayPtr<unsigned char>&" can not automatically bind
     // void Geometry::SetRawVertexData(const SharedArrayPtr<unsigned char>& data, unsigned elementMask)
     // Error: type "const SharedArrayPtr<unsigned char>&" can not automatically bind
@@ -9953,17 +9961,17 @@ template <class T> void RegisterMembers_Geometry(asIScriptEngine* engine, const 
     #endif
 }
 
-// PODVector<int> Graphics::GetMultiSampleLevels() const
-template <class T> CScriptArray* Graphics_PODVectorlesintgre_GetMultiSampleLevels_void_template(T* _ptr)
+// Vector<int> Graphics::GetMultiSampleLevels() const
+template <class T> CScriptArray* Graphics_Vectorlesintgre_GetMultiSampleLevels_void_template(T* _ptr)
 {
-    PODVector<int> result = _ptr->GetMultiSampleLevels();
+    Vector<int> result = _ptr->GetMultiSampleLevels();
     return VectorToArray(result, "Array<int>");
 }
 
-// PODVector<IntVector3> Graphics::GetResolutions(int monitor) const
-template <class T> CScriptArray* Graphics_PODVectorlesIntVector3gre_GetResolutions_int_template(T* _ptr, int monitor)
+// Vector<IntVector3> Graphics::GetResolutions(int monitor) const
+template <class T> CScriptArray* Graphics_VectorlesIntVector3gre_GetResolutions_int_template(T* _ptr, int monitor)
 {
-    PODVector<IntVector3> result = _ptr->GetResolutions(monitor);
+    Vector<IntVector3> result = _ptr->GetResolutions(monitor);
     return VectorToArray(result, "Array<IntVector3>");
 }
 
@@ -10002,7 +10010,7 @@ template <class T> void RegisterMembers_Graphics(asIScriptEngine* engine, const 
     // Error: type "void*" can not automatically bind
     // void Graphics::SetShaderParameter(StringHash param, const float* data, unsigned count)
     // Error: type "const float*" can not automatically bind
-    // bool Graphics::SetVertexBuffers(const PODVector<VertexBuffer*>& buffers, unsigned instanceOffset = 0)
+    // bool Graphics::SetVertexBuffers(const Vector<VertexBuffer*>& buffers, unsigned instanceOffset = 0)
     // Not registered because have @nobind mark
 
     // void Graphics::BeginDumpShaders(const String& fileName)
@@ -10180,9 +10188,9 @@ template <class T> void RegisterMembers_Graphics(asIScriptEngine* engine, const 
     engine->RegisterObjectMethod(className, "int GetMultiSample() const", AS_METHODPR(T, GetMultiSample, () const, int), AS_CALL_THISCALL);
     engine->RegisterObjectMethod(className, "int get_multiSample() const", AS_METHODPR(T, GetMultiSample, () const, int), AS_CALL_THISCALL);
 
-    // PODVector<int> Graphics::GetMultiSampleLevels() const
-    engine->RegisterObjectMethod(className, "Array<int>@ GetMultiSampleLevels() const", AS_FUNCTION_OBJFIRST(Graphics_PODVectorlesintgre_GetMultiSampleLevels_void_template<Graphics>), AS_CALL_CDECL_OBJFIRST);
-    engine->RegisterObjectMethod(className, "Array<int>@ get_multiSampleLevels() const", AS_FUNCTION_OBJFIRST(Graphics_PODVectorlesintgre_GetMultiSampleLevels_void_template<Graphics>), AS_CALL_CDECL_OBJFIRST);
+    // Vector<int> Graphics::GetMultiSampleLevels() const
+    engine->RegisterObjectMethod(className, "Array<int>@ GetMultiSampleLevels() const", AS_FUNCTION_OBJFIRST(Graphics_Vectorlesintgre_GetMultiSampleLevels_void_template<Graphics>), AS_CALL_CDECL_OBJFIRST);
+    engine->RegisterObjectMethod(className, "Array<int>@ get_multiSampleLevels() const", AS_FUNCTION_OBJFIRST(Graphics_Vectorlesintgre_GetMultiSampleLevels_void_template<Graphics>), AS_CALL_CDECL_OBJFIRST);
 
     // unsigned Graphics::GetNumBatches() const
     engine->RegisterObjectMethod(className, "uint GetNumBatches() const", AS_METHODPR(T, GetNumBatches, () const, unsigned), AS_CALL_THISCALL);
@@ -10216,9 +10224,9 @@ template <class T> void RegisterMembers_Graphics(asIScriptEngine* engine, const 
     engine->RegisterObjectMethod(className, "bool GetResizable() const", AS_METHODPR(T, GetResizable, () const, bool), AS_CALL_THISCALL);
     engine->RegisterObjectMethod(className, "bool get_resizable() const", AS_METHODPR(T, GetResizable, () const, bool), AS_CALL_THISCALL);
 
-    // PODVector<IntVector3> Graphics::GetResolutions(int monitor) const
-    engine->RegisterObjectMethod(className, "Array<IntVector3>@ GetResolutions(int) const", AS_FUNCTION_OBJFIRST(Graphics_PODVectorlesIntVector3gre_GetResolutions_int_template<Graphics>), AS_CALL_CDECL_OBJFIRST);
-    engine->RegisterObjectMethod(className, "Array<IntVector3>@ get_resolutions(int) const", AS_FUNCTION_OBJFIRST(Graphics_PODVectorlesIntVector3gre_GetResolutions_int_template<Graphics>), AS_CALL_CDECL_OBJFIRST);
+    // Vector<IntVector3> Graphics::GetResolutions(int monitor) const
+    engine->RegisterObjectMethod(className, "Array<IntVector3>@ GetResolutions(int) const", AS_FUNCTION_OBJFIRST(Graphics_VectorlesIntVector3gre_GetResolutions_int_template<Graphics>), AS_CALL_CDECL_OBJFIRST);
+    engine->RegisterObjectMethod(className, "Array<IntVector3>@ get_resolutions(int) const", AS_FUNCTION_OBJFIRST(Graphics_VectorlesIntVector3gre_GetResolutions_int_template<Graphics>), AS_CALL_CDECL_OBJFIRST);
 
     // const IntRect& Graphics::GetScissorRect() const
     engine->RegisterObjectMethod(className, "const IntRect& GetScissorRect() const", AS_METHODPR(T, GetScissorRect, () const, const IntRect&), AS_CALL_THISCALL);
@@ -11713,8 +11721,8 @@ template <class T> void RegisterMembers_ResourceCache(asIScriptEngine* engine, c
     // Error: type "const HashMap<StringHash, ResourceGroup>&" can not automatically bind
     // ResourceRouter* ResourceCache::GetResourceRouter(unsigned index) const
     // Error: type "ResourceRouter" can not automatically bind bacause have @nobind mark
-    // void ResourceCache::GetResources(PODVector<Resource*>& result, StringHash type) const
-    // Error: type "PODVector<Resource*>&" can not automatically bind
+    // void ResourceCache::GetResources(Vector<Resource*>& result, StringHash type) const
+    // Error: type "Vector<Resource*>&" can not automatically bind
     // void ResourceCache::RemoveResourceRouter(ResourceRouter* router)
     // Error: type "ResourceRouter" can not automatically bind bacause have @nobind mark
 
@@ -11865,7 +11873,7 @@ template <class T> void RegisterMembers_ResourceCache(asIScriptEngine* engine, c
     // Not registered because template
     // template <class T> T* ResourceCache::GetResource(const String& name, bool sendEventOnFailure = true)
     // Not registered because template
-    // template <class T> void ResourceCache::GetResources(PODVector<T*>& result) const
+    // template <class T> void ResourceCache::GetResources(Vector<T*>& result) const
     // Not registered because template
     // template <class T> SharedPtr<T> ResourceCache::GetTempResource(const String& name, bool sendEventOnFailure = true)
     // Not registered because template
@@ -12108,7 +12116,7 @@ template <class T> void RegisterMembers_UI(asIScriptEngine* engine, const char* 
     RegisterMembers_Object<T>(engine, className);
 
     // const Vector<UIElement*> UI::GetDragElements()
-    // Error: type "const Vector<UIElement*>" can not automatically bind
+    // Not registered because have @nobind mark
 
     // void UI::Clear()
     engine->RegisterObjectMethod(className, "void Clear()", AS_METHODPR(T, Clear, (), void), AS_CALL_THISCALL);
@@ -12353,14 +12361,14 @@ template <class T> void RegisterMembers_VectorBuffer(asIScriptEngine* engine, co
 {
     RegisterMembers_AbstractFile<T>(engine, className);
 
-    // const PODVector<unsigned char>& VectorBuffer::GetBuffer() const
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
+    // const Vector<unsigned char>& VectorBuffer::GetBuffer() const
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
     // const unsigned char* VectorBuffer::GetData() const
     // Error: type "const unsigned char*" can not automatically bind
     // unsigned char* VectorBuffer::GetModifiableData()
     // Error: type "unsigned char*" can not automatically bind
-    // void VectorBuffer::SetData(const PODVector<unsigned char>& data)
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
+    // void VectorBuffer::SetData(const Vector<unsigned char>& data)
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
     // void VectorBuffer::SetData(const void* data, unsigned size)
     // Error: type "const void*" can not automatically bind
 
@@ -12378,48 +12386,48 @@ template <class T> void RegisterMembers_VectorBuffer(asIScriptEngine* engine, co
     #endif
 }
 
-// const PODVector<VertexElement>& VertexBuffer::GetElements() const
-template <class T> CScriptArray* VertexBuffer_constspPODVectorlesVertexElementgreamp_GetElements_void_template(T* _ptr)
+// const Vector<VertexElement>& VertexBuffer::GetElements() const
+template <class T> CScriptArray* VertexBuffer_constspVectorlesVertexElementgreamp_GetElements_void_template(T* _ptr)
 {
-    const PODVector<VertexElement>& result = _ptr->GetElements();
+    const Vector<VertexElement>& result = _ptr->GetElements();
     return VectorToArray(result, "Array<VertexElement>");
 }
 
-// bool VertexBuffer::SetSize(unsigned vertexCount, const PODVector<VertexElement>& elements, bool dynamic = false)
-template <class T> bool VertexBuffer_bool_SetSize_unsigned_constspPODVectorlesVertexElementgreamp_bool_template(T* _ptr, unsigned vertexCount, CScriptArray* elements_conv, bool dynamic)
+// bool VertexBuffer::SetSize(unsigned vertexCount, const Vector<VertexElement>& elements, bool dynamic = false)
+template <class T> bool VertexBuffer_bool_SetSize_unsigned_constspVectorlesVertexElementgreamp_bool_template(T* _ptr, unsigned vertexCount, CScriptArray* elements_conv, bool dynamic)
 {
-    PODVector<VertexElement> elements = ArrayToVector<VertexElement>(elements_conv);
+    Vector<VertexElement> elements = ArrayToVector<VertexElement>(elements_conv);
     bool result = _ptr->SetSize(vertexCount, elements, dynamic);
     return result;
 }
 
-// static bool VertexBuffer::HasElement(const PODVector<VertexElement>& elements, VertexElementType type, VertexElementSemantic semantic, unsigned char index = 0)
-template <class T> bool VertexBuffer_bool_HasElement_constspPODVectorlesVertexElementgreamp_VertexElementType_VertexElementSemantic_unsignedspchar(CScriptArray* elements_conv, VertexElementType type, VertexElementSemantic semantic, unsigned char index)
+// static bool VertexBuffer::HasElement(const Vector<VertexElement>& elements, VertexElementType type, VertexElementSemantic semantic, unsigned char index = 0)
+template <class T> bool VertexBuffer_bool_HasElement_constspVectorlesVertexElementgreamp_VertexElementType_VertexElementSemantic_unsignedspchar(CScriptArray* elements_conv, VertexElementType type, VertexElementSemantic semantic, unsigned char index)
 {
-    PODVector<VertexElement> elements = ArrayToVector<VertexElement>(elements_conv);
+    Vector<VertexElement> elements = ArrayToVector<VertexElement>(elements_conv);
     bool result = T::HasElement(elements, type, semantic, index);
     return result;
 }
 
-// static unsigned VertexBuffer::GetElementOffset(const PODVector<VertexElement>& elements, VertexElementType type, VertexElementSemantic semantic, unsigned char index = 0)
-template <class T> unsigned VertexBuffer_unsigned_GetElementOffset_constspPODVectorlesVertexElementgreamp_VertexElementType_VertexElementSemantic_unsignedspchar(CScriptArray* elements_conv, VertexElementType type, VertexElementSemantic semantic, unsigned char index)
+// static unsigned VertexBuffer::GetElementOffset(const Vector<VertexElement>& elements, VertexElementType type, VertexElementSemantic semantic, unsigned char index = 0)
+template <class T> unsigned VertexBuffer_unsigned_GetElementOffset_constspVectorlesVertexElementgreamp_VertexElementType_VertexElementSemantic_unsignedspchar(CScriptArray* elements_conv, VertexElementType type, VertexElementSemantic semantic, unsigned char index)
 {
-    PODVector<VertexElement> elements = ArrayToVector<VertexElement>(elements_conv);
+    Vector<VertexElement> elements = ArrayToVector<VertexElement>(elements_conv);
     unsigned result = T::GetElementOffset(elements, type, semantic, index);
     return result;
 }
 
-// static PODVector<VertexElement> VertexBuffer::GetElements(unsigned elementMask)
-template <class T> CScriptArray* VertexBuffer_PODVectorlesVertexElementgre_GetElements_unsigned(unsigned elementMask)
+// static Vector<VertexElement> VertexBuffer::GetElements(unsigned elementMask)
+template <class T> CScriptArray* VertexBuffer_VectorlesVertexElementgre_GetElements_unsigned(unsigned elementMask)
 {
-    PODVector<VertexElement> result = T::GetElements(elementMask);
+    Vector<VertexElement> result = T::GetElements(elementMask);
     return VectorToArray(result, "Array<VertexElement>");
 }
 
-// static unsigned VertexBuffer::GetVertexSize(const PODVector<VertexElement>& elements)
-template <class T> unsigned VertexBuffer_unsigned_GetVertexSize_constspPODVectorlesVertexElementgreamp(CScriptArray* elements_conv)
+// static unsigned VertexBuffer::GetVertexSize(const Vector<VertexElement>& elements)
+template <class T> unsigned VertexBuffer_unsigned_GetVertexSize_constspVectorlesVertexElementgreamp(CScriptArray* elements_conv)
 {
-    PODVector<VertexElement> elements = ArrayToVector<VertexElement>(elements_conv);
+    Vector<VertexElement> elements = ArrayToVector<VertexElement>(elements_conv);
     unsigned result = T::GetVertexSize(elements);
     return result;
 }
@@ -12458,9 +12466,9 @@ template <class T> void RegisterMembers_VertexBuffer(asIScriptEngine* engine, co
     // unsigned VertexBuffer::GetElementOffset(VertexElementType type, VertexElementSemantic semantic, unsigned char index = 0) const
     engine->RegisterObjectMethod(className, "uint GetElementOffset(VertexElementType, VertexElementSemantic, uint8 = 0) const", AS_METHODPR(T, GetElementOffset, (VertexElementType, VertexElementSemantic, unsigned char) const, unsigned), AS_CALL_THISCALL);
 
-    // const PODVector<VertexElement>& VertexBuffer::GetElements() const
-    engine->RegisterObjectMethod(className, "Array<VertexElement>@ GetElements() const", AS_FUNCTION_OBJFIRST(VertexBuffer_constspPODVectorlesVertexElementgreamp_GetElements_void_template<VertexBuffer>), AS_CALL_CDECL_OBJFIRST);
-    engine->RegisterObjectMethod(className, "Array<VertexElement>@ get_elements() const", AS_FUNCTION_OBJFIRST(VertexBuffer_constspPODVectorlesVertexElementgreamp_GetElements_void_template<VertexBuffer>), AS_CALL_CDECL_OBJFIRST);
+    // const Vector<VertexElement>& VertexBuffer::GetElements() const
+    engine->RegisterObjectMethod(className, "Array<VertexElement>@ GetElements() const", AS_FUNCTION_OBJFIRST(VertexBuffer_constspVectorlesVertexElementgreamp_GetElements_void_template<VertexBuffer>), AS_CALL_CDECL_OBJFIRST);
+    engine->RegisterObjectMethod(className, "Array<VertexElement>@ get_elements() const", AS_FUNCTION_OBJFIRST(VertexBuffer_constspVectorlesVertexElementgreamp_GetElements_void_template<VertexBuffer>), AS_CALL_CDECL_OBJFIRST);
 
     // unsigned VertexBuffer::GetVertexCount() const
     engine->RegisterObjectMethod(className, "uint GetVertexCount() const", AS_METHODPR(T, GetVertexCount, () const, unsigned), AS_CALL_THISCALL);
@@ -12491,8 +12499,8 @@ template <class T> void RegisterMembers_VertexBuffer(asIScriptEngine* engine, co
     engine->RegisterObjectMethod(className, "void SetShadowed(bool)", AS_METHODPR(T, SetShadowed, (bool), void), AS_CALL_THISCALL);
     engine->RegisterObjectMethod(className, "void set_shadowed(bool)", AS_METHODPR(T, SetShadowed, (bool), void), AS_CALL_THISCALL);
 
-    // bool VertexBuffer::SetSize(unsigned vertexCount, const PODVector<VertexElement>& elements, bool dynamic = false)
-    engine->RegisterObjectMethod(className, "bool SetSize(uint, Array<VertexElement>@+, bool = false)", AS_FUNCTION_OBJFIRST(VertexBuffer_bool_SetSize_unsigned_constspPODVectorlesVertexElementgreamp_bool_template<VertexBuffer>), AS_CALL_CDECL_OBJFIRST);
+    // bool VertexBuffer::SetSize(unsigned vertexCount, const Vector<VertexElement>& elements, bool dynamic = false)
+    engine->RegisterObjectMethod(className, "bool SetSize(uint, Array<VertexElement>@+, bool = false)", AS_FUNCTION_OBJFIRST(VertexBuffer_bool_SetSize_unsigned_constspVectorlesVertexElementgreamp_bool_template<VertexBuffer>), AS_CALL_CDECL_OBJFIRST);
 
     // bool VertexBuffer::SetSize(unsigned vertexCount, unsigned elementMask, bool dynamic = false)
     engine->RegisterObjectMethod(className, "bool SetSize(uint, uint, bool = false)", AS_METHODPR(T, SetSize, (unsigned, unsigned, bool), bool), AS_CALL_THISCALL);
@@ -12500,22 +12508,22 @@ template <class T> void RegisterMembers_VertexBuffer(asIScriptEngine* engine, co
     // void VertexBuffer::Unlock()
     engine->RegisterObjectMethod(className, "void Unlock()", AS_METHODPR(T, Unlock, (), void), AS_CALL_THISCALL);
 
-    // static const VertexElement* VertexBuffer::GetElement(const PODVector<VertexElement>& elements, VertexElementType type, VertexElementSemantic semantic, unsigned char index = 0)
+    // static const VertexElement* VertexBuffer::GetElement(const Vector<VertexElement>& elements, VertexElementType type, VertexElementSemantic semantic, unsigned char index = 0)
     // Error: type "const VertexElement*" can not automatically bind
-    // static void VertexBuffer::UpdateOffsets(PODVector<VertexElement>& elements)
-    // Error: type "PODVector<VertexElement>&" can not automatically bind
+    // static void VertexBuffer::UpdateOffsets(Vector<VertexElement>& elements)
+    // Error: type "Vector<VertexElement>&" can not automatically bind
 
-    // static bool VertexBuffer::HasElement(const PODVector<VertexElement>& elements, VertexElementType type, VertexElementSemantic semantic, unsigned char index = 0)
-    engine->SetDefaultNamespace(className);engine->RegisterGlobalFunction("bool HasElement(Array<VertexElement>@+, VertexElementType, VertexElementSemantic, uint8 = 0)", AS_FUNCTION(VertexBuffer_bool_HasElement_constspPODVectorlesVertexElementgreamp_VertexElementType_VertexElementSemantic_unsignedspchar<VertexBuffer>), AS_CALL_CDECL);engine->SetDefaultNamespace("");
+    // static bool VertexBuffer::HasElement(const Vector<VertexElement>& elements, VertexElementType type, VertexElementSemantic semantic, unsigned char index = 0)
+    engine->SetDefaultNamespace(className);engine->RegisterGlobalFunction("bool HasElement(Array<VertexElement>@+, VertexElementType, VertexElementSemantic, uint8 = 0)", AS_FUNCTION(VertexBuffer_bool_HasElement_constspVectorlesVertexElementgreamp_VertexElementType_VertexElementSemantic_unsignedspchar<VertexBuffer>), AS_CALL_CDECL);engine->SetDefaultNamespace("");
 
-    // static unsigned VertexBuffer::GetElementOffset(const PODVector<VertexElement>& elements, VertexElementType type, VertexElementSemantic semantic, unsigned char index = 0)
-    engine->SetDefaultNamespace(className);engine->RegisterGlobalFunction("uint GetElementOffset(Array<VertexElement>@+, VertexElementType, VertexElementSemantic, uint8 = 0)", AS_FUNCTION(VertexBuffer_unsigned_GetElementOffset_constspPODVectorlesVertexElementgreamp_VertexElementType_VertexElementSemantic_unsignedspchar<VertexBuffer>), AS_CALL_CDECL);engine->SetDefaultNamespace("");
+    // static unsigned VertexBuffer::GetElementOffset(const Vector<VertexElement>& elements, VertexElementType type, VertexElementSemantic semantic, unsigned char index = 0)
+    engine->SetDefaultNamespace(className);engine->RegisterGlobalFunction("uint GetElementOffset(Array<VertexElement>@+, VertexElementType, VertexElementSemantic, uint8 = 0)", AS_FUNCTION(VertexBuffer_unsigned_GetElementOffset_constspVectorlesVertexElementgreamp_VertexElementType_VertexElementSemantic_unsignedspchar<VertexBuffer>), AS_CALL_CDECL);engine->SetDefaultNamespace("");
 
-    // static PODVector<VertexElement> VertexBuffer::GetElements(unsigned elementMask)
-    engine->SetDefaultNamespace(className);engine->RegisterGlobalFunction("Array<VertexElement>@ GetElements(uint)", AS_FUNCTION(VertexBuffer_PODVectorlesVertexElementgre_GetElements_unsigned<VertexBuffer>), AS_CALL_CDECL);engine->SetDefaultNamespace("");
+    // static Vector<VertexElement> VertexBuffer::GetElements(unsigned elementMask)
+    engine->SetDefaultNamespace(className);engine->RegisterGlobalFunction("Array<VertexElement>@ GetElements(uint)", AS_FUNCTION(VertexBuffer_VectorlesVertexElementgre_GetElements_unsigned<VertexBuffer>), AS_CALL_CDECL);engine->SetDefaultNamespace("");
 
-    // static unsigned VertexBuffer::GetVertexSize(const PODVector<VertexElement>& elements)
-    engine->SetDefaultNamespace(className);engine->RegisterGlobalFunction("uint GetVertexSize(Array<VertexElement>@+)", AS_FUNCTION(VertexBuffer_unsigned_GetVertexSize_constspPODVectorlesVertexElementgreamp<VertexBuffer>), AS_CALL_CDECL);engine->SetDefaultNamespace("");
+    // static unsigned VertexBuffer::GetVertexSize(const Vector<VertexElement>& elements)
+    engine->SetDefaultNamespace(className);engine->RegisterGlobalFunction("uint GetVertexSize(Array<VertexElement>@+)", AS_FUNCTION(VertexBuffer_unsigned_GetVertexSize_constspVectorlesVertexElementgreamp<VertexBuffer>), AS_CALL_CDECL);engine->SetDefaultNamespace("");
 
     // static unsigned VertexBuffer::GetVertexSize(unsigned elementMask)
     engine->SetDefaultNamespace(className);engine->RegisterGlobalFunction("uint GetVertexSize(uint)", AS_FUNCTIONPR(T::GetVertexSize, (unsigned), unsigned), AS_CALL_CDECL);engine->SetDefaultNamespace("");
@@ -12525,24 +12533,31 @@ template <class T> void RegisterMembers_VertexBuffer(asIScriptEngine* engine, co
     #endif
 }
 
-// const PODVector<Drawable*>& View::GetGeometries() const
-template <class T> CScriptArray* View_constspPODVectorlesDrawablestargreamp_GetGeometries_void_template(T* _ptr)
+// const Vector<Drawable*>& View::GetGeometries() const
+template <class T> CScriptArray* View_constspVectorlesDrawablestargreamp_GetGeometries_void_template(T* _ptr)
 {
-    const PODVector<Drawable*>& result = _ptr->GetGeometries();
+    const Vector<Drawable*>& result = _ptr->GetGeometries();
     return VectorToHandleArray(result, "Array<Drawable@>");
 }
 
-// const PODVector<Light*>& View::GetLights() const
-template <class T> CScriptArray* View_constspPODVectorlesLightstargreamp_GetLights_void_template(T* _ptr)
+// const Vector<LightBatchQueue>& View::GetLightQueues() const
+template <class T> CScriptArray* View_constspVectorlesLightBatchQueuegreamp_GetLightQueues_void_template(T* _ptr)
 {
-    const PODVector<Light*>& result = _ptr->GetLights();
+    const Vector<LightBatchQueue>& result = _ptr->GetLightQueues();
+    return VectorToArray(result, "Array<LightBatchQueue>");
+}
+
+// const Vector<Light*>& View::GetLights() const
+template <class T> CScriptArray* View_constspVectorlesLightstargreamp_GetLights_void_template(T* _ptr)
+{
+    const Vector<Light*>& result = _ptr->GetLights();
     return VectorToHandleArray(result, "Array<Light@>");
 }
 
-// const PODVector<Drawable*>& View::GetOccluders() const
-template <class T> CScriptArray* View_constspPODVectorlesDrawablestargreamp_GetOccluders_void_template(T* _ptr)
+// const Vector<Drawable*>& View::GetOccluders() const
+template <class T> CScriptArray* View_constspVectorlesDrawablestargreamp_GetOccluders_void_template(T* _ptr)
 {
-    const PODVector<Drawable*>& result = _ptr->GetOccluders();
+    const Vector<Drawable*>& result = _ptr->GetOccluders();
     return VectorToHandleArray(result, "Array<Drawable@>");
 }
 
@@ -12550,9 +12565,6 @@ template <class T> CScriptArray* View_constspPODVectorlesDrawablestargreamp_GetO
 template <class T> void RegisterMembers_View(asIScriptEngine* engine, const char* className)
 {
     RegisterMembers_Object<T>(engine, className);
-
-    // const Vector<LightBatchQueue>& View::GetLightQueues() const
-    // Error: type "const Vector<LightBatchQueue>&" can not automatically bind
 
     // bool View::Define(RenderSurface* renderTarget, Viewport* viewport)
     engine->RegisterObjectMethod(className, "bool Define(RenderSurface@+, Viewport@+)", AS_METHODPR(T, Define, (RenderSurface*, Viewport*), bool), AS_CALL_THISCALL);
@@ -12575,20 +12587,23 @@ template <class T> void RegisterMembers_View(asIScriptEngine* engine, const char
     // const FrameInfo& View::GetFrameInfo() const
     engine->RegisterObjectMethod(className, "const FrameInfo& GetFrameInfo() const", AS_METHODPR(T, GetFrameInfo, () const, const FrameInfo&), AS_CALL_THISCALL);
 
-    // const PODVector<Drawable*>& View::GetGeometries() const
-    engine->RegisterObjectMethod(className, "Array<Drawable@>@ GetGeometries() const", AS_FUNCTION_OBJFIRST(View_constspPODVectorlesDrawablestargreamp_GetGeometries_void_template<View>), AS_CALL_CDECL_OBJFIRST);
+    // const Vector<Drawable*>& View::GetGeometries() const
+    engine->RegisterObjectMethod(className, "Array<Drawable@>@ GetGeometries() const", AS_FUNCTION_OBJFIRST(View_constspVectorlesDrawablestargreamp_GetGeometries_void_template<View>), AS_CALL_CDECL_OBJFIRST);
 
     // Graphics* View::GetGraphics() const
     engine->RegisterObjectMethod(className, "Graphics@+ GetGraphics() const", AS_METHODPR(T, GetGraphics, () const, Graphics*), AS_CALL_THISCALL);
 
-    // const PODVector<Light*>& View::GetLights() const
-    engine->RegisterObjectMethod(className, "Array<Light@>@ GetLights() const", AS_FUNCTION_OBJFIRST(View_constspPODVectorlesLightstargreamp_GetLights_void_template<View>), AS_CALL_CDECL_OBJFIRST);
+    // const Vector<LightBatchQueue>& View::GetLightQueues() const
+    engine->RegisterObjectMethod(className, "Array<LightBatchQueue>@ GetLightQueues() const", AS_FUNCTION_OBJFIRST(View_constspVectorlesLightBatchQueuegreamp_GetLightQueues_void_template<View>), AS_CALL_CDECL_OBJFIRST);
+
+    // const Vector<Light*>& View::GetLights() const
+    engine->RegisterObjectMethod(className, "Array<Light@>@ GetLights() const", AS_FUNCTION_OBJFIRST(View_constspVectorlesLightstargreamp_GetLights_void_template<View>), AS_CALL_CDECL_OBJFIRST);
 
     // unsigned View::GetNumActiveOccluders() const
     engine->RegisterObjectMethod(className, "uint GetNumActiveOccluders() const", AS_METHODPR(T, GetNumActiveOccluders, () const, unsigned), AS_CALL_THISCALL);
 
-    // const PODVector<Drawable*>& View::GetOccluders() const
-    engine->RegisterObjectMethod(className, "Array<Drawable@>@ GetOccluders() const", AS_FUNCTION_OBJFIRST(View_constspPODVectorlesDrawablestargreamp_GetOccluders_void_template<View>), AS_CALL_CDECL_OBJFIRST);
+    // const Vector<Drawable*>& View::GetOccluders() const
+    engine->RegisterObjectMethod(className, "Array<Drawable@>@ GetOccluders() const", AS_FUNCTION_OBJFIRST(View_constspVectorlesDrawablestargreamp_GetOccluders_void_template<View>), AS_CALL_CDECL_OBJFIRST);
 
     // OcclusionBuffer* View::GetOcclusionBuffer() const
     engine->RegisterObjectMethod(className, "OcclusionBuffer@+ GetOcclusionBuffer() const", AS_METHODPR(T, GetOcclusionBuffer, () const, OcclusionBuffer*), AS_CALL_THISCALL);
@@ -13148,10 +13163,10 @@ template <class T> void RegisterMembers_Network(asIScriptEngine* engine, const c
 
 #ifdef URHO3D_PHYSICS
 
-// void ConvexData::BuildHull(const PODVector<Vector3>& vertices)
-template <class T> void ConvexData_void_BuildHull_constspPODVectorlesVector3greamp_template(T* _ptr, CScriptArray* vertices_conv)
+// void ConvexData::BuildHull(const Vector<Vector3>& vertices)
+template <class T> void ConvexData_void_BuildHull_constspVectorlesVector3greamp_template(T* _ptr, CScriptArray* vertices_conv)
 {
-    PODVector<Vector3> vertices = ArrayToVector<Vector3>(vertices_conv);
+    Vector<Vector3> vertices = ArrayToVector<Vector3>(vertices_conv);
     _ptr->BuildHull(vertices);
 }
 
@@ -13160,8 +13175,8 @@ template <class T> void RegisterMembers_ConvexData(asIScriptEngine* engine, cons
 {
     RegisterMembers_CollisionGeometryData<T>(engine, className);
 
-    // void ConvexData::BuildHull(const PODVector<Vector3>& vertices)
-    engine->RegisterObjectMethod(className, "void BuildHull(Array<Vector3>@+)", AS_FUNCTION_OBJFIRST(ConvexData_void_BuildHull_constspPODVectorlesVector3greamp_template<ConvexData>), AS_CALL_CDECL_OBJFIRST);
+    // void ConvexData::BuildHull(const Vector<Vector3>& vertices)
+    engine->RegisterObjectMethod(className, "void BuildHull(Array<Vector3>@+)", AS_FUNCTION_OBJFIRST(ConvexData_void_BuildHull_constspVectorlesVector3greamp_template<ConvexData>), AS_CALL_CDECL_OBJFIRST);
 
     // SharedArrayPtr<Vector3> ConvexData::vertexData_
     // Error: type "SharedArrayPtr<Vector3>" can not automatically bind
@@ -13470,10 +13485,10 @@ template <class T> void RegisterMembers_Image(asIScriptEngine* engine, const cha
 
     // unsigned char* Image::GetData() const
     // Error: type "unsigned char*" can not automatically bind
-    // void Image::GetLevels(PODVector<Image*>& levels)
-    // Error: type "PODVector<Image*>&" can not automatically bind
-    // void Image::GetLevels(PODVector<const Image*>& levels) const
-    // Error: type "PODVector<const Image*>&" can not automatically bind
+    // void Image::GetLevels(Vector<Image*>& levels)
+    // Error: type "Vector<Image*>&" can not automatically bind
+    // void Image::GetLevels(Vector<const Image*>& levels) const
+    // Error: type "Vector<const Image*>&" can not automatically bind
     // SDL_Surface* Image::GetSDLSurface(const IntRect& rect = IntRect::ZERO) const
     // Error: type "SDL_Surface*" can not automatically bind
     // void Image::SetData(const unsigned char* pixelData)
@@ -13666,6 +13681,13 @@ template <class T> Material* Material_SharedPtrlesMaterialgre_Clone_constspStrin
     return result.Detach();
 }
 
+// const Vector<TechniqueEntry>& Material::GetTechniques() const
+template <class T> CScriptArray* Material_constspVectorlesTechniqueEntrygreamp_GetTechniques_void_template(T* _ptr)
+{
+    const Vector<TechniqueEntry>& result = _ptr->GetTechniques();
+    return VectorToArray(result, "Array<TechniqueEntry>");
+}
+
 // class Material | File: ../Graphics/Material.h
 template <class T> void RegisterMembers_Material(asIScriptEngine* engine, const char* className)
 {
@@ -13673,8 +13695,6 @@ template <class T> void RegisterMembers_Material(asIScriptEngine* engine, const 
 
     // const HashMap<StringHash, MaterialShaderParameter>& Material::GetShaderParameters() const
     // Error: type "const HashMap<StringHash, MaterialShaderParameter>&" can not automatically bind
-    // const Vector<TechniqueEntry>& Material::GetTechniques() const
-    // Error: type "const Vector<TechniqueEntry>&" can not automatically bind
     // const HashMap<TextureUnit, SharedPtr<Texture>>& Material::GetTextures() const
     // Error: type "const HashMap<TextureUnit, SharedPtr<Texture>>&" can not automatically bind
 
@@ -13756,6 +13776,9 @@ template <class T> void RegisterMembers_Material(asIScriptEngine* engine, const 
 
     // const TechniqueEntry& Material::GetTechniqueEntry(unsigned index) const
     engine->RegisterObjectMethod(className, "const TechniqueEntry& GetTechniqueEntry(uint) const", AS_METHODPR(T, GetTechniqueEntry, (unsigned) const, const TechniqueEntry&), AS_CALL_THISCALL);
+
+    // const Vector<TechniqueEntry>& Material::GetTechniques() const
+    engine->RegisterObjectMethod(className, "Array<TechniqueEntry>@ GetTechniques() const", AS_FUNCTION_OBJFIRST(Material_constspVectorlesTechniqueEntrygreamp_GetTechniques_void_template<Material>), AS_CALL_CDECL_OBJFIRST);
 
     // Texture* Material::GetTexture(TextureUnit unit) const
     engine->RegisterObjectMethod(className, "Texture@+ GetTexture(TextureUnit) const", AS_METHODPR(T, GetTexture, (TextureUnit) const, Texture*), AS_CALL_THISCALL);
@@ -13942,13 +13965,13 @@ template <class T> void RegisterMembers_ParticleEffect(asIScriptEngine* engine, 
     RegisterMembers_Resource<T>(engine, className);
 
     // const Vector<ColorFrame>& ParticleEffect::GetColorFrames() const
-    // Error: type "const Vector<ColorFrame>&" can not automatically bind
+    // Not registered because have @nobind mark
     // const Vector<TextureFrame>& ParticleEffect::GetTextureFrames() const
-    // Error: type "const Vector<TextureFrame>&" can not automatically bind
+    // Not registered because have @nobind mark
     // void ParticleEffect::SetColorFrames(const Vector<ColorFrame>& colorFrames)
-    // Error: type "const Vector<ColorFrame>&" can not automatically bind
+    // Not registered because have @nobind mark
     // void ParticleEffect::SetTextureFrames(const Vector<TextureFrame>& textureFrames)
-    // Error: type "const Vector<TextureFrame>&" can not automatically bind
+    // Not registered because have @nobind mark
 
     // void ParticleEffect::AddColorFrame(const ColorFrame& colorFrame)
     engine->RegisterObjectMethod(className, "void AddColorFrame(const ColorFrame&in)", AS_METHODPR(T, AddColorFrame, (const ColorFrame&), void), AS_CALL_THISCALL);
@@ -14352,10 +14375,10 @@ template <class T> Technique* Technique_SharedPtrlesTechniquegre_CloneWithDefine
     return result.Detach();
 }
 
-// PODVector<Pass*> Technique::GetPasses() const
-template <class T> CScriptArray* Technique_PODVectorlesPassstargre_GetPasses_void_template(T* _ptr)
+// Vector<Pass*> Technique::GetPasses() const
+template <class T> CScriptArray* Technique_VectorlesPassstargre_GetPasses_void_template(T* _ptr)
 {
-    PODVector<Pass*> result = _ptr->GetPasses();
+    Vector<Pass*> result = _ptr->GetPasses();
     return VectorToHandleArray(result, "Array<Pass@>");
 }
 
@@ -14390,9 +14413,9 @@ template <class T> void RegisterMembers_Technique(asIScriptEngine* engine, const
     // Pass* Technique::GetPass(const String& name) const
     engine->RegisterObjectMethod(className, "Pass@+ GetPass(const String&in) const", AS_METHODPR(T, GetPass, (const String&) const, Pass*), AS_CALL_THISCALL);
 
-    // PODVector<Pass*> Technique::GetPasses() const
-    engine->RegisterObjectMethod(className, "Array<Pass@>@ GetPasses() const", AS_FUNCTION_OBJFIRST(Technique_PODVectorlesPassstargre_GetPasses_void_template<Technique>), AS_CALL_CDECL_OBJFIRST);
-    engine->RegisterObjectMethod(className, "Array<Pass@>@ get_passes() const", AS_FUNCTION_OBJFIRST(Technique_PODVectorlesPassstargre_GetPasses_void_template<Technique>), AS_CALL_CDECL_OBJFIRST);
+    // Vector<Pass*> Technique::GetPasses() const
+    engine->RegisterObjectMethod(className, "Array<Pass@>@ GetPasses() const", AS_FUNCTION_OBJFIRST(Technique_VectorlesPassstargre_GetPasses_void_template<Technique>), AS_CALL_CDECL_OBJFIRST);
+    engine->RegisterObjectMethod(className, "Array<Pass@>@ get_passes() const", AS_FUNCTION_OBJFIRST(Technique_VectorlesPassstargre_GetPasses_void_template<Technique>), AS_CALL_CDECL_OBJFIRST);
 
     // Vector<String> Technique::GetPassNames() const
     engine->RegisterObjectMethod(className, "Array<String>@ GetPassNames() const", AS_FUNCTION_OBJFIRST(Technique_VectorlesStringgre_GetPassNames_void_template<Technique>), AS_CALL_CDECL_OBJFIRST);
@@ -14463,15 +14486,20 @@ template <class T> void RegisterMembers_Technique(asIScriptEngine* engine, const
     #endif
 }
 
+// const Vector<VAnimKeyFrame>& ValueAnimation::GetKeyFrames() const
+template <class T> CScriptArray* ValueAnimation_constspVectorlesVAnimKeyFramegreamp_GetKeyFrames_void_template(T* _ptr)
+{
+    const Vector<VAnimKeyFrame>& result = _ptr->GetKeyFrames();
+    return VectorToArray(result, "Array<VAnimKeyFrame>");
+}
+
 // class ValueAnimation | File: ../Scene/ValueAnimation.h
 template <class T> void RegisterMembers_ValueAnimation(asIScriptEngine* engine, const char* className)
 {
     RegisterMembers_Resource<T>(engine, className);
 
-    // void ValueAnimation::GetEventFrames(float beginTime, float endTime, PODVector<const VAnimEventFrame*>& eventFrames) const
-    // Error: type "PODVector<const VAnimEventFrame*>&" can not automatically bind
-    // const Vector<VAnimKeyFrame>& ValueAnimation::GetKeyFrames() const
-    // Error: type "const Vector<VAnimKeyFrame>&" can not automatically bind
+    // void ValueAnimation::GetEventFrames(float beginTime, float endTime, Vector<const VAnimEventFrame*>& eventFrames) const
+    // Error: type "Vector<const VAnimEventFrame*>&" can not automatically bind
     // void* ValueAnimation::GetOwner() const
     // Error: type "void*" can not automatically bind
     // void ValueAnimation::SetOwner(void* owner)
@@ -14489,6 +14517,9 @@ template <class T> void RegisterMembers_ValueAnimation(asIScriptEngine* engine, 
     // InterpMethod ValueAnimation::GetInterpolationMethod() const
     engine->RegisterObjectMethod(className, "InterpMethod GetInterpolationMethod() const", AS_METHODPR(T, GetInterpolationMethod, () const, InterpMethod), AS_CALL_THISCALL);
     engine->RegisterObjectMethod(className, "InterpMethod get_interpolationMethod() const", AS_METHODPR(T, GetInterpolationMethod, () const, InterpMethod), AS_CALL_THISCALL);
+
+    // const Vector<VAnimKeyFrame>& ValueAnimation::GetKeyFrames() const
+    engine->RegisterObjectMethod(className, "Array<VAnimKeyFrame>@ GetKeyFrames() const", AS_FUNCTION_OBJFIRST(ValueAnimation_constspVectorlesVAnimKeyFramegreamp_GetKeyFrames_void_template<ValueAnimation>), AS_CALL_CDECL_OBJFIRST);
 
     // float ValueAnimation::GetSplineTension() const
     engine->RegisterObjectMethod(className, "float GetSplineTension() const", AS_METHODPR(T, GetSplineTension, () const, float), AS_CALL_THISCALL);
@@ -15017,6 +15048,13 @@ template <class T> Animation* Animation_SharedPtrlesAnimationgre_Clone_constspSt
     return result.Detach();
 }
 
+// const Vector<AnimationTriggerPoint>& Animation::GetTriggers() const
+template <class T> CScriptArray* Animation_constspVectorlesAnimationTriggerPointgreamp_GetTriggers_void_template(T* _ptr)
+{
+    const Vector<AnimationTriggerPoint>& result = _ptr->GetTriggers();
+    return VectorToArray(result, "Array<AnimationTriggerPoint>");
+}
+
 // class Animation | File: ../Graphics/Animation.h
 template <class T> void RegisterMembers_Animation(asIScriptEngine* engine, const char* className)
 {
@@ -15026,8 +15064,6 @@ template <class T> void RegisterMembers_Animation(asIScriptEngine* engine, const
     // Error: type "const HashMap<StringHash, AnimationTrack>&" can not automatically bind
     // AnimationTriggerPoint* Animation::GetTrigger(unsigned index)
     // Error: type "AnimationTriggerPoint*" can not automatically bind
-    // const Vector<AnimationTriggerPoint>& Animation::GetTriggers() const
-    // Error: type "const Vector<AnimationTriggerPoint>&" can not automatically bind
 
     // void Animation::AddTrigger(const AnimationTriggerPoint& trigger)
     engine->RegisterObjectMethod(className, "void AddTrigger(const AnimationTriggerPoint&in)", AS_METHODPR(T, AddTrigger, (const AnimationTriggerPoint&), void), AS_CALL_THISCALL);
@@ -15069,6 +15105,9 @@ template <class T> void RegisterMembers_Animation(asIScriptEngine* engine, const
 
     // AnimationTrack* Animation::GetTrack(StringHash nameHash)
     engine->RegisterObjectMethod(className, "AnimationTrack@ GetTrack(StringHash)", AS_METHODPR(T, GetTrack, (StringHash), AnimationTrack*), AS_CALL_THISCALL);
+
+    // const Vector<AnimationTriggerPoint>& Animation::GetTriggers() const
+    engine->RegisterObjectMethod(className, "Array<AnimationTriggerPoint>@ GetTriggers() const", AS_FUNCTION_OBJFIRST(Animation_constspVectorlesAnimationTriggerPointgreamp_GetTriggers_void_template<Animation>), AS_CALL_CDECL_OBJFIRST);
 
     // void Animation::RemoveAllTracks()
     engine->RegisterObjectMethod(className, "void RemoveAllTracks()", AS_METHODPR(T, RemoveAllTracks, (), void), AS_CALL_THISCALL);
@@ -15115,10 +15154,10 @@ template <class T> void RegisterMembers_Component(asIScriptEngine* engine, const
     // Error: type "ComponentReplicationState*" can not automatically bind
     // void Component::CleanupConnection(Connection* connection)
     // Not registered because have @manualbind mark
-    // void Component::GetComponents(PODVector<Component*>& dest, StringHash type) const
-    // Error: type "PODVector<Component*>&" can not automatically bind
-    // virtual void Component::GetDependencyNodes(PODVector<Node*>& dest)
-    // Error: type "PODVector<Node*>&" can not automatically bind
+    // void Component::GetComponents(Vector<Component*>& dest, StringHash type) const
+    // Error: type "Vector<Component*>&" can not automatically bind
+    // virtual void Component::GetDependencyNodes(Vector<Node*>& dest)
+    // Error: type "Vector<Node*>&" can not automatically bind
 
     // Component* Component::GetComponent(StringHash type) const
     engine->RegisterObjectMethod(className, "Component@+ GetComponent(StringHash) const", AS_METHODPR(T, GetComponent, (StringHash) const, Component*), AS_CALL_THISCALL);
@@ -15161,7 +15200,7 @@ template <class T> void RegisterMembers_Component(asIScriptEngine* engine, const
 
     // template <class T> T* Component::GetComponent() const
     // Not registered because template
-    // template <class T> void Component::GetComponents(PODVector<T*>& dest) const
+    // template <class T> void Component::GetComponents(Vector<T*>& dest) const
     // Not registered because template
 
     #ifdef REGISTER_MEMBERS_MANUAL_PART_Component
@@ -15176,10 +15215,10 @@ template <class T> Model* Model_SharedPtrlesModelgre_Clone_constspStringamp_temp
     return result.Detach();
 }
 
-// const PODVector<Vector3>& Model::GetGeometryCenters() const
-template <class T> CScriptArray* Model_constspPODVectorlesVector3greamp_GetGeometryCenters_void_template(T* _ptr)
+// const Vector<Vector3>& Model::GetGeometryCenters() const
+template <class T> CScriptArray* Model_constspVectorlesVector3greamp_GetGeometryCenters_void_template(T* _ptr)
 {
-    const PODVector<Vector3>& result = _ptr->GetGeometryCenters();
+    const Vector<Vector3>& result = _ptr->GetGeometryCenters();
     return VectorToArray(result, "Array<Vector3>");
 }
 
@@ -15188,6 +15227,13 @@ template <class T> CScriptArray* Model_constspVectorlesSharedPtrlesIndexBuffergr
 {
     const Vector<SharedPtr<IndexBuffer>>& result = _ptr->GetIndexBuffers();
     return VectorToHandleArray(result, "Array<IndexBuffer@>");
+}
+
+// const Vector<ModelMorph>& Model::GetMorphs() const
+template <class T> CScriptArray* Model_constspVectorlesModelMorphgreamp_GetMorphs_void_template(T* _ptr)
+{
+    const Vector<ModelMorph>& result = _ptr->GetMorphs();
+    return VectorToArray(result, "Array<ModelMorph>");
 }
 
 // const Vector<SharedPtr<VertexBuffer>>& Model::GetVertexBuffers() const
@@ -15205,12 +15251,19 @@ template <class T> bool Model_bool_SetIndexBuffers_constspVectorlesSharedPtrlesI
     return result;
 }
 
-// bool Model::SetVertexBuffers(const Vector<SharedPtr<VertexBuffer>>& buffers, const PODVector<unsigned>& morphRangeStarts, const PODVector<unsigned>& morphRangeCounts)
-template <class T> bool Model_bool_SetVertexBuffers_constspVectorlesSharedPtrlesVertexBuffergregreamp_constspPODVectorlesunsignedgreamp_constspPODVectorlesunsignedgreamp_template(T* _ptr, CScriptArray* buffers_conv, CScriptArray* morphRangeStarts_conv, CScriptArray* morphRangeCounts_conv)
+// void Model::SetMorphs(const Vector<ModelMorph>& morphs)
+template <class T> void Model_void_SetMorphs_constspVectorlesModelMorphgreamp_template(T* _ptr, CScriptArray* morphs_conv)
+{
+    Vector<ModelMorph> morphs = ArrayToVector<ModelMorph>(morphs_conv);
+    _ptr->SetMorphs(morphs);
+}
+
+// bool Model::SetVertexBuffers(const Vector<SharedPtr<VertexBuffer>>& buffers, const Vector<unsigned>& morphRangeStarts, const Vector<unsigned>& morphRangeCounts)
+template <class T> bool Model_bool_SetVertexBuffers_constspVectorlesSharedPtrlesVertexBuffergregreamp_constspVectorlesunsignedgreamp_constspVectorlesunsignedgreamp_template(T* _ptr, CScriptArray* buffers_conv, CScriptArray* morphRangeStarts_conv, CScriptArray* morphRangeCounts_conv)
 {
     Vector<SharedPtr<VertexBuffer>> buffers = HandleArrayToVector<VertexBuffer>(buffers_conv);
-    PODVector<unsigned> morphRangeStarts = ArrayToVector<unsigned>(morphRangeStarts_conv);
-    PODVector<unsigned> morphRangeCounts = ArrayToVector<unsigned>(morphRangeCounts_conv);
+    Vector<unsigned> morphRangeStarts = ArrayToVector<unsigned>(morphRangeStarts_conv);
+    Vector<unsigned> morphRangeCounts = ArrayToVector<unsigned>(morphRangeCounts_conv);
     bool result = _ptr->SetVertexBuffers(buffers, morphRangeStarts, morphRangeCounts);
     return result;
 }
@@ -15222,20 +15275,16 @@ template <class T> void RegisterMembers_Model(asIScriptEngine* engine, const cha
 
     // const Vector<Vector<SharedPtr<Geometry>>>& Model::GetGeometries() const
     // Error: type "const Vector<Vector<SharedPtr<Geometry>>>&" can not automatically bind
-    // const Vector<PODVector<unsigned>>& Model::GetGeometryBoneMappings() const
-    // Error: type "const Vector<PODVector<unsigned>>&" can not automatically bind
+    // const Vector<Vector<unsigned>>& Model::GetGeometryBoneMappings() const
+    // Error: type "const Vector<Vector<unsigned>>&" can not automatically bind
     // const ModelMorph* Model::GetMorph(unsigned index) const
     // Error: type "const ModelMorph*" can not automatically bind
     // const ModelMorph* Model::GetMorph(const String& name) const
     // Error: type "const ModelMorph*" can not automatically bind
     // const ModelMorph* Model::GetMorph(StringHash nameHash) const
     // Error: type "const ModelMorph*" can not automatically bind
-    // const Vector<ModelMorph>& Model::GetMorphs() const
-    // Error: type "const Vector<ModelMorph>&" can not automatically bind
-    // void Model::SetGeometryBoneMappings(const Vector<PODVector<unsigned>>& geometryBoneMappings)
-    // Error: type "const Vector<PODVector<unsigned>>&" can not automatically bind
-    // void Model::SetMorphs(const Vector<ModelMorph>& morphs)
-    // Error: type "const Vector<ModelMorph>&" can not automatically bind
+    // void Model::SetGeometryBoneMappings(const Vector<Vector<unsigned>>& geometryBoneMappings)
+    // Error: type "const Vector<Vector<unsigned>>&" can not automatically bind
 
     // SharedPtr<Model> Model::Clone(const String& cloneName = String::EMPTY) const
     engine->RegisterObjectMethod(className, "Model@+ Clone(const String&in = String::EMPTY) const", AS_FUNCTION_OBJFIRST(Model_SharedPtrlesModelgre_Clone_constspStringamp_template<Model>), AS_CALL_CDECL_OBJFIRST);
@@ -15251,8 +15300,8 @@ template <class T> void RegisterMembers_Model(asIScriptEngine* engine, const cha
     engine->RegisterObjectMethod(className, "const Vector3& GetGeometryCenter(uint) const", AS_METHODPR(T, GetGeometryCenter, (unsigned) const, const Vector3&), AS_CALL_THISCALL);
     engine->RegisterObjectMethod(className, "const Vector3& get_geometryCenters(uint) const", AS_METHODPR(T, GetGeometryCenter, (unsigned) const, const Vector3&), AS_CALL_THISCALL);
 
-    // const PODVector<Vector3>& Model::GetGeometryCenters() const
-    engine->RegisterObjectMethod(className, "Array<Vector3>@ GetGeometryCenters() const", AS_FUNCTION_OBJFIRST(Model_constspPODVectorlesVector3greamp_GetGeometryCenters_void_template<Model>), AS_CALL_CDECL_OBJFIRST);
+    // const Vector<Vector3>& Model::GetGeometryCenters() const
+    engine->RegisterObjectMethod(className, "Array<Vector3>@ GetGeometryCenters() const", AS_FUNCTION_OBJFIRST(Model_constspVectorlesVector3greamp_GetGeometryCenters_void_template<Model>), AS_CALL_CDECL_OBJFIRST);
 
     // const Vector<SharedPtr<IndexBuffer>>& Model::GetIndexBuffers() const
     engine->RegisterObjectMethod(className, "Array<IndexBuffer@>@ GetIndexBuffers() const", AS_FUNCTION_OBJFIRST(Model_constspVectorlesSharedPtrlesIndexBuffergregreamp_GetIndexBuffers_void_template<Model>), AS_CALL_CDECL_OBJFIRST);
@@ -15262,6 +15311,9 @@ template <class T> void RegisterMembers_Model(asIScriptEngine* engine, const cha
 
     // unsigned Model::GetMorphRangeStart(unsigned bufferIndex) const
     engine->RegisterObjectMethod(className, "uint GetMorphRangeStart(uint) const", AS_METHODPR(T, GetMorphRangeStart, (unsigned) const, unsigned), AS_CALL_THISCALL);
+
+    // const Vector<ModelMorph>& Model::GetMorphs() const
+    engine->RegisterObjectMethod(className, "Array<ModelMorph>@ GetMorphs() const", AS_FUNCTION_OBJFIRST(Model_constspVectorlesModelMorphgreamp_GetMorphs_void_template<Model>), AS_CALL_CDECL_OBJFIRST);
 
     // unsigned Model::GetNumGeometries() const
     engine->RegisterObjectMethod(className, "uint GetNumGeometries() const", AS_METHODPR(T, GetNumGeometries, () const, unsigned), AS_CALL_THISCALL);
@@ -15296,6 +15348,9 @@ template <class T> void RegisterMembers_Model(asIScriptEngine* engine, const cha
     // bool Model::SetIndexBuffers(const Vector<SharedPtr<IndexBuffer>>& buffers)
     engine->RegisterObjectMethod(className, "bool SetIndexBuffers(Array<IndexBuffer@>@+)", AS_FUNCTION_OBJFIRST(Model_bool_SetIndexBuffers_constspVectorlesSharedPtrlesIndexBuffergregreamp_template<Model>), AS_CALL_CDECL_OBJFIRST);
 
+    // void Model::SetMorphs(const Vector<ModelMorph>& morphs)
+    engine->RegisterObjectMethod(className, "void SetMorphs(Array<ModelMorph>@+)", AS_FUNCTION_OBJFIRST(Model_void_SetMorphs_constspVectorlesModelMorphgreamp_template<Model>), AS_CALL_CDECL_OBJFIRST);
+
     // void Model::SetNumGeometries(unsigned num)
     engine->RegisterObjectMethod(className, "void SetNumGeometries(uint)", AS_METHODPR(T, SetNumGeometries, (unsigned), void), AS_CALL_THISCALL);
     engine->RegisterObjectMethod(className, "void set_numGeometries(uint)", AS_METHODPR(T, SetNumGeometries, (unsigned), void), AS_CALL_THISCALL);
@@ -15307,8 +15362,8 @@ template <class T> void RegisterMembers_Model(asIScriptEngine* engine, const cha
     // void Model::SetSkeleton(const Skeleton& skeleton)
     engine->RegisterObjectMethod(className, "void SetSkeleton(const Skeleton&in)", AS_METHODPR(T, SetSkeleton, (const Skeleton&), void), AS_CALL_THISCALL);
 
-    // bool Model::SetVertexBuffers(const Vector<SharedPtr<VertexBuffer>>& buffers, const PODVector<unsigned>& morphRangeStarts, const PODVector<unsigned>& morphRangeCounts)
-    engine->RegisterObjectMethod(className, "bool SetVertexBuffers(Array<VertexBuffer@>@+, Array<uint>@+, Array<uint>@+)", AS_FUNCTION_OBJFIRST(Model_bool_SetVertexBuffers_constspVectorlesSharedPtrlesVertexBuffergregreamp_constspPODVectorlesunsignedgreamp_constspPODVectorlesunsignedgreamp_template<Model>), AS_CALL_CDECL_OBJFIRST);
+    // bool Model::SetVertexBuffers(const Vector<SharedPtr<VertexBuffer>>& buffers, const Vector<unsigned>& morphRangeStarts, const Vector<unsigned>& morphRangeCounts)
+    engine->RegisterObjectMethod(className, "bool SetVertexBuffers(Array<VertexBuffer@>@+, Array<uint>@+, Array<uint>@+)", AS_FUNCTION_OBJFIRST(Model_bool_SetVertexBuffers_constspVectorlesSharedPtrlesVertexBuffergregreamp_constspVectorlesunsignedgreamp_constspVectorlesunsignedgreamp_template<Model>), AS_CALL_CDECL_OBJFIRST);
 
     // static void Model::RegisterObject(Context* context)
     // Not registered because have @nobind mark
@@ -15332,24 +15387,24 @@ template <class T> CScriptArray* Node_constspVectorlesSharedPtrlesNodegregreamp_
     return VectorToHandleArray(result, "Array<Node@>");
 }
 
-// PODVector<Node*> Node::GetChildren(bool recursive) const
-template <class T> CScriptArray* Node_PODVectorlesNodestargre_GetChildren_bool_template(T* _ptr, bool recursive)
+// Vector<Node*> Node::GetChildren(bool recursive) const
+template <class T> CScriptArray* Node_VectorlesNodestargre_GetChildren_bool_template(T* _ptr, bool recursive)
 {
-    PODVector<Node*> result = _ptr->GetChildren(recursive);
+    Vector<Node*> result = _ptr->GetChildren(recursive);
     return VectorToHandleArray(result, "Array<Node@>");
 }
 
-// PODVector<Node*> Node::GetChildrenWithComponent(StringHash type, bool recursive = false) const
-template <class T> CScriptArray* Node_PODVectorlesNodestargre_GetChildrenWithComponent_StringHash_bool_template(T* _ptr, StringHash type, bool recursive)
+// Vector<Node*> Node::GetChildrenWithComponent(StringHash type, bool recursive = false) const
+template <class T> CScriptArray* Node_VectorlesNodestargre_GetChildrenWithComponent_StringHash_bool_template(T* _ptr, StringHash type, bool recursive)
 {
-    PODVector<Node*> result = _ptr->GetChildrenWithComponent(type, recursive);
+    Vector<Node*> result = _ptr->GetChildrenWithComponent(type, recursive);
     return VectorToHandleArray(result, "Array<Node@>");
 }
 
-// PODVector<Node*> Node::GetChildrenWithTag(const String& tag, bool recursive = false) const
-template <class T> CScriptArray* Node_PODVectorlesNodestargre_GetChildrenWithTag_constspStringamp_bool_template(T* _ptr, const String& tag, bool recursive)
+// Vector<Node*> Node::GetChildrenWithTag(const String& tag, bool recursive = false) const
+template <class T> CScriptArray* Node_VectorlesNodestargre_GetChildrenWithTag_constspStringamp_bool_template(T* _ptr, const String& tag, bool recursive)
 {
-    PODVector<Node*> result = _ptr->GetChildrenWithTag(tag, recursive);
+    Vector<Node*> result = _ptr->GetChildrenWithTag(tag, recursive);
     return VectorToHandleArray(result, "Array<Node@>");
 }
 
@@ -15360,10 +15415,10 @@ template <class T> CScriptArray* Node_constspVectorlesSharedPtrlesComponentgregr
     return VectorToHandleArray(result, "Array<Component@>");
 }
 
-// const PODVector<Node*>& Node::GetDependencyNodes() const
-template <class T> CScriptArray* Node_constspPODVectorlesNodestargreamp_GetDependencyNodes_void_template(T* _ptr)
+// const Vector<Node*>& Node::GetDependencyNodes() const
+template <class T> CScriptArray* Node_constspVectorlesNodestargreamp_GetDependencyNodes_void_template(T* _ptr)
 {
-    const PODVector<Node*>& result = _ptr->GetDependencyNodes();
+    const Vector<Node*>& result = _ptr->GetDependencyNodes();
     return VectorToHandleArray(result, "Array<Node@>");
 }
 
@@ -15392,20 +15447,20 @@ template <class T> void RegisterMembers_Node(asIScriptEngine* engine, const char
     // Not registered because have @manualbind mark
     // Node* Node::GetChild(const char* name, bool recursive = false) const
     // Error: type "const char*" can not automatically bind
-    // void Node::GetChildren(PODVector<Node*>& dest, bool recursive = false) const
-    // Error: type "PODVector<Node*>&" can not automatically bind
-    // void Node::GetChildrenWithComponent(PODVector<Node*>& dest, StringHash type, bool recursive = false) const
-    // Error: type "PODVector<Node*>&" can not automatically bind
-    // void Node::GetChildrenWithTag(PODVector<Node*>& dest, const String& tag, bool recursive = false) const
-    // Error: type "PODVector<Node*>&" can not automatically bind
-    // void Node::GetComponents(PODVector<Component*>& dest, StringHash type, bool recursive = false) const
-    // Error: type "PODVector<Component*>&" can not automatically bind
+    // void Node::GetChildren(Vector<Node*>& dest, bool recursive = false) const
+    // Error: type "Vector<Node*>&" can not automatically bind
+    // void Node::GetChildrenWithComponent(Vector<Node*>& dest, StringHash type, bool recursive = false) const
+    // Error: type "Vector<Node*>&" can not automatically bind
+    // void Node::GetChildrenWithTag(Vector<Node*>& dest, const String& tag, bool recursive = false) const
+    // Error: type "Vector<Node*>&" can not automatically bind
+    // void Node::GetComponents(Vector<Component*>& dest, StringHash type, bool recursive = false) const
+    // Error: type "Vector<Component*>&" can not automatically bind
     // const Vector<WeakPtr<Component>> Node::GetListeners() const
     // Error: type "const Vector<WeakPtr<Component>>" can not automatically bind
-    // const PODVector<unsigned char>& Node::GetNetParentAttr() const
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
-    // const PODVector<unsigned char>& Node::GetNetRotationAttr() const
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
+    // const Vector<unsigned char>& Node::GetNetParentAttr() const
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
+    // const Vector<unsigned char>& Node::GetNetRotationAttr() const
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
     // Connection* Node::GetOwner() const
     // Not registered because have @manualbind mark
     // bool Node::Load(Deserializer& source, SceneResolver& resolver, bool loadChildren = true, bool rewriteIDs = false, CreateMode mode = REPLICATED)
@@ -15416,10 +15471,10 @@ template <class T> void RegisterMembers_Node(asIScriptEngine* engine, const char
     // Can not be registered here bacause hidden in derived classes: Scene
     // void Node::MarkReplicationDirty()
     // Can not be registered here bacause hidden in derived classes: Scene
-    // void Node::SetNetParentAttr(const PODVector<unsigned char>& value)
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
-    // void Node::SetNetRotationAttr(const PODVector<unsigned char>& value)
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
+    // void Node::SetNetParentAttr(const Vector<unsigned char>& value)
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
+    // void Node::SetNetRotationAttr(const Vector<unsigned char>& value)
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
     // void Node::SetOwner(Connection* owner)
     // Not registered because have @manualbind mark
 
@@ -15474,14 +15529,14 @@ template <class T> void RegisterMembers_Node(asIScriptEngine* engine, const char
     // const Vector<SharedPtr<Node>>& Node::GetChildren() const
     engine->RegisterObjectMethod(className, "Array<Node@>@ GetChildren() const", AS_FUNCTION_OBJFIRST(Node_constspVectorlesSharedPtrlesNodegregreamp_GetChildren_void_template<Node>), AS_CALL_CDECL_OBJFIRST);
 
-    // PODVector<Node*> Node::GetChildren(bool recursive) const
-    engine->RegisterObjectMethod(className, "Array<Node@>@ GetChildren(bool) const", AS_FUNCTION_OBJFIRST(Node_PODVectorlesNodestargre_GetChildren_bool_template<Node>), AS_CALL_CDECL_OBJFIRST);
+    // Vector<Node*> Node::GetChildren(bool recursive) const
+    engine->RegisterObjectMethod(className, "Array<Node@>@ GetChildren(bool) const", AS_FUNCTION_OBJFIRST(Node_VectorlesNodestargre_GetChildren_bool_template<Node>), AS_CALL_CDECL_OBJFIRST);
 
-    // PODVector<Node*> Node::GetChildrenWithComponent(StringHash type, bool recursive = false) const
-    engine->RegisterObjectMethod(className, "Array<Node@>@ GetChildrenWithComponent(StringHash, bool = false) const", AS_FUNCTION_OBJFIRST(Node_PODVectorlesNodestargre_GetChildrenWithComponent_StringHash_bool_template<Node>), AS_CALL_CDECL_OBJFIRST);
+    // Vector<Node*> Node::GetChildrenWithComponent(StringHash type, bool recursive = false) const
+    engine->RegisterObjectMethod(className, "Array<Node@>@ GetChildrenWithComponent(StringHash, bool = false) const", AS_FUNCTION_OBJFIRST(Node_VectorlesNodestargre_GetChildrenWithComponent_StringHash_bool_template<Node>), AS_CALL_CDECL_OBJFIRST);
 
-    // PODVector<Node*> Node::GetChildrenWithTag(const String& tag, bool recursive = false) const
-    engine->RegisterObjectMethod(className, "Array<Node@>@ GetChildrenWithTag(const String&in, bool = false) const", AS_FUNCTION_OBJFIRST(Node_PODVectorlesNodestargre_GetChildrenWithTag_constspStringamp_bool_template<Node>), AS_CALL_CDECL_OBJFIRST);
+    // Vector<Node*> Node::GetChildrenWithTag(const String& tag, bool recursive = false) const
+    engine->RegisterObjectMethod(className, "Array<Node@>@ GetChildrenWithTag(const String&in, bool = false) const", AS_FUNCTION_OBJFIRST(Node_VectorlesNodestargre_GetChildrenWithTag_constspStringamp_bool_template<Node>), AS_CALL_CDECL_OBJFIRST);
 
     // Component* Node::GetComponent(StringHash type, bool recursive = false) const
     engine->RegisterObjectMethod(className, "Component@+ GetComponent(StringHash, bool = false) const", AS_METHODPR(T, GetComponent, (StringHash, bool) const, Component*), AS_CALL_THISCALL);
@@ -15489,8 +15544,8 @@ template <class T> void RegisterMembers_Node(asIScriptEngine* engine, const char
     // const Vector<SharedPtr<Component>>& Node::GetComponents() const
     engine->RegisterObjectMethod(className, "Array<Component@>@ GetComponents() const", AS_FUNCTION_OBJFIRST(Node_constspVectorlesSharedPtrlesComponentgregreamp_GetComponents_void_template<Node>), AS_CALL_CDECL_OBJFIRST);
 
-    // const PODVector<Node*>& Node::GetDependencyNodes() const
-    engine->RegisterObjectMethod(className, "Array<Node@>@ GetDependencyNodes() const", AS_FUNCTION_OBJFIRST(Node_constspPODVectorlesNodestargreamp_GetDependencyNodes_void_template<Node>), AS_CALL_CDECL_OBJFIRST);
+    // const Vector<Node*>& Node::GetDependencyNodes() const
+    engine->RegisterObjectMethod(className, "Array<Node@>@ GetDependencyNodes() const", AS_FUNCTION_OBJFIRST(Node_constspVectorlesNodestargreamp_GetDependencyNodes_void_template<Node>), AS_CALL_CDECL_OBJFIRST);
 
     // Vector3 Node::GetDirection() const
     engine->RegisterObjectMethod(className, "Vector3 GetDirection() const", AS_METHODPR(T, GetDirection, () const, Vector3), AS_CALL_THISCALL);
@@ -15932,15 +15987,15 @@ template <class T> void RegisterMembers_Node(asIScriptEngine* engine, const char
 
     // template <class T> T* Node::CreateComponent(CreateMode mode = REPLICATED, unsigned id = 0)
     // Not registered because template
-    // template <class T> void Node::GetChildrenWithComponent(PODVector<Node*>& dest, bool recursive = false) const
+    // template <class T> void Node::GetChildrenWithComponent(Vector<Node*>& dest, bool recursive = false) const
     // Not registered because template
     // template <class T> T* Node::GetComponent(bool recursive = false) const
     // Not registered because template
-    // template <class T> void Node::GetComponents(PODVector<T*>& dest, bool recursive = false) const
+    // template <class T> void Node::GetComponents(Vector<T*>& dest, bool recursive = false) const
     // Not registered because template
     // template <class T> T* Node::GetDerivedComponent(bool recursive = false) const
     // Not registered because template
-    // template <class T> void Node::GetDerivedComponents(PODVector<T*>& dest, bool recursive = false, bool clearVector = true) const
+    // template <class T> void Node::GetDerivedComponents(Vector<T*>& dest, bool recursive = false, bool clearVector = true) const
     // Not registered because template
     // template <class T> T* Node::GetOrCreateComponent(CreateMode mode = REPLICATED, unsigned id = 0)
     // Not registered because template
@@ -16250,17 +16305,17 @@ template <class T> CScriptArray* UIElement_constspVectorlesSharedPtrlesUIElement
     return VectorToHandleArray(result, "Array<UIElement@>");
 }
 
-// PODVector<UIElement*> UIElement::GetChildren(bool recursive) const
-template <class T> CScriptArray* UIElement_PODVectorlesUIElementstargre_GetChildren_bool_template(T* _ptr, bool recursive)
+// Vector<UIElement*> UIElement::GetChildren(bool recursive) const
+template <class T> CScriptArray* UIElement_VectorlesUIElementstargre_GetChildren_bool_template(T* _ptr, bool recursive)
 {
-    PODVector<UIElement*> result = _ptr->GetChildren(recursive);
+    Vector<UIElement*> result = _ptr->GetChildren(recursive);
     return VectorToHandleArray(result, "Array<UIElement@>");
 }
 
-// PODVector<UIElement*> UIElement::GetChildrenWithTag(const String& tag, bool recursive = false) const
-template <class T> CScriptArray* UIElement_PODVectorlesUIElementstargre_GetChildrenWithTag_constspStringamp_bool_template(T* _ptr, const String& tag, bool recursive)
+// Vector<UIElement*> UIElement::GetChildrenWithTag(const String& tag, bool recursive = false) const
+template <class T> CScriptArray* UIElement_VectorlesUIElementstargre_GetChildrenWithTag_constspStringamp_bool_template(T* _ptr, const String& tag, bool recursive)
 {
-    PODVector<UIElement*> result = _ptr->GetChildrenWithTag(tag, recursive);
+    Vector<UIElement*> result = _ptr->GetChildrenWithTag(tag, recursive);
     return VectorToHandleArray(result, "Array<UIElement@>");
 }
 
@@ -16283,16 +16338,16 @@ template <class T> void RegisterMembers_UIElement(asIScriptEngine* engine, const
 {
     RegisterMembers_Animatable<T>(engine, className);
 
-    // virtual void UIElement::GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect& currentScissor)
-    // Error: type "PODVector<UIBatch>&" can not automatically bind
-    // void UIElement::GetBatchesWithOffset(IntVector2& offset, PODVector<UIBatch>& batches, PODVector<float>& vertexData, IntRect currentScissor)
-    // Error: type "PODVector<UIBatch>&" can not automatically bind
-    // void UIElement::GetChildren(PODVector<UIElement*>& dest, bool recursive = false) const
-    // Error: type "PODVector<UIElement*>&" can not automatically bind
-    // void UIElement::GetChildrenWithTag(PODVector<UIElement*>& dest, const String& tag, bool recursive = false) const
-    // Error: type "PODVector<UIElement*>&" can not automatically bind
-    // virtual void UIElement::GetDebugDrawBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect& currentScissor)
-    // Error: type "PODVector<UIBatch>&" can not automatically bind
+    // virtual void UIElement::GetBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor)
+    // Error: type "Vector<UIBatch>&" can not automatically bind
+    // void UIElement::GetBatchesWithOffset(IntVector2& offset, Vector<UIBatch>& batches, Vector<float>& vertexData, IntRect currentScissor)
+    // Error: type "Vector<UIBatch>&" can not automatically bind
+    // void UIElement::GetChildren(Vector<UIElement*>& dest, bool recursive = false) const
+    // Error: type "Vector<UIElement*>&" can not automatically bind
+    // void UIElement::GetChildrenWithTag(Vector<UIElement*>& dest, const String& tag, bool recursive = false) const
+    // Error: type "Vector<UIElement*>&" can not automatically bind
+    // virtual void UIElement::GetDebugDrawBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor)
+    // Error: type "Vector<UIBatch>&" can not automatically bind
     // const IntVector2& UIElement::GetPosition() const
     // Can not be registered here bacause hidden in derived classes: Sprite
     // bool UIElement::IsSelected() const
@@ -16367,11 +16422,11 @@ template <class T> void RegisterMembers_UIElement(asIScriptEngine* engine, const
     // const Vector<SharedPtr<UIElement>>& UIElement::GetChildren() const
     engine->RegisterObjectMethod(className, "Array<UIElement@>@ GetChildren() const", AS_FUNCTION_OBJFIRST(UIElement_constspVectorlesSharedPtrlesUIElementgregreamp_GetChildren_void_template<UIElement>), AS_CALL_CDECL_OBJFIRST);
 
-    // PODVector<UIElement*> UIElement::GetChildren(bool recursive) const
-    engine->RegisterObjectMethod(className, "Array<UIElement@>@ GetChildren(bool) const", AS_FUNCTION_OBJFIRST(UIElement_PODVectorlesUIElementstargre_GetChildren_bool_template<UIElement>), AS_CALL_CDECL_OBJFIRST);
+    // Vector<UIElement*> UIElement::GetChildren(bool recursive) const
+    engine->RegisterObjectMethod(className, "Array<UIElement@>@ GetChildren(bool) const", AS_FUNCTION_OBJFIRST(UIElement_VectorlesUIElementstargre_GetChildren_bool_template<UIElement>), AS_CALL_CDECL_OBJFIRST);
 
-    // PODVector<UIElement*> UIElement::GetChildrenWithTag(const String& tag, bool recursive = false) const
-    engine->RegisterObjectMethod(className, "Array<UIElement@>@ GetChildrenWithTag(const String&in, bool = false) const", AS_FUNCTION_OBJFIRST(UIElement_PODVectorlesUIElementstargre_GetChildrenWithTag_constspStringamp_bool_template<UIElement>), AS_CALL_CDECL_OBJFIRST);
+    // Vector<UIElement*> UIElement::GetChildrenWithTag(const String& tag, bool recursive = false) const
+    engine->RegisterObjectMethod(className, "Array<UIElement@>@ GetChildrenWithTag(const String&in, bool = false) const", AS_FUNCTION_OBJFIRST(UIElement_VectorlesUIElementstargre_GetChildrenWithTag_constspStringamp_bool_template<UIElement>), AS_CALL_CDECL_OBJFIRST);
 
     // const IntRect& UIElement::GetClipBorder() const
     engine->RegisterObjectMethod(className, "const IntRect& GetClipBorder() const", AS_METHODPR(T, GetClipBorder, () const, const IntRect&), AS_CALL_THISCALL);
@@ -17016,17 +17071,17 @@ template <class T> void RegisterMembers_AnimationController(asIScriptEngine* eng
     RegisterMembers_Component<T>(engine, className);
 
     // const Vector<AnimationControl>& AnimationController::GetAnimations() const
-    // Error: type "const Vector<AnimationControl>&" can not automatically bind
+    // Not registered because have @nobind mark
     // VariantVector AnimationController::GetAnimationsAttr() const
     // Error: type "VariantVector" can not automatically bind
-    // const PODVector<unsigned char>& AnimationController::GetNetAnimationsAttr() const
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
+    // const Vector<unsigned char>& AnimationController::GetNetAnimationsAttr() const
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
     // VariantVector AnimationController::GetNodeAnimationStatesAttr() const
     // Error: type "VariantVector" can not automatically bind
     // void AnimationController::SetAnimationsAttr(const VariantVector& value)
     // Error: type "const VariantVector&" can not automatically bind
-    // void AnimationController::SetNetAnimationsAttr(const PODVector<unsigned char>& value)
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
+    // void AnimationController::SetNetAnimationsAttr(const Vector<unsigned char>& value)
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
     // void AnimationController::SetNodeAnimationStatesAttr(const VariantVector& value)
     // Error: type "const VariantVector&" can not automatically bind
 
@@ -17612,17 +17667,24 @@ template <class T> void RegisterMembers_DebugRenderer(asIScriptEngine* engine, c
     #endif
 }
 
-// const PODVector<Light*>& Drawable::GetLights() const
-template <class T> CScriptArray* Drawable_constspPODVectorlesLightstargreamp_GetLights_void_template(T* _ptr)
+// const Vector<SourceBatch>& Drawable::GetBatches() const
+template <class T> CScriptArray* Drawable_constspVectorlesSourceBatchgreamp_GetBatches_void_template(T* _ptr)
 {
-    const PODVector<Light*>& result = _ptr->GetLights();
+    const Vector<SourceBatch>& result = _ptr->GetBatches();
+    return VectorToArray(result, "Array<SourceBatch>");
+}
+
+// const Vector<Light*>& Drawable::GetLights() const
+template <class T> CScriptArray* Drawable_constspVectorlesLightstargreamp_GetLights_void_template(T* _ptr)
+{
+    const Vector<Light*>& result = _ptr->GetLights();
     return VectorToHandleArray(result, "Array<Light@>");
 }
 
-// const PODVector<Light*>& Drawable::GetVertexLights() const
-template <class T> CScriptArray* Drawable_constspPODVectorlesLightstargreamp_GetVertexLights_void_template(T* _ptr)
+// const Vector<Light*>& Drawable::GetVertexLights() const
+template <class T> CScriptArray* Drawable_constspVectorlesLightstargreamp_GetVertexLights_void_template(T* _ptr)
 {
-    const PODVector<Light*>& result = _ptr->GetVertexLights();
+    const Vector<Light*>& result = _ptr->GetVertexLights();
     return VectorToHandleArray(result, "Array<Light@>");
 }
 
@@ -17631,11 +17693,9 @@ template <class T> void RegisterMembers_Drawable(asIScriptEngine* engine, const 
 {
     RegisterMembers_Component<T>(engine, className);
 
-    // const Vector<SourceBatch>& Drawable::GetBatches() const
-    // Error: type "const Vector<SourceBatch>&" can not automatically bind
     // Octant* Drawable::GetOctant() const
     // Error: type "Octant" can not automatically bind bacause have @nobind mark
-    // virtual void Drawable::ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQueryResult>& results)
+    // virtual void Drawable::ProcessRayQuery(const RayOctreeQuery& query, Vector<RayQueryResult>& results)
     // Error: type "RayOctreeQuery" can not automatically bind bacause have @nobind mark
     // virtual void Drawable::Update(const FrameInfo& frame)
     // Can not be registered here bacause hidden in derived classes: ParticleEmitter2D
@@ -17651,6 +17711,9 @@ template <class T> void RegisterMembers_Drawable(asIScriptEngine* engine, const 
 
     // virtual bool Drawable::DrawOcclusion(OcclusionBuffer* buffer)
     engine->RegisterObjectMethod(className, "bool DrawOcclusion(OcclusionBuffer@+)", AS_METHODPR(T, DrawOcclusion, (OcclusionBuffer*), bool), AS_CALL_THISCALL);
+
+    // const Vector<SourceBatch>& Drawable::GetBatches() const
+    engine->RegisterObjectMethod(className, "Array<SourceBatch>@ GetBatches() const", AS_FUNCTION_OBJFIRST(Drawable_constspVectorlesSourceBatchgreamp_GetBatches_void_template<Drawable>), AS_CALL_CDECL_OBJFIRST);
 
     // const BoundingBox& Drawable::GetBoundingBox() const
     engine->RegisterObjectMethod(className, "const BoundingBox& GetBoundingBox() const", AS_METHODPR(T, GetBoundingBox, () const, const BoundingBox&), AS_CALL_THISCALL);
@@ -17677,8 +17740,8 @@ template <class T> void RegisterMembers_Drawable(asIScriptEngine* engine, const 
     engine->RegisterObjectMethod(className, "uint GetLightMask() const", AS_METHODPR(T, GetLightMask, () const, unsigned), AS_CALL_THISCALL);
     engine->RegisterObjectMethod(className, "uint get_lightMask() const", AS_METHODPR(T, GetLightMask, () const, unsigned), AS_CALL_THISCALL);
 
-    // const PODVector<Light*>& Drawable::GetLights() const
-    engine->RegisterObjectMethod(className, "Array<Light@>@ GetLights() const", AS_FUNCTION_OBJFIRST(Drawable_constspPODVectorlesLightstargreamp_GetLights_void_template<Drawable>), AS_CALL_CDECL_OBJFIRST);
+    // const Vector<Light*>& Drawable::GetLights() const
+    engine->RegisterObjectMethod(className, "Array<Light@>@ GetLights() const", AS_FUNCTION_OBJFIRST(Drawable_constspVectorlesLightstargreamp_GetLights_void_template<Drawable>), AS_CALL_CDECL_OBJFIRST);
 
     // float Drawable::GetLodBias() const
     engine->RegisterObjectMethod(className, "float GetLodBias() const", AS_METHODPR(T, GetLodBias, () const, float), AS_CALL_THISCALL);
@@ -17717,8 +17780,8 @@ template <class T> void RegisterMembers_Drawable(asIScriptEngine* engine, const 
     // virtual UpdateGeometryType Drawable::GetUpdateGeometryType()
     engine->RegisterObjectMethod(className, "UpdateGeometryType GetUpdateGeometryType()", AS_METHODPR(T, GetUpdateGeometryType, (), UpdateGeometryType), AS_CALL_THISCALL);
 
-    // const PODVector<Light*>& Drawable::GetVertexLights() const
-    engine->RegisterObjectMethod(className, "Array<Light@>@ GetVertexLights() const", AS_FUNCTION_OBJFIRST(Drawable_constspPODVectorlesLightstargreamp_GetVertexLights_void_template<Drawable>), AS_CALL_CDECL_OBJFIRST);
+    // const Vector<Light*>& Drawable::GetVertexLights() const
+    engine->RegisterObjectMethod(className, "Array<Light@>@ GetVertexLights() const", AS_FUNCTION_OBJFIRST(Drawable_constspVectorlesLightstargreamp_GetVertexLights_void_template<Drawable>), AS_CALL_CDECL_OBJFIRST);
 
     // unsigned Drawable::GetViewMask() const
     engine->RegisterObjectMethod(className, "uint GetViewMask() const", AS_METHODPR(T, GetViewMask, () const, unsigned), AS_CALL_THISCALL);
@@ -17943,8 +18006,8 @@ template <class T> void RegisterMembers_Scene(asIScriptEngine* engine, const cha
 {
     RegisterMembers_Node<T>(engine, className);
 
-    // bool Scene::GetNodesWithTag(PODVector<Node*>& dest, const String& tag) const
-    // Error: type "PODVector<Node*>&" can not automatically bind
+    // bool Scene::GetNodesWithTag(Vector<Node*>& dest, const String& tag) const
+    // Error: type "Vector<Node*>&" can not automatically bind
 
     // void Scene::AddRequiredPackageFile(PackageFile* package)
     engine->RegisterObjectMethod(className, "void AddRequiredPackageFile(PackageFile@+)", AS_METHODPR(T, AddRequiredPackageFile, (PackageFile*), void), AS_CALL_THISCALL);
@@ -19153,8 +19216,8 @@ template <class T> void RegisterMembers_UnknownComponent(asIScriptEngine* engine
 {
     RegisterMembers_Component<T>(engine, className);
 
-    // const PODVector<unsigned char>& UnknownComponent::GetBinaryAttributes() const
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
+    // const Vector<unsigned char>& UnknownComponent::GetBinaryAttributes() const
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
 
     // virtual void Component::DrawDebugGeometry(DebugRenderer* debug, bool depthTest)
     engine->RegisterObjectMethod(className, "void DrawDebugGeometry(DebugRenderer@+, bool)", AS_METHODPR(T, DrawDebugGeometry, (DebugRenderer*, bool), void), AS_CALL_THISCALL);
@@ -19591,10 +19654,10 @@ template <class T> void RegisterMembers_CrowdAgent(asIScriptEngine* engine, cons
     #endif
 }
 
-// PODVector<CrowdAgent*> CrowdManager::GetAgents(Node* node = nullptr, bool inCrowdFilter = true) const
-template <class T> CScriptArray* CrowdManager_PODVectorlesCrowdAgentstargre_GetAgents_Nodestar_bool_template(T* _ptr, Node* node, bool inCrowdFilter)
+// Vector<CrowdAgent*> CrowdManager::GetAgents(Node* node = nullptr, bool inCrowdFilter = true) const
+template <class T> CScriptArray* CrowdManager_VectorlesCrowdAgentstargre_GetAgents_Nodestar_bool_template(T* _ptr, Node* node, bool inCrowdFilter)
 {
-    PODVector<CrowdAgent*> result = _ptr->GetAgents(node, inCrowdFilter);
+    Vector<CrowdAgent*> result = _ptr->GetAgents(node, inCrowdFilter);
     return VectorToHandleArray(result, "Array<CrowdAgent@>");
 }
 
@@ -19605,8 +19668,8 @@ template <class T> void RegisterMembers_CrowdManager(asIScriptEngine* engine, co
 
     // Vector3 CrowdManager::FindNearestPoint(const Vector3& point, int queryFilterType, dtPolyRef* nearestRef = nullptr)
     // Error: type "dtPolyRef*" can not automatically bind
-    // void CrowdManager::FindPath(PODVector<Vector3>& dest, const Vector3& start, const Vector3& end, int queryFilterType)
-    // Error: type "PODVector<Vector3>&" can not automatically bind
+    // void CrowdManager::FindPath(Vector<Vector3>& dest, const Vector3& start, const Vector3& end, int queryFilterType)
+    // Error: type "Vector<Vector3>&" can not automatically bind
     // float CrowdManager::GetDistanceToWall(const Vector3& point, float radius, int queryFilterType, Vector3* hitPos = nullptr, Vector3* hitNormal = nullptr)
     // Error: type "Vector3*" can not automatically bind
     // VariantVector CrowdManager::GetObstacleAvoidanceTypesAttr() const
@@ -19630,8 +19693,8 @@ template <class T> void RegisterMembers_CrowdManager(asIScriptEngine* engine, co
     // void CrowdManager::DrawDebugGeometry(bool depthTest)
     engine->RegisterObjectMethod(className, "void DrawDebugGeometry(bool)", AS_METHODPR(T, DrawDebugGeometry, (bool), void), AS_CALL_THISCALL);
 
-    // PODVector<CrowdAgent*> CrowdManager::GetAgents(Node* node = nullptr, bool inCrowdFilter = true) const
-    engine->RegisterObjectMethod(className, "Array<CrowdAgent@>@ GetAgents(Node@+ = null, bool = true) const", AS_FUNCTION_OBJFIRST(CrowdManager_PODVectorlesCrowdAgentstargre_GetAgents_Nodestar_bool_template<CrowdManager>), AS_CALL_CDECL_OBJFIRST);
+    // Vector<CrowdAgent*> CrowdManager::GetAgents(Node* node = nullptr, bool inCrowdFilter = true) const
+    engine->RegisterObjectMethod(className, "Array<CrowdAgent@>@ GetAgents(Node@+ = null, bool = true) const", AS_FUNCTION_OBJFIRST(CrowdManager_VectorlesCrowdAgentstargre_GetAgents_Nodestar_bool_template<CrowdManager>), AS_CALL_CDECL_OBJFIRST);
 
     // float CrowdManager::GetAreaCost(unsigned queryFilterType, unsigned areaID) const
     engine->RegisterObjectMethod(className, "float GetAreaCost(uint, uint) const", AS_METHODPR(T, GetAreaCost, (unsigned, unsigned) const, float), AS_CALL_THISCALL);
@@ -19769,30 +19832,30 @@ template <class T> void RegisterMembers_NavigationMesh(asIScriptEngine* engine, 
 {
     RegisterMembers_Component<T>(engine, className);
 
-    // virtual bool NavigationMesh::AddTile(const PODVector<unsigned char>& tileData)
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
+    // virtual bool NavigationMesh::AddTile(const Vector<unsigned char>& tileData)
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
     // Vector3 NavigationMesh::FindNearestPoint(const Vector3& point, const Vector3& extents = Vector3::ONE, const dtQueryFilter* filter = nullptr, dtPolyRef* nearestRef = nullptr)
     // Error: type "const dtQueryFilter*" can not automatically bind
-    // void NavigationMesh::FindPath(PODVector<Vector3>& dest, const Vector3& start, const Vector3& end, const Vector3& extents = Vector3::ONE, const dtQueryFilter* filter = nullptr)
-    // Error: type "PODVector<Vector3>&" can not automatically bind
-    // void NavigationMesh::FindPath(PODVector<NavigationPathPoint>& dest, const Vector3& start, const Vector3& end, const Vector3& extents = Vector3::ONE, const dtQueryFilter* filter = nullptr)
-    // Error: type "PODVector<NavigationPathPoint>&" can not automatically bind
+    // void NavigationMesh::FindPath(Vector<Vector3>& dest, const Vector3& start, const Vector3& end, const Vector3& extents = Vector3::ONE, const dtQueryFilter* filter = nullptr)
+    // Error: type "Vector<Vector3>&" can not automatically bind
+    // void NavigationMesh::FindPath(Vector<NavigationPathPoint>& dest, const Vector3& start, const Vector3& end, const Vector3& extents = Vector3::ONE, const dtQueryFilter* filter = nullptr)
+    // Error: type "Vector<NavigationPathPoint>&" can not automatically bind
     // float NavigationMesh::GetDistanceToWall(const Vector3& point, float radius, const Vector3& extents = Vector3::ONE, const dtQueryFilter* filter = nullptr, Vector3* hitPos = nullptr, Vector3* hitNormal = nullptr)
     // Error: type "const dtQueryFilter*" can not automatically bind
-    // virtual PODVector<unsigned char> NavigationMesh::GetNavigationDataAttr() const
-    // Error: type "PODVector<unsigned char>" can not automatically bind
+    // virtual Vector<unsigned char> NavigationMesh::GetNavigationDataAttr() const
+    // Error: type "Vector<unsigned char>" can not automatically bind
     // Vector3 NavigationMesh::GetRandomPoint(const dtQueryFilter* filter = nullptr, dtPolyRef* randomRef = nullptr)
     // Error: type "const dtQueryFilter*" can not automatically bind
     // Vector3 NavigationMesh::GetRandomPointInCircle(const Vector3& center, float radius, const Vector3& extents = Vector3::ONE, const dtQueryFilter* filter = nullptr, dtPolyRef* randomRef = nullptr)
     // Error: type "const dtQueryFilter*" can not automatically bind
-    // virtual PODVector<unsigned char> NavigationMesh::GetTileData(const IntVector2& tile) const
-    // Error: type "PODVector<unsigned char>" can not automatically bind
+    // virtual Vector<unsigned char> NavigationMesh::GetTileData(const IntVector2& tile) const
+    // Error: type "Vector<unsigned char>" can not automatically bind
     // Vector3 NavigationMesh::MoveAlongSurface(const Vector3& start, const Vector3& end, const Vector3& extents = Vector3::ONE, int maxVisited = 3, const dtQueryFilter* filter = nullptr)
     // Error: type "const dtQueryFilter*" can not automatically bind
     // Vector3 NavigationMesh::Raycast(const Vector3& start, const Vector3& end, const Vector3& extents = Vector3::ONE, const dtQueryFilter* filter = nullptr, Vector3* hitNormal = nullptr)
     // Error: type "const dtQueryFilter*" can not automatically bind
-    // virtual void NavigationMesh::SetNavigationDataAttr(const PODVector<unsigned char>& value)
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
+    // virtual void NavigationMesh::SetNavigationDataAttr(const Vector<unsigned char>& value)
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
 
     // virtual bool NavigationMesh::Allocate(const BoundingBox& boundingBox, unsigned maxTiles)
     engine->RegisterObjectMethod(className, "bool Allocate(const BoundingBox&in, uint)", AS_METHODPR(T, Allocate, (const BoundingBox&, unsigned), bool), AS_CALL_THISCALL);
@@ -20423,26 +20486,26 @@ template <class T> void RegisterMembers_PhysicsWorld(asIScriptEngine* engine, co
     // Error: type "const btVector3&" can not automatically bind
     // void PhysicsWorld::drawLine(const btVector3& from, const btVector3& to, const btVector3& color) override
     // Error: type "const btVector3&" can not automatically bind
-    // void PhysicsWorld::GetCollidingBodies(PODVector<RigidBody*>& result, const RigidBody* body)
-    // Error: type "PODVector<RigidBody*>&" can not automatically bind
+    // void PhysicsWorld::GetCollidingBodies(Vector<RigidBody*>& result, const RigidBody* body)
+    // Error: type "Vector<RigidBody*>&" can not automatically bind
     // CollisionGeometryDataCache& PhysicsWorld::GetConvexCache()
     // Error: type "CollisionGeometryDataCache&" can not automatically bind
     // CollisionGeometryDataCache& PhysicsWorld::GetGImpactTrimeshCache()
     // Error: type "CollisionGeometryDataCache&" can not automatically bind
-    // void PhysicsWorld::GetRigidBodies(PODVector<RigidBody*>& result, const Sphere& sphere, unsigned collisionMask = M_MAX_UNSIGNED)
-    // Error: type "PODVector<RigidBody*>&" can not automatically bind
-    // void PhysicsWorld::GetRigidBodies(PODVector<RigidBody*>& result, const BoundingBox& box, unsigned collisionMask = M_MAX_UNSIGNED)
-    // Error: type "PODVector<RigidBody*>&" can not automatically bind
-    // void PhysicsWorld::GetRigidBodies(PODVector<RigidBody*>& result, const RigidBody* body)
-    // Error: type "PODVector<RigidBody*>&" can not automatically bind
+    // void PhysicsWorld::GetRigidBodies(Vector<RigidBody*>& result, const Sphere& sphere, unsigned collisionMask = M_MAX_UNSIGNED)
+    // Error: type "Vector<RigidBody*>&" can not automatically bind
+    // void PhysicsWorld::GetRigidBodies(Vector<RigidBody*>& result, const BoundingBox& box, unsigned collisionMask = M_MAX_UNSIGNED)
+    // Error: type "Vector<RigidBody*>&" can not automatically bind
+    // void PhysicsWorld::GetRigidBodies(Vector<RigidBody*>& result, const RigidBody* body)
+    // Error: type "Vector<RigidBody*>&" can not automatically bind
     // CollisionGeometryDataCache& PhysicsWorld::GetTriMeshCache()
     // Error: type "CollisionGeometryDataCache&" can not automatically bind
     // btDiscreteDynamicsWorld* PhysicsWorld::GetWorld()
     // Error: type "btDiscreteDynamicsWorld*" can not automatically bind
     // bool PhysicsWorld::isVisible(const btVector3& aabbMin, const btVector3& aabbMax) override
     // Error: type "const btVector3&" can not automatically bind
-    // void PhysicsWorld::Raycast(PODVector<PhysicsRaycastResult>& result, const Ray& ray, float maxDistance, unsigned collisionMask = M_MAX_UNSIGNED)
-    // Error: type "PODVector<PhysicsRaycastResult>&" can not automatically bind
+    // void PhysicsWorld::Raycast(Vector<PhysicsRaycastResult>& result, const Ray& ray, float maxDistance, unsigned collisionMask = M_MAX_UNSIGNED)
+    // Error: type "Vector<PhysicsRaycastResult>&" can not automatically bind
     // void PhysicsWorld::reportErrorWarning(const char* warningString) override
     // Error: type "const char*" can not automatically bind
 
@@ -20603,16 +20666,16 @@ template <class T> void RegisterMembers_RigidBody(asIScriptEngine* engine, const
 
     // btRigidBody* RigidBody::GetBody() const
     // Error: type "btRigidBody*" can not automatically bind
-    // void RigidBody::GetCollidingBodies(PODVector<RigidBody*>& result) const
-    // Error: type "PODVector<RigidBody*>&" can not automatically bind
+    // void RigidBody::GetCollidingBodies(Vector<RigidBody*>& result) const
+    // Error: type "Vector<RigidBody*>&" can not automatically bind
     // btCompoundShape* RigidBody::GetCompoundShape() const
     // Error: type "btCompoundShape*" can not automatically bind
-    // const PODVector<unsigned char>& RigidBody::GetNetAngularVelocityAttr() const
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
+    // const Vector<unsigned char>& RigidBody::GetNetAngularVelocityAttr() const
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
     // void RigidBody::getWorldTransform(btTransform& worldTrans) const override
     // Not registered because have @nobind mark
-    // void RigidBody::SetNetAngularVelocityAttr(const PODVector<unsigned char>& value)
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
+    // void RigidBody::SetNetAngularVelocityAttr(const Vector<unsigned char>& value)
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
     // void RigidBody::setWorldTransform(const btTransform& worldTrans) override
     // Not registered because have @nobind mark
 
@@ -21060,14 +21123,14 @@ template <class T> void RegisterMembers_PhysicsWorld2D(asIScriptEngine* engine, 
     // Error: type "const b2Transform&" can not automatically bind
     // void PhysicsWorld2D::EndContact(b2Contact* contact) override
     // Error: type "b2Contact*" can not automatically bind
-    // void PhysicsWorld2D::GetRigidBodies(PODVector<RigidBody2D*>& results, const Rect& aabb, unsigned collisionMask = M_MAX_UNSIGNED)
-    // Error: type "PODVector<RigidBody2D*>&" can not automatically bind
+    // void PhysicsWorld2D::GetRigidBodies(Vector<RigidBody2D*>& results, const Rect& aabb, unsigned collisionMask = M_MAX_UNSIGNED)
+    // Error: type "Vector<RigidBody2D*>&" can not automatically bind
     // b2World* PhysicsWorld2D::GetWorld()
     // Error: type "b2World*" can not automatically bind
     // void PhysicsWorld2D::PreSolve(b2Contact* contact, const b2Manifold* oldManifold) override
     // Error: type "b2Contact*" can not automatically bind
-    // void PhysicsWorld2D::Raycast(PODVector<PhysicsRaycastResult2D>& results, const Vector2& startPoint, const Vector2& endPoint, unsigned collisionMask = M_MAX_UNSIGNED)
-    // Error: type "PODVector<PhysicsRaycastResult2D>&" can not automatically bind
+    // void PhysicsWorld2D::Raycast(Vector<PhysicsRaycastResult2D>& results, const Vector2& startPoint, const Vector2& endPoint, unsigned collisionMask = M_MAX_UNSIGNED)
+    // Error: type "Vector<PhysicsRaycastResult2D>&" can not automatically bind
 
     // void PhysicsWorld2D::AddDelayedWorldTransform(const DelayedWorldTransform2D& transform)
     engine->RegisterObjectMethod(className, "void AddDelayedWorldTransform(const DelayedWorldTransform2D&in)", AS_METHODPR(T, AddDelayedWorldTransform, (const DelayedWorldTransform2D&), void), AS_CALL_THISCALL);
@@ -21531,16 +21594,16 @@ template <class T> void RegisterMembers_BillboardSet(asIScriptEngine* engine, co
 {
     RegisterMembers_Drawable<T>(engine, className);
 
-    // PODVector<Billboard>& BillboardSet::GetBillboards()
-    // Error: type "PODVector<Billboard>&" can not automatically bind
+    // Vector<Billboard>& BillboardSet::GetBillboards()
+    // Error: type "Vector<Billboard>&" can not automatically bind
     // VariantVector BillboardSet::GetBillboardsAttr() const
     // Error: type "VariantVector" can not automatically bind
-    // const PODVector<unsigned char>& BillboardSet::GetNetBillboardsAttr() const
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
+    // const Vector<unsigned char>& BillboardSet::GetNetBillboardsAttr() const
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
     // void BillboardSet::SetBillboardsAttr(const VariantVector& value)
     // Error: type "const VariantVector&" can not automatically bind
-    // void BillboardSet::SetNetBillboardsAttr(const PODVector<unsigned char>& value)
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
+    // void BillboardSet::SetNetBillboardsAttr(const Vector<unsigned char>& value)
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
 
     // void BillboardSet::Commit()
     engine->RegisterObjectMethod(className, "void Commit()", AS_METHODPR(T, Commit, (), void), AS_CALL_THISCALL);
@@ -21767,12 +21830,12 @@ template <class T> void RegisterMembers_CustomGeometry(asIScriptEngine* engine, 
 {
     RegisterMembers_Drawable<T>(engine, className);
 
-    // PODVector<unsigned char> CustomGeometry::GetGeometryDataAttr() const
-    // Error: type "PODVector<unsigned char>" can not automatically bind
-    // Vector<PODVector<CustomGeometryVertex>>& CustomGeometry::GetVertices()
-    // Error: type "Vector<PODVector<CustomGeometryVertex>>&" can not automatically bind
-    // void CustomGeometry::SetGeometryDataAttr(const PODVector<unsigned char>& value)
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
+    // Vector<unsigned char> CustomGeometry::GetGeometryDataAttr() const
+    // Error: type "Vector<unsigned char>" can not automatically bind
+    // Vector<Vector<CustomGeometryVertex>>& CustomGeometry::GetVertices()
+    // Error: type "Vector<Vector<CustomGeometryVertex>>&" can not automatically bind
+    // void CustomGeometry::SetGeometryDataAttr(const Vector<unsigned char>& value)
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
 
     // void CustomGeometry::BeginGeometry(unsigned index, PrimitiveType type)
     engine->RegisterObjectMethod(className, "void BeginGeometry(uint, PrimitiveType)", AS_METHODPR(T, BeginGeometry, (unsigned, PrimitiveType), void), AS_CALL_THISCALL);
@@ -21855,10 +21918,10 @@ template <class T> void RegisterMembers_DecalSet(asIScriptEngine* engine, const 
 {
     RegisterMembers_Drawable<T>(engine, className);
 
-    // PODVector<unsigned char> DecalSet::GetDecalsAttr() const
-    // Error: type "PODVector<unsigned char>" can not automatically bind
-    // void DecalSet::SetDecalsAttr(const PODVector<unsigned char>& value)
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
+    // Vector<unsigned char> DecalSet::GetDecalsAttr() const
+    // Error: type "Vector<unsigned char>" can not automatically bind
+    // void DecalSet::SetDecalsAttr(const Vector<unsigned char>& value)
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
 
     // bool DecalSet::AddDecal(Drawable* target, const Vector3& worldPosition, const Quaternion& worldRotation, float size, float aspectRatio, float depth, const Vector2& topLeftUV, const Vector2& bottomRightUV, float timeToLive = 0.0f, float normalCutoff = 0.1f, unsigned subGeometry = M_MAX_UNSIGNED)
     engine->RegisterObjectMethod(className, "bool AddDecal(Drawable@+, const Vector3&in, const Quaternion&in, float, float, float, const Vector2&in, const Vector2&in, float = 0.0f, float = 0.1f, uint = M_MAX_UNSIGNED)", AS_METHODPR(T, AddDecal, (Drawable*, const Vector3&, const Quaternion&, float, float, float, const Vector2&, const Vector2&, float, float, unsigned), bool), AS_CALL_THISCALL);
@@ -22265,31 +22328,31 @@ template <class T> void RegisterMembers_LineEdit(asIScriptEngine* engine, const 
     #endif
 }
 
-// PODVector<UIElement*> ListView::GetItems() const
-template <class T> CScriptArray* ListView_PODVectorlesUIElementstargre_GetItems_void_template(T* _ptr)
+// Vector<UIElement*> ListView::GetItems() const
+template <class T> CScriptArray* ListView_VectorlesUIElementstargre_GetItems_void_template(T* _ptr)
 {
-    PODVector<UIElement*> result = _ptr->GetItems();
+    Vector<UIElement*> result = _ptr->GetItems();
     return VectorToHandleArray(result, "Array<UIElement@>");
 }
 
-// PODVector<UIElement*> ListView::GetSelectedItems() const
-template <class T> CScriptArray* ListView_PODVectorlesUIElementstargre_GetSelectedItems_void_template(T* _ptr)
+// Vector<UIElement*> ListView::GetSelectedItems() const
+template <class T> CScriptArray* ListView_VectorlesUIElementstargre_GetSelectedItems_void_template(T* _ptr)
 {
-    PODVector<UIElement*> result = _ptr->GetSelectedItems();
+    Vector<UIElement*> result = _ptr->GetSelectedItems();
     return VectorToHandleArray(result, "Array<UIElement@>");
 }
 
-// const PODVector<unsigned>& ListView::GetSelections() const
-template <class T> CScriptArray* ListView_constspPODVectorlesunsignedgreamp_GetSelections_void_template(T* _ptr)
+// const Vector<unsigned>& ListView::GetSelections() const
+template <class T> CScriptArray* ListView_constspVectorlesunsignedgreamp_GetSelections_void_template(T* _ptr)
 {
-    const PODVector<unsigned>& result = _ptr->GetSelections();
+    const Vector<unsigned>& result = _ptr->GetSelections();
     return VectorToArray(result, "Array<uint>");
 }
 
-// void ListView::SetSelections(const PODVector<unsigned>& indices)
-template <class T> void ListView_void_SetSelections_constspPODVectorlesunsignedgreamp_template(T* _ptr, CScriptArray* indices_conv)
+// void ListView::SetSelections(const Vector<unsigned>& indices)
+template <class T> void ListView_void_SetSelections_constspVectorlesunsignedgreamp_template(T* _ptr, CScriptArray* indices_conv)
 {
-    PODVector<unsigned> indices = ArrayToVector<unsigned>(indices_conv);
+    Vector<unsigned> indices = ArrayToVector<unsigned>(indices_conv);
     _ptr->SetSelections(indices);
 }
 
@@ -22351,8 +22414,8 @@ template <class T> void RegisterMembers_ListView(asIScriptEngine* engine, const 
     engine->RegisterObjectMethod(className, "UIElement@+ GetItem(uint) const", AS_METHODPR(T, GetItem, (unsigned) const, UIElement*), AS_CALL_THISCALL);
     engine->RegisterObjectMethod(className, "UIElement@+ get_items(uint) const", AS_METHODPR(T, GetItem, (unsigned) const, UIElement*), AS_CALL_THISCALL);
 
-    // PODVector<UIElement*> ListView::GetItems() const
-    engine->RegisterObjectMethod(className, "Array<UIElement@>@ GetItems() const", AS_FUNCTION_OBJFIRST(ListView_PODVectorlesUIElementstargre_GetItems_void_template<ListView>), AS_CALL_CDECL_OBJFIRST);
+    // Vector<UIElement*> ListView::GetItems() const
+    engine->RegisterObjectMethod(className, "Array<UIElement@>@ GetItems() const", AS_FUNCTION_OBJFIRST(ListView_VectorlesUIElementstargre_GetItems_void_template<ListView>), AS_CALL_CDECL_OBJFIRST);
 
     // bool ListView::GetMultiselect() const
     engine->RegisterObjectMethod(className, "bool GetMultiselect() const", AS_METHODPR(T, GetMultiselect, () const, bool), AS_CALL_THISCALL);
@@ -22366,17 +22429,17 @@ template <class T> void RegisterMembers_ListView(asIScriptEngine* engine, const 
     engine->RegisterObjectMethod(className, "UIElement@+ GetSelectedItem() const", AS_METHODPR(T, GetSelectedItem, () const, UIElement*), AS_CALL_THISCALL);
     engine->RegisterObjectMethod(className, "UIElement@+ get_selectedItem() const", AS_METHODPR(T, GetSelectedItem, () const, UIElement*), AS_CALL_THISCALL);
 
-    // PODVector<UIElement*> ListView::GetSelectedItems() const
-    engine->RegisterObjectMethod(className, "Array<UIElement@>@ GetSelectedItems() const", AS_FUNCTION_OBJFIRST(ListView_PODVectorlesUIElementstargre_GetSelectedItems_void_template<ListView>), AS_CALL_CDECL_OBJFIRST);
-    engine->RegisterObjectMethod(className, "Array<UIElement@>@ get_selectedItems() const", AS_FUNCTION_OBJFIRST(ListView_PODVectorlesUIElementstargre_GetSelectedItems_void_template<ListView>), AS_CALL_CDECL_OBJFIRST);
+    // Vector<UIElement*> ListView::GetSelectedItems() const
+    engine->RegisterObjectMethod(className, "Array<UIElement@>@ GetSelectedItems() const", AS_FUNCTION_OBJFIRST(ListView_VectorlesUIElementstargre_GetSelectedItems_void_template<ListView>), AS_CALL_CDECL_OBJFIRST);
+    engine->RegisterObjectMethod(className, "Array<UIElement@>@ get_selectedItems() const", AS_FUNCTION_OBJFIRST(ListView_VectorlesUIElementstargre_GetSelectedItems_void_template<ListView>), AS_CALL_CDECL_OBJFIRST);
 
     // unsigned ListView::GetSelection() const
     engine->RegisterObjectMethod(className, "uint GetSelection() const", AS_METHODPR(T, GetSelection, () const, unsigned), AS_CALL_THISCALL);
     engine->RegisterObjectMethod(className, "uint get_selection() const", AS_METHODPR(T, GetSelection, () const, unsigned), AS_CALL_THISCALL);
 
-    // const PODVector<unsigned>& ListView::GetSelections() const
-    engine->RegisterObjectMethod(className, "Array<uint>@ GetSelections() const", AS_FUNCTION_OBJFIRST(ListView_constspPODVectorlesunsignedgreamp_GetSelections_void_template<ListView>), AS_CALL_CDECL_OBJFIRST);
-    engine->RegisterObjectMethod(className, "Array<uint>@ get_selections() const", AS_FUNCTION_OBJFIRST(ListView_constspPODVectorlesunsignedgreamp_GetSelections_void_template<ListView>), AS_CALL_CDECL_OBJFIRST);
+    // const Vector<unsigned>& ListView::GetSelections() const
+    engine->RegisterObjectMethod(className, "Array<uint>@ GetSelections() const", AS_FUNCTION_OBJFIRST(ListView_constspVectorlesunsignedgreamp_GetSelections_void_template<ListView>), AS_CALL_CDECL_OBJFIRST);
+    engine->RegisterObjectMethod(className, "Array<uint>@ get_selections() const", AS_FUNCTION_OBJFIRST(ListView_constspVectorlesunsignedgreamp_GetSelections_void_template<ListView>), AS_CALL_CDECL_OBJFIRST);
 
     // bool ListView::GetSelectOnClickEnd() const
     engine->RegisterObjectMethod(className, "bool GetSelectOnClickEnd() const", AS_METHODPR(T, GetSelectOnClickEnd, () const, bool), AS_CALL_THISCALL);
@@ -22427,8 +22490,8 @@ template <class T> void RegisterMembers_ListView(asIScriptEngine* engine, const 
     engine->RegisterObjectMethod(className, "void SetSelection(uint)", AS_METHODPR(T, SetSelection, (unsigned), void), AS_CALL_THISCALL);
     engine->RegisterObjectMethod(className, "void set_selection(uint)", AS_METHODPR(T, SetSelection, (unsigned), void), AS_CALL_THISCALL);
 
-    // void ListView::SetSelections(const PODVector<unsigned>& indices)
-    engine->RegisterObjectMethod(className, "void SetSelections(Array<uint>@+)", AS_FUNCTION_OBJFIRST(ListView_void_SetSelections_constspPODVectorlesunsignedgreamp_template<ListView>), AS_CALL_CDECL_OBJFIRST);
+    // void ListView::SetSelections(const Vector<unsigned>& indices)
+    engine->RegisterObjectMethod(className, "void SetSelections(Array<uint>@+)", AS_FUNCTION_OBJFIRST(ListView_void_SetSelections_constspVectorlesunsignedgreamp_template<ListView>), AS_CALL_CDECL_OBJFIRST);
 
     // void ListView::SetSelectOnClickEnd(bool enable)
     engine->RegisterObjectMethod(className, "void SetSelectOnClickEnd(bool)", AS_METHODPR(T, SetSelectOnClickEnd, (bool), void), AS_CALL_THISCALL);
@@ -22902,8 +22965,8 @@ template <class T> void RegisterMembers_TerrainPatch(asIScriptEngine* engine, co
 {
     RegisterMembers_Drawable<T>(engine, className);
 
-    // PODVector<float>& TerrainPatch::GetLodErrors()
-    // Error: type "PODVector<float>&" can not automatically bind
+    // Vector<float>& TerrainPatch::GetLodErrors()
+    // Error: type "Vector<float>&" can not automatically bind
 
     // const IntVector2& TerrainPatch::GetCoordinates() const
     engine->RegisterObjectMethod(className, "const IntVector2& GetCoordinates() const", AS_METHODPR(T, GetCoordinates, () const, const IntVector2&), AS_CALL_THISCALL);
@@ -23861,17 +23924,17 @@ template <class T> void RegisterMembers_CollisionBox2D(asIScriptEngine* engine, 
     #endif
 }
 
-// const PODVector<Vector2>& CollisionChain2D::GetVertices() const
-template <class T> CScriptArray* CollisionChain2D_constspPODVectorlesVector2greamp_GetVertices_void_template(T* _ptr)
+// const Vector<Vector2>& CollisionChain2D::GetVertices() const
+template <class T> CScriptArray* CollisionChain2D_constspVectorlesVector2greamp_GetVertices_void_template(T* _ptr)
 {
-    const PODVector<Vector2>& result = _ptr->GetVertices();
+    const Vector<Vector2>& result = _ptr->GetVertices();
     return VectorToArray(result, "Array<Vector2>");
 }
 
-// void CollisionChain2D::SetVertices(const PODVector<Vector2>& vertices)
-template <class T> void CollisionChain2D_void_SetVertices_constspPODVectorlesVector2greamp_template(T* _ptr, CScriptArray* vertices_conv)
+// void CollisionChain2D::SetVertices(const Vector<Vector2>& vertices)
+template <class T> void CollisionChain2D_void_SetVertices_constspVectorlesVector2greamp_template(T* _ptr, CScriptArray* vertices_conv)
 {
-    PODVector<Vector2> vertices = ArrayToVector<Vector2>(vertices_conv);
+    Vector<Vector2> vertices = ArrayToVector<Vector2>(vertices_conv);
     _ptr->SetVertices(vertices);
 }
 
@@ -23880,10 +23943,10 @@ template <class T> void RegisterMembers_CollisionChain2D(asIScriptEngine* engine
 {
     RegisterMembers_CollisionShape2D<T>(engine, className);
 
-    // PODVector<unsigned char> CollisionChain2D::GetVerticesAttr() const
-    // Error: type "PODVector<unsigned char>" can not automatically bind
-    // void CollisionChain2D::SetVerticesAttr(const PODVector<unsigned char>& value)
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
+    // Vector<unsigned char> CollisionChain2D::GetVerticesAttr() const
+    // Error: type "Vector<unsigned char>" can not automatically bind
+    // void CollisionChain2D::SetVerticesAttr(const Vector<unsigned char>& value)
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
 
     // bool CollisionChain2D::GetLoop() const
     engine->RegisterObjectMethod(className, "bool GetLoop() const", AS_METHODPR(T, GetLoop, () const, bool), AS_CALL_THISCALL);
@@ -23896,8 +23959,8 @@ template <class T> void RegisterMembers_CollisionChain2D(asIScriptEngine* engine
     engine->RegisterObjectMethod(className, "uint GetVertexCount() const", AS_METHODPR(T, GetVertexCount, () const, unsigned), AS_CALL_THISCALL);
     engine->RegisterObjectMethod(className, "uint get_vertexCount() const", AS_METHODPR(T, GetVertexCount, () const, unsigned), AS_CALL_THISCALL);
 
-    // const PODVector<Vector2>& CollisionChain2D::GetVertices() const
-    engine->RegisterObjectMethod(className, "Array<Vector2>@ GetVertices() const", AS_FUNCTION_OBJFIRST(CollisionChain2D_constspPODVectorlesVector2greamp_GetVertices_void_template<CollisionChain2D>), AS_CALL_CDECL_OBJFIRST);
+    // const Vector<Vector2>& CollisionChain2D::GetVertices() const
+    engine->RegisterObjectMethod(className, "Array<Vector2>@ GetVertices() const", AS_FUNCTION_OBJFIRST(CollisionChain2D_constspVectorlesVector2greamp_GetVertices_void_template<CollisionChain2D>), AS_CALL_CDECL_OBJFIRST);
 
     // void CollisionChain2D::SetLoop(bool loop)
     engine->RegisterObjectMethod(className, "void SetLoop(bool)", AS_METHODPR(T, SetLoop, (bool), void), AS_CALL_THISCALL);
@@ -23910,8 +23973,8 @@ template <class T> void RegisterMembers_CollisionChain2D(asIScriptEngine* engine
     engine->RegisterObjectMethod(className, "void SetVertexCount(uint)", AS_METHODPR(T, SetVertexCount, (unsigned), void), AS_CALL_THISCALL);
     engine->RegisterObjectMethod(className, "void set_vertexCount(uint)", AS_METHODPR(T, SetVertexCount, (unsigned), void), AS_CALL_THISCALL);
 
-    // void CollisionChain2D::SetVertices(const PODVector<Vector2>& vertices)
-    engine->RegisterObjectMethod(className, "void SetVertices(Array<Vector2>@+)", AS_FUNCTION_OBJFIRST(CollisionChain2D_void_SetVertices_constspPODVectorlesVector2greamp_template<CollisionChain2D>), AS_CALL_CDECL_OBJFIRST);
+    // void CollisionChain2D::SetVertices(const Vector<Vector2>& vertices)
+    engine->RegisterObjectMethod(className, "void SetVertices(Array<Vector2>@+)", AS_FUNCTION_OBJFIRST(CollisionChain2D_void_SetVertices_constspVectorlesVector2greamp_template<CollisionChain2D>), AS_CALL_CDECL_OBJFIRST);
 
     #ifdef REGISTER_MEMBERS_MANUAL_PART_CollisionChain2D
         REGISTER_MEMBERS_MANUAL_PART_CollisionChain2D();
@@ -23976,17 +24039,17 @@ template <class T> void RegisterMembers_CollisionEdge2D(asIScriptEngine* engine,
     #endif
 }
 
-// const PODVector<Vector2>& CollisionPolygon2D::GetVertices() const
-template <class T> CScriptArray* CollisionPolygon2D_constspPODVectorlesVector2greamp_GetVertices_void_template(T* _ptr)
+// const Vector<Vector2>& CollisionPolygon2D::GetVertices() const
+template <class T> CScriptArray* CollisionPolygon2D_constspVectorlesVector2greamp_GetVertices_void_template(T* _ptr)
 {
-    const PODVector<Vector2>& result = _ptr->GetVertices();
+    const Vector<Vector2>& result = _ptr->GetVertices();
     return VectorToArray(result, "Array<Vector2>");
 }
 
-// void CollisionPolygon2D::SetVertices(const PODVector<Vector2>& vertices)
-template <class T> void CollisionPolygon2D_void_SetVertices_constspPODVectorlesVector2greamp_template(T* _ptr, CScriptArray* vertices_conv)
+// void CollisionPolygon2D::SetVertices(const Vector<Vector2>& vertices)
+template <class T> void CollisionPolygon2D_void_SetVertices_constspVectorlesVector2greamp_template(T* _ptr, CScriptArray* vertices_conv)
 {
-    PODVector<Vector2> vertices = ArrayToVector<Vector2>(vertices_conv);
+    Vector<Vector2> vertices = ArrayToVector<Vector2>(vertices_conv);
     _ptr->SetVertices(vertices);
 }
 
@@ -23995,10 +24058,10 @@ template <class T> void RegisterMembers_CollisionPolygon2D(asIScriptEngine* engi
 {
     RegisterMembers_CollisionShape2D<T>(engine, className);
 
-    // PODVector<unsigned char> CollisionPolygon2D::GetVerticesAttr() const
-    // Error: type "PODVector<unsigned char>" can not automatically bind
-    // void CollisionPolygon2D::SetVerticesAttr(const PODVector<unsigned char>& value)
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
+    // Vector<unsigned char> CollisionPolygon2D::GetVerticesAttr() const
+    // Error: type "Vector<unsigned char>" can not automatically bind
+    // void CollisionPolygon2D::SetVerticesAttr(const Vector<unsigned char>& value)
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
 
     // const Vector2& CollisionPolygon2D::GetVertex(unsigned index) const
     engine->RegisterObjectMethod(className, "const Vector2& GetVertex(uint) const", AS_METHODPR(T, GetVertex, (unsigned) const, const Vector2&), AS_CALL_THISCALL);
@@ -24007,8 +24070,8 @@ template <class T> void RegisterMembers_CollisionPolygon2D(asIScriptEngine* engi
     engine->RegisterObjectMethod(className, "uint GetVertexCount() const", AS_METHODPR(T, GetVertexCount, () const, unsigned), AS_CALL_THISCALL);
     engine->RegisterObjectMethod(className, "uint get_vertexCount() const", AS_METHODPR(T, GetVertexCount, () const, unsigned), AS_CALL_THISCALL);
 
-    // const PODVector<Vector2>& CollisionPolygon2D::GetVertices() const
-    engine->RegisterObjectMethod(className, "Array<Vector2>@ GetVertices() const", AS_FUNCTION_OBJFIRST(CollisionPolygon2D_constspPODVectorlesVector2greamp_GetVertices_void_template<CollisionPolygon2D>), AS_CALL_CDECL_OBJFIRST);
+    // const Vector<Vector2>& CollisionPolygon2D::GetVertices() const
+    engine->RegisterObjectMethod(className, "Array<Vector2>@ GetVertices() const", AS_FUNCTION_OBJFIRST(CollisionPolygon2D_constspVectorlesVector2greamp_GetVertices_void_template<CollisionPolygon2D>), AS_CALL_CDECL_OBJFIRST);
 
     // void CollisionPolygon2D::SetVertex(unsigned index, const Vector2& vertex)
     engine->RegisterObjectMethod(className, "void SetVertex(uint, const Vector2&in)", AS_METHODPR(T, SetVertex, (unsigned, const Vector2&), void), AS_CALL_THISCALL);
@@ -24017,8 +24080,8 @@ template <class T> void RegisterMembers_CollisionPolygon2D(asIScriptEngine* engi
     engine->RegisterObjectMethod(className, "void SetVertexCount(uint)", AS_METHODPR(T, SetVertexCount, (unsigned), void), AS_CALL_THISCALL);
     engine->RegisterObjectMethod(className, "void set_vertexCount(uint)", AS_METHODPR(T, SetVertexCount, (unsigned), void), AS_CALL_THISCALL);
 
-    // void CollisionPolygon2D::SetVertices(const PODVector<Vector2>& vertices)
-    engine->RegisterObjectMethod(className, "void SetVertices(Array<Vector2>@+)", AS_FUNCTION_OBJFIRST(CollisionPolygon2D_void_SetVertices_constspPODVectorlesVector2greamp_template<CollisionPolygon2D>), AS_CALL_CDECL_OBJFIRST);
+    // void CollisionPolygon2D::SetVertices(const Vector<Vector2>& vertices)
+    engine->RegisterObjectMethod(className, "void SetVertices(Array<Vector2>@+)", AS_FUNCTION_OBJFIRST(CollisionPolygon2D_void_SetVertices_constspVectorlesVector2greamp_template<CollisionPolygon2D>), AS_CALL_CDECL_OBJFIRST);
 
     #ifdef REGISTER_MEMBERS_MANUAL_PART_CollisionPolygon2D
         REGISTER_MEMBERS_MANUAL_PART_CollisionPolygon2D();
@@ -24581,13 +24644,17 @@ template <class T> void RegisterMembers_ConstraintWheel2D(asIScriptEngine* engin
 
 #ifdef URHO3D_URHO2D
 
+// const Vector<SourceBatch2D>& Drawable2D::GetSourceBatches()
+template <class T> CScriptArray* Drawable2D_constspVectorlesSourceBatch2Dgreamp_GetSourceBatches_void_template(T* _ptr)
+{
+    const Vector<SourceBatch2D>& result = _ptr->GetSourceBatches();
+    return VectorToArray(result, "Array<SourceBatch2D>");
+}
+
 // class Drawable2D | File: ../Urho2D/Drawable2D.h
 template <class T> void RegisterMembers_Drawable2D(asIScriptEngine* engine, const char* className)
 {
     RegisterMembers_Drawable<T>(engine, className);
-
-    // const Vector<SourceBatch2D>& Drawable2D::GetSourceBatches()
-    // Error: type "const Vector<SourceBatch2D>&" can not automatically bind
 
     // int Drawable2D::GetLayer() const
     engine->RegisterObjectMethod(className, "int GetLayer() const", AS_METHODPR(T, GetLayer, () const, int), AS_CALL_THISCALL);
@@ -24596,6 +24663,9 @@ template <class T> void RegisterMembers_Drawable2D(asIScriptEngine* engine, cons
     // int Drawable2D::GetOrderInLayer() const
     engine->RegisterObjectMethod(className, "int GetOrderInLayer() const", AS_METHODPR(T, GetOrderInLayer, () const, int), AS_CALL_THISCALL);
     engine->RegisterObjectMethod(className, "int get_orderInLayer() const", AS_METHODPR(T, GetOrderInLayer, () const, int), AS_CALL_THISCALL);
+
+    // const Vector<SourceBatch2D>& Drawable2D::GetSourceBatches()
+    engine->RegisterObjectMethod(className, "Array<SourceBatch2D>@ GetSourceBatches()", AS_FUNCTION_OBJFIRST(Drawable2D_constspVectorlesSourceBatch2Dgreamp_GetSourceBatches_void_template<Drawable2D>), AS_CALL_CDECL_OBJFIRST);
 
     // void Drawable2D::SetLayer(int layer)
     engine->RegisterObjectMethod(className, "void SetLayer(int)", AS_METHODPR(T, SetLayer, (int), void), AS_CALL_THISCALL);
@@ -24644,6 +24714,13 @@ template <class T> CScriptArray* AnimatedModel_constspVectorlesSharedPtrlesAnima
     return VectorToHandleArray(result, "Array<AnimationState@>");
 }
 
+// const Vector<ModelMorph>& AnimatedModel::GetMorphs() const
+template <class T> CScriptArray* AnimatedModel_constspVectorlesModelMorphgreamp_GetMorphs_void_template(T* _ptr)
+{
+    const Vector<ModelMorph>& result = _ptr->GetMorphs();
+    return VectorToArray(result, "Array<ModelMorph>");
+}
+
 // const Vector<SharedPtr<VertexBuffer>>& AnimatedModel::GetMorphVertexBuffers() const
 template <class T> CScriptArray* AnimatedModel_constspVectorlesSharedPtrlesVertexBuffergregreamp_GetMorphVertexBuffers_void_template(T* _ptr)
 {
@@ -24660,20 +24737,18 @@ template <class T> void RegisterMembers_AnimatedModel(asIScriptEngine* engine, c
     // Error: type "VariantVector" can not automatically bind
     // VariantVector AnimatedModel::GetBonesEnabledAttr() const
     // Error: type "VariantVector" can not automatically bind
-    // const Vector<PODVector<unsigned>>& AnimatedModel::GetGeometryBoneMappings() const
-    // Error: type "const Vector<PODVector<unsigned>>&" can not automatically bind
-    // const Vector<PODVector<Matrix3x4>>& AnimatedModel::GetGeometrySkinMatrices() const
-    // Error: type "const Vector<PODVector<Matrix3x4>>&" can not automatically bind
-    // const Vector<ModelMorph>& AnimatedModel::GetMorphs() const
-    // Error: type "const Vector<ModelMorph>&" can not automatically bind
-    // const PODVector<unsigned char>& AnimatedModel::GetMorphsAttr() const
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
+    // const Vector<Vector<unsigned>>& AnimatedModel::GetGeometryBoneMappings() const
+    // Error: type "const Vector<Vector<unsigned>>&" can not automatically bind
+    // const Vector<Vector<Matrix3x4>>& AnimatedModel::GetGeometrySkinMatrices() const
+    // Error: type "const Vector<Vector<Matrix3x4>>&" can not automatically bind
+    // const Vector<unsigned char>& AnimatedModel::GetMorphsAttr() const
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
     // void AnimatedModel::SetAnimationStatesAttr(const VariantVector& value)
     // Error: type "const VariantVector&" can not automatically bind
     // void AnimatedModel::SetBonesEnabledAttr(const VariantVector& value)
     // Error: type "const VariantVector&" can not automatically bind
-    // void AnimatedModel::SetMorphsAttr(const PODVector<unsigned char>& value)
-    // Error: type "const PODVector<unsigned char>&" can not automatically bind
+    // void AnimatedModel::SetMorphsAttr(const Vector<unsigned char>& value)
+    // Error: type "const Vector<unsigned char>&" can not automatically bind
 
     // AnimationState* AnimatedModel::AddAnimationState(Animation* animation)
     engine->RegisterObjectMethod(className, "AnimationState@+ AddAnimationState(Animation@+)", AS_METHODPR(T, AddAnimationState, (Animation*), AnimationState*), AS_CALL_THISCALL);
@@ -24700,6 +24775,9 @@ template <class T> void RegisterMembers_AnimatedModel(asIScriptEngine* engine, c
 
     // const Vector<SharedPtr<AnimationState>>& AnimatedModel::GetAnimationStates() const
     engine->RegisterObjectMethod(className, "Array<AnimationState@>@ GetAnimationStates() const", AS_FUNCTION_OBJFIRST(AnimatedModel_constspVectorlesSharedPtrlesAnimationStategregreamp_GetAnimationStates_void_template<AnimatedModel>), AS_CALL_CDECL_OBJFIRST);
+
+    // const Vector<ModelMorph>& AnimatedModel::GetMorphs() const
+    engine->RegisterObjectMethod(className, "Array<ModelMorph>@ GetMorphs() const", AS_FUNCTION_OBJFIRST(AnimatedModel_constspVectorlesModelMorphgreamp_GetMorphs_void_template<AnimatedModel>), AS_CALL_CDECL_OBJFIRST);
 
     // const Vector<SharedPtr<VertexBuffer>>& AnimatedModel::GetMorphVertexBuffers() const
     engine->RegisterObjectMethod(className, "Array<VertexBuffer@>@ GetMorphVertexBuffers() const", AS_FUNCTION_OBJFIRST(AnimatedModel_constspVectorlesSharedPtrlesVertexBuffergregreamp_GetMorphVertexBuffers_void_template<AnimatedModel>), AS_CALL_CDECL_OBJFIRST);
@@ -25215,10 +25293,10 @@ template <class T> void RegisterMembers_StaticSprite2D(asIScriptEngine* engine, 
 
 #endif // def URHO3D_URHO2D
 
-// PODVector<UIElement*> DropDownList::GetItems() const
-template <class T> CScriptArray* DropDownList_PODVectorlesUIElementstargre_GetItems_void_template(T* _ptr)
+// Vector<UIElement*> DropDownList::GetItems() const
+template <class T> CScriptArray* DropDownList_VectorlesUIElementstargre_GetItems_void_template(T* _ptr)
 {
-    PODVector<UIElement*> result = _ptr->GetItems();
+    Vector<UIElement*> result = _ptr->GetItems();
     return VectorToHandleArray(result, "Array<UIElement@>");
 }
 
@@ -25234,8 +25312,8 @@ template <class T> void RegisterMembers_DropDownList(asIScriptEngine* engine, co
     engine->RegisterObjectMethod(className, "UIElement@+ GetItem(uint) const", AS_METHODPR(T, GetItem, (unsigned) const, UIElement*), AS_CALL_THISCALL);
     engine->RegisterObjectMethod(className, "UIElement@+ get_items(uint) const", AS_METHODPR(T, GetItem, (unsigned) const, UIElement*), AS_CALL_THISCALL);
 
-    // PODVector<UIElement*> DropDownList::GetItems() const
-    engine->RegisterObjectMethod(className, "Array<UIElement@>@ GetItems() const", AS_FUNCTION_OBJFIRST(DropDownList_PODVectorlesUIElementstargre_GetItems_void_template<DropDownList>), AS_CALL_CDECL_OBJFIRST);
+    // Vector<UIElement*> DropDownList::GetItems() const
+    engine->RegisterObjectMethod(className, "Array<UIElement@>@ GetItems() const", AS_FUNCTION_OBJFIRST(DropDownList_VectorlesUIElementstargre_GetItems_void_template<DropDownList>), AS_CALL_CDECL_OBJFIRST);
 
     // ListView* DropDownList::GetListView() const
     engine->RegisterObjectMethod(className, "ListView@+ GetListView() const", AS_METHODPR(T, GetListView, () const, ListView*), AS_CALL_THISCALL);

--- a/Source/Urho3D/AngelScript/Manual_Graphics.h
+++ b/Source/Urho3D/AngelScript/Manual_Graphics.h
@@ -366,7 +366,7 @@ template <class T> Node* RayQueryResult_GetNode(T* ptr)
 // void Octree::Raycast(RayOctreeQuery& query) const | File: ../Graphics/Octree.h
 template <class T> CScriptArray* Octree_Raycast(const Ray& ray, RayQueryLevel level, float maxDistance, unsigned char drawableFlags, unsigned viewMask, Octree* ptr)
 {
-    PODVector<RayQueryResult> result;
+    Vector<RayQueryResult> result;
     RayOctreeQuery query(result, ray, level, maxDistance, drawableFlags, viewMask);
     ptr->Raycast(query);
     return VectorToArray<RayQueryResult>(result, "Array<RayQueryResult>");
@@ -375,7 +375,7 @@ template <class T> CScriptArray* Octree_Raycast(const Ray& ray, RayQueryLevel le
 // void Octree::RaycastSingle(RayOctreeQuery& query) const | File: ../Graphics/Octree.h
 template <class T> RayQueryResult Octree_RaycastSingle(const Ray& ray, RayQueryLevel level, float maxDistance, unsigned char drawableFlags, unsigned viewMask, Octree* ptr)
 {
-    PODVector<RayQueryResult> result;
+    Vector<RayQueryResult> result;
     RayOctreeQuery query(result, ray, level, maxDistance, drawableFlags, viewMask);
     ptr->RaycastSingle(query);
 
@@ -397,7 +397,7 @@ template <class T> RayQueryResult Octree_RaycastSingle(const Ray& ray, RayQueryL
 // void Octree::GetDrawables(OctreeQuery& query) const | File: ../Graphics/Octree.h
 template <class T> CScriptArray* Octree_GetDrawables_Point(const Vector3& point, unsigned char drawableFlags, unsigned viewMask, Octree* ptr)
 {
-    PODVector<Drawable*> result;
+    Vector<Drawable*> result;
     PointOctreeQuery query(result, point, drawableFlags, viewMask);
     ptr->GetDrawables(query);
     return VectorToHandleArray<Drawable>(result, "Array<Drawable@>");
@@ -406,7 +406,7 @@ template <class T> CScriptArray* Octree_GetDrawables_Point(const Vector3& point,
 // void Octree::GetDrawables(OctreeQuery& query) const | File: ../Graphics/Octree.h
 template <class T> CScriptArray* Octree_GetDrawables_Box(const BoundingBox& box, unsigned char drawableFlags, unsigned viewMask, Octree* ptr)
 {
-    PODVector<Drawable*> result;
+    Vector<Drawable*> result;
     BoxOctreeQuery query(result, box, drawableFlags, viewMask);
     ptr->GetDrawables(query);
     return VectorToHandleArray<Drawable>(result, "Array<Drawable@>");
@@ -415,7 +415,7 @@ template <class T> CScriptArray* Octree_GetDrawables_Box(const BoundingBox& box,
 // void Octree::GetDrawables(OctreeQuery& query) const | File: ../Graphics/Octree.h
 template <class T> CScriptArray* Octree_GetDrawables_Frustum(const Frustum& frustum, unsigned char drawableFlags, unsigned viewMask, Octree* ptr)
 {
-    PODVector<Drawable*> result;
+    Vector<Drawable*> result;
     FrustumOctreeQuery query(result, frustum, drawableFlags, viewMask);
     ptr->GetDrawables(query);
     return VectorToHandleArray<Drawable>(result, "Array<Drawable@>");
@@ -424,7 +424,7 @@ template <class T> CScriptArray* Octree_GetDrawables_Frustum(const Frustum& frus
 // void Octree::GetDrawables(OctreeQuery& query) const | File: ../Graphics/Octree.h
 template <class T> CScriptArray* Octree_GetDrawables_Sphere(const Sphere& sphere, unsigned char drawableFlags, unsigned viewMask, Octree* ptr)
 {
-    PODVector<Drawable*> result;
+    Vector<Drawable*> result;
     SphereOctreeQuery query(result, sphere, drawableFlags, viewMask);
     ptr->GetDrawables(query);
     return VectorToHandleArray<Drawable>(result, "Array<Drawable@>");
@@ -433,7 +433,7 @@ template <class T> CScriptArray* Octree_GetDrawables_Sphere(const Sphere& sphere
 // void Octree::GetDrawables(OctreeQuery& query) const | File: ../Graphics/Octree.h
 template <class T> CScriptArray* Octree_GetDrawables_All(unsigned char drawableFlags, unsigned viewMask, Octree* ptr)
 {
-    PODVector<Drawable*> result;
+    Vector<Drawable*> result;
     AllContentOctreeQuery query(result, drawableFlags, viewMask);
     ptr->GetDrawables(query);
     return VectorToHandleArray<Drawable>(result, "Array<Drawable@>");

--- a/Source/Urho3D/AngelScript/Manual_IO.h
+++ b/Source/Urho3D/AngelScript/Manual_IO.h
@@ -13,7 +13,7 @@ namespace Urho3D
 // virtual unsigned Deserializer::Read(void* dest, unsigned size) = 0 | File: ../IO/Deserializer.h
 template <class T> CScriptArray* Deserializer_Read(unsigned size, T* ptr)
 {
-    PODVector<unsigned char> vector(size);
+    Vector<unsigned char> vector(size);
     unsigned bytesRead = size ? ptr->Read(&vector[0], size) : 0;
     vector.Resize(bytesRead);
     return VectorToArray(vector, "Array<uint8>");

--- a/Source/Urho3D/AngelScript/Manual_Math.h
+++ b/Source/Urho3D/AngelScript/Manual_Math.h
@@ -189,23 +189,23 @@ template <class T> Vector3 Frustum_GetVertex(unsigned index, T* ptr)
 
 // ========================================================================================
 
-// Vector<PODVector<Vector3>> Polyhedron::faces_ | File: ../Math/Polyhedron.h
+// Vector<Vector<Vector3>> Polyhedron::faces_ | File: ../Math/Polyhedron.h
 template <class T> unsigned Polyhedron_GetNumFaces(T* ptr)
 {
     return ptr->faces_.Size();
 }
 
-// Vector<PODVector<Vector3>> Polyhedron::faces_ | File: ../Math/Polyhedron.h
+// Vector<Vector<Vector3>> Polyhedron::faces_ | File: ../Math/Polyhedron.h
 template <class T> CScriptArray* Polyhedron_GetFace(unsigned index, T* ptr)
 {
-    PODVector<Vector3> face;
+    Vector<Vector3> face;
     if (index < ptr->faces_.Size())
         face = ptr->faces_[index];
     return VectorToArray<Vector3>(face, "Array<Vector3>");
 }
 
 #define REGISTER_MEMBERS_MANUAL_PART_Polyhedron() \
-    /* Vector<PODVector<Vector3>> Polyhedron::faces_ | File: ../Math/Polyhedron.h */ \
+    /* Vector<Vector<Vector3>> Polyhedron::faces_ | File: ../Math/Polyhedron.h */ \
     engine->RegisterObjectMethod(className, "uint get_numFaces() const", AS_FUNCTION_OBJLAST(Polyhedron_GetNumFaces<T>), AS_CALL_CDECL_OBJLAST); \
     engine->RegisterObjectMethod(className, "Array<Vector3>@ get_face(uint) const", AS_FUNCTION_OBJLAST(Polyhedron_GetFace<T>), AS_CALL_CDECL_OBJLAST);
 

--- a/Source/Urho3D/AngelScript/Manual_Navigation.h
+++ b/Source/Urho3D/AngelScript/Manual_Navigation.h
@@ -13,7 +13,7 @@
 namespace Urho3D
 {
 
-// virtual PODVector<unsigned char> NavigationMesh::GetTileData(const IntVector2& tile) const | File: ../Navigation/NavigationMesh.h
+// virtual Vector<unsigned char> NavigationMesh::GetTileData(const IntVector2& tile) const | File: ../Navigation/NavigationMesh.h
 template <class T> VectorBuffer NavigationMesh_GetTileData(const IntVector2& tile, const T* ptr)
 {
     VectorBuffer buffer;
@@ -21,7 +21,7 @@ template <class T> VectorBuffer NavigationMesh_GetTileData(const IntVector2& til
     return buffer;
 }
 
-// virtual bool NavigationMesh::AddTile(const PODVector<unsigned char>& tileData) | File: ../Navigation/NavigationMesh.h
+// virtual bool NavigationMesh::AddTile(const Vector<unsigned char>& tileData) | File: ../Navigation/NavigationMesh.h
 template <class T> bool NavigationMesh_AddTile(const VectorBuffer& tileData, T* ptr)
 {
     return ptr->AddTile(tileData.GetBuffer());
@@ -63,19 +63,19 @@ template <class T> Vector3 NavigationMesh_MoveAlongSurface(const Vector3& start,
     return ptr->MoveAlongSurface(start, end, extents, maxVisited);
 }
 
-// void NavigationMesh::FindPath(PODVector<Vector3>& dest, const Vector3& start, const Vector3& end, const Vector3& extents = Vector3::ONE, const dtQueryFilter* filter = nullptr) | File: ../Navigation/NavigationMesh.h
+// void NavigationMesh::FindPath(Vector<Vector3>& dest, const Vector3& start, const Vector3& end, const Vector3& extents = Vector3::ONE, const dtQueryFilter* filter = nullptr) | File: ../Navigation/NavigationMesh.h
 template <class T> CScriptArray* NavigationMesh_FindPath(const Vector3& start, const Vector3& end, const Vector3& extents, T* ptr)
 {
-    PODVector<Vector3> dest;
+    Vector<Vector3> dest;
     ptr->FindPath(dest, start, end, extents);
     return VectorToArray<Vector3>(dest, "Array<Vector3>");
 }
 
 #define REGISTER_MEMBERS_MANUAL_PART_NavigationMesh() \
-    /* virtual PODVector<unsigned char> NavigationMesh::GetTileData(const IntVector2& tile) const | File: ../Navigation/NavigationMesh.h */ \
+    /* virtual Vector<unsigned char> NavigationMesh::GetTileData(const IntVector2& tile) const | File: ../Navigation/NavigationMesh.h */ \
     engine->RegisterObjectMethod(className, "VectorBuffer GetTileData(const IntVector2&) const", AS_FUNCTION_OBJLAST(NavigationMesh_GetTileData<T>), AS_CALL_CDECL_OBJLAST); \
     \
-    /* virtual bool NavigationMesh::AddTile(const PODVector<unsigned char>& tileData) | File: ../Navigation/NavigationMesh.h */ \
+    /* virtual bool NavigationMesh::AddTile(const Vector<unsigned char>& tileData) | File: ../Navigation/NavigationMesh.h */ \
     engine->RegisterObjectMethod(className, "bool AddTile(const VectorBuffer&in) const", AS_FUNCTION_OBJLAST(NavigationMesh_AddTile<T>), AS_CALL_CDECL_OBJLAST); \
     \
     /* Vector3 NavigationMesh::FindNearestPoint(const Vector3& point, const Vector3& extents = Vector3::ONE, const dtQueryFilter* filter = nullptr, dtPolyRef* nearestRef = nullptr) | File: ../Navigation/NavigationMesh.h */ \
@@ -96,7 +96,7 @@ template <class T> CScriptArray* NavigationMesh_FindPath(const Vector3& start, c
     /* Vector3 NavigationMesh::MoveAlongSurface(const Vector3& start, const Vector3& end, const Vector3& extents = Vector3::ONE, int maxVisited = 3, const dtQueryFilter* filter = nullptr)  | File: ../Navigation/NavigationMesh.h */ \
     engine->RegisterObjectMethod(className, "Vector3 MoveAlongSurface(const Vector3&in, const Vector3&in, const Vector3&in = Vector3::ONE, int = 3)", AS_FUNCTION_OBJLAST(NavigationMesh_MoveAlongSurface<T>), AS_CALL_CDECL_OBJLAST); \
     \
-    /* void NavigationMesh::FindPath(PODVector<Vector3>& dest, const Vector3& start, const Vector3& end, const Vector3& extents = Vector3::ONE, const dtQueryFilter* filter = nullptr) | File: ../Navigation/NavigationMesh.h */ \
+    /* void NavigationMesh::FindPath(Vector<Vector3>& dest, const Vector3& start, const Vector3& end, const Vector3& extents = Vector3::ONE, const dtQueryFilter* filter = nullptr) | File: ../Navigation/NavigationMesh.h */ \
     engine->RegisterObjectMethod(className, "Array<Vector3>@ FindPath(const Vector3&in, const Vector3&in, const Vector3&in extents = Vector3::ONE)", AS_FUNCTION_OBJLAST(NavigationMesh_FindPath<T>), AS_CALL_CDECL_OBJLAST);
 
 // ========================================================================================

--- a/Source/Urho3D/AngelScript/Manual_Physics.h
+++ b/Source/Urho3D/AngelScript/Manual_Physics.h
@@ -27,24 +27,24 @@ template <class T> RigidBody* PhysicsRaycastResult_GetRigidBody(T* ptr)
 
 // ========================================================================================
 
-// void RigidBody::GetCollidingBodies(PODVector<RigidBody*>& result) const | File: ../Physics/RigidBody.h
+// void RigidBody::GetCollidingBodies(Vector<RigidBody*>& result) const | File: ../Physics/RigidBody.h
 template <class T> CScriptArray* RigidBody_GetCollidingBodies(T* ptr)
 {
-    PODVector<RigidBody*> result;
+    Vector<RigidBody*> result;
     ptr->GetCollidingBodies(result);
     return VectorToHandleArray<RigidBody>(result, "Array<RigidBody@>");
 }
 
 #define REGISTER_MEMBERS_MANUAL_PART_RigidBody() \
-    /* void RigidBody::GetCollidingBodies(PODVector<RigidBody*>& result) const | File: ../Physics/RigidBody.h */ \
+    /* void RigidBody::GetCollidingBodies(Vector<RigidBody*>& result) const | File: ../Physics/RigidBody.h */ \
     engine->RegisterObjectMethod(className, "Array<RigidBody@>@ get_collidingBodies() const", AS_FUNCTION_OBJLAST(RigidBody_GetCollidingBodies<T>), AS_CALL_CDECL_OBJLAST);
 
 // ========================================================================================
 
-// void PhysicsWorld::Raycast(PODVector<PhysicsRaycastResult>& result, const Ray& ray, float maxDistance, unsigned collisionMask = M_MAX_UNSIGNED) | File: ../Physics/PhysicsWorld.h
+// void PhysicsWorld::Raycast(Vector<PhysicsRaycastResult>& result, const Ray& ray, float maxDistance, unsigned collisionMask = M_MAX_UNSIGNED) | File: ../Physics/PhysicsWorld.h
 template <class T> CScriptArray* PhysicsWorld_Raycast(const Ray& ray, float maxDistance, unsigned collisionMask, T* ptr)
 {
-    PODVector<PhysicsRaycastResult> result;
+    Vector<PhysicsRaycastResult> result;
     ptr->Raycast(result, ray, maxDistance, collisionMask);
     return VectorToArray<PhysicsRaycastResult>(result, "Array<PhysicsRaycastResult>");
 }
@@ -73,34 +73,34 @@ template <class T> PhysicsRaycastResult PhysicsWorld_SphereCast(const Ray& ray, 
     return result;
 }
 
-// void PhysicsWorld::GetRigidBodies(PODVector<RigidBody*>& result, const Sphere& sphere, unsigned collisionMask = M_MAX_UNSIGNED) | File: ../Physics/PhysicsWorld.h
+// void PhysicsWorld::GetRigidBodies(Vector<RigidBody*>& result, const Sphere& sphere, unsigned collisionMask = M_MAX_UNSIGNED) | File: ../Physics/PhysicsWorld.h
 template <class T> CScriptArray* PhysicsWorld_GetRigidBodies_Sphere(const Sphere& sphere, unsigned collisionMask, T* ptr)
 {
-    PODVector<RigidBody*> result;
+    Vector<RigidBody*> result;
     ptr->GetRigidBodies(result, sphere, collisionMask);
     return VectorToHandleArray<RigidBody>(result, "Array<RigidBody@>");
 }
 
-// void PhysicsWorld::GetRigidBodies(PODVector<RigidBody*>& result, const BoundingBox& box, unsigned collisionMask = M_MAX_UNSIGNED) | File: ../Physics/PhysicsWorld.h
+// void PhysicsWorld::GetRigidBodies(Vector<RigidBody*>& result, const BoundingBox& box, unsigned collisionMask = M_MAX_UNSIGNED) | File: ../Physics/PhysicsWorld.h
 template <class T> CScriptArray* PhysicsWorld_GetRigidBodies_Box(const BoundingBox& box, unsigned collisionMask, T* ptr)
 {
-    PODVector<RigidBody*> result;
+    Vector<RigidBody*> result;
     ptr->GetRigidBodies(result, box, collisionMask);
     return VectorToHandleArray<RigidBody>(result, "Array<RigidBody@>");
 }
 
-// void PhysicsWorld::GetRigidBodies(PODVector<RigidBody*>& result, const RigidBody* body) | File: ../Physics/PhysicsWorld.h
+// void PhysicsWorld::GetRigidBodies(Vector<RigidBody*>& result, const RigidBody* body) | File: ../Physics/PhysicsWorld.h
 template <class T> CScriptArray* PhysicsWorld_GetRigidBodies_Body(RigidBody* body, T* ptr)
 {
-    PODVector<RigidBody*> result;
+    Vector<RigidBody*> result;
     ptr->GetRigidBodies(result, body);
     return VectorToHandleArray<RigidBody>(result, "Array<RigidBody@>");
 }
 
-// void PhysicsWorld::GetCollidingBodies(PODVector<RigidBody*>& result, const RigidBody* body) | File: ../Physics/PhysicsWorld.h
+// void PhysicsWorld::GetCollidingBodies(Vector<RigidBody*>& result, const RigidBody* body) | File: ../Physics/PhysicsWorld.h
 template <class T> CScriptArray* PhysicsWorld_GetCollidingBodies(RigidBody* body, T* ptr)
 {
-    PODVector<RigidBody*> result;
+    Vector<RigidBody*> result;
     ptr->GetCollidingBodies(result, body);
     return VectorToHandleArray<RigidBody>(result, "Array<RigidBody@>");
 }
@@ -117,7 +117,7 @@ template <class T> PhysicsRaycastResult PhysicsWorld_ConvexCast(CollisionShape* 
 }
 
 #define REGISTER_MEMBERS_MANUAL_PART_PhysicsWorld() \
-    /* void PhysicsWorld::Raycast(PODVector<PhysicsRaycastResult>& result, const Ray& ray, float maxDistance, unsigned collisionMask = M_MAX_UNSIGNED) | File: ../Physics/PhysicsWorld.h */ \
+    /* void PhysicsWorld::Raycast(Vector<PhysicsRaycastResult>& result, const Ray& ray, float maxDistance, unsigned collisionMask = M_MAX_UNSIGNED) | File: ../Physics/PhysicsWorld.h */ \
     engine->RegisterObjectMethod(className, "Array<PhysicsRaycastResult>@ Raycast(const Ray&in, float, uint = 0xffff)", AS_FUNCTION_OBJLAST(PhysicsWorld_Raycast<T>), AS_CALL_CDECL_OBJLAST); \
     \
     /* void PhysicsWorld::RaycastSingle(PhysicsRaycastResult& result, const Ray& ray, float maxDistance, unsigned collisionMask = M_MAX_UNSIGNED) | File: ../Physics/PhysicsWorld.h */ \
@@ -129,16 +129,16 @@ template <class T> PhysicsRaycastResult PhysicsWorld_ConvexCast(CollisionShape* 
     /* void PhysicsWorld::SphereCast(PhysicsRaycastResult& result, const Ray& ray, float radius, float maxDistance, unsigned collisionMask = M_MAX_UNSIGNED) | File: ../Physics/PhysicsWorld.h */ \
     engine->RegisterObjectMethod(className, "PhysicsRaycastResult SphereCast(const Ray&in, float, float, uint collisionMask = 0xffff)", AS_FUNCTION_OBJLAST(PhysicsWorld_SphereCast<T>), AS_CALL_CDECL_OBJLAST); \
     \
-    /* void PhysicsWorld::GetRigidBodies(PODVector<RigidBody*>& result, const Sphere& sphere, unsigned collisionMask = M_MAX_UNSIGNED) | File: ../Physics/PhysicsWorld.h */ \
+    /* void PhysicsWorld::GetRigidBodies(Vector<RigidBody*>& result, const Sphere& sphere, unsigned collisionMask = M_MAX_UNSIGNED) | File: ../Physics/PhysicsWorld.h */ \
     engine->RegisterObjectMethod(className, "Array<RigidBody@>@ GetRigidBodies(const Sphere&in, uint = 0xffff)", AS_FUNCTION_OBJLAST(PhysicsWorld_GetRigidBodies_Sphere<T>), AS_CALL_CDECL_OBJLAST); \
     \
-    /* void PhysicsWorld::GetRigidBodies(PODVector<RigidBody*>& result, const BoundingBox& box, unsigned collisionMask = M_MAX_UNSIGNED) | File: ../Physics/PhysicsWorld.h */ \
+    /* void PhysicsWorld::GetRigidBodies(Vector<RigidBody*>& result, const BoundingBox& box, unsigned collisionMask = M_MAX_UNSIGNED) | File: ../Physics/PhysicsWorld.h */ \
     engine->RegisterObjectMethod(className, "Array<RigidBody@>@ GetRigidBodies(const BoundingBox&in, uint collisionMask = 0xffff)", AS_FUNCTION_OBJLAST(PhysicsWorld_GetRigidBodies_Box<T>), AS_CALL_CDECL_OBJLAST); \
     \
-    /* void PhysicsWorld::GetRigidBodies(PODVector<RigidBody*>& result, const RigidBody* body) | File: ../Physics/PhysicsWorld.h */ \
+    /* void PhysicsWorld::GetRigidBodies(Vector<RigidBody*>& result, const RigidBody* body) | File: ../Physics/PhysicsWorld.h */ \
     engine->RegisterObjectMethod(className, "Array<RigidBody@>@ GetRigidBodies(RigidBody@+)", AS_FUNCTION_OBJLAST(PhysicsWorld_GetRigidBodies_Body<T>), AS_CALL_CDECL_OBJLAST); \
     \
-    /* void PhysicsWorld::GetCollidingBodies(PODVector<RigidBody*>& result, const RigidBody* body) | File: ../Physics/PhysicsWorld.h */ \
+    /* void PhysicsWorld::GetCollidingBodies(Vector<RigidBody*>& result, const RigidBody* body) | File: ../Physics/PhysicsWorld.h */ \
     engine->RegisterObjectMethod(className, "Array<RigidBody@>@ GetCollidingBodies(RigidBody@+)", AS_FUNCTION_OBJLAST(PhysicsWorld_GetCollidingBodies<T>), AS_CALL_CDECL_OBJLAST); \
     \
     /* There seems to be a bug in AngelScript resulting in a crash if we use an auto handle with this function. */    \

--- a/Source/Urho3D/AngelScript/Manual_Physics2D.h
+++ b/Source/Urho3D/AngelScript/Manual_Physics2D.h
@@ -25,10 +25,10 @@ template <class T> RigidBody2D* PhysicsRaycastResult2D_GetBody(T* ptr)
 
 // ========================================================================================
 
-// void PhysicsWorld2D::Raycast(PODVector<PhysicsRaycastResult2D>& results, const Vector2& startPoint, const Vector2& endPoint, unsigned collisionMask = M_MAX_UNSIGNED) | File: ../Urho2D/PhysicsWorld2D.h
+// void PhysicsWorld2D::Raycast(Vector<PhysicsRaycastResult2D>& results, const Vector2& startPoint, const Vector2& endPoint, unsigned collisionMask = M_MAX_UNSIGNED) | File: ../Urho2D/PhysicsWorld2D.h
 template <class T> CScriptArray* PhysicsWorld2D_Raycast(const Vector2& startPoint, const Vector2& endPoint, unsigned collisionMask, T* ptr)
 {
-    PODVector<PhysicsRaycastResult2D> result;
+    Vector<PhysicsRaycastResult2D> result;
     ptr->Raycast(result, startPoint, endPoint, collisionMask);
     return VectorToArray<PhysicsRaycastResult2D>(result, "Array<PhysicsRaycastResult2D>");
 }
@@ -41,22 +41,22 @@ template <class T> PhysicsRaycastResult2D PhysicsWorld2D_RaycastSingle(const Vec
     return result;
 }
 
-// void PhysicsWorld2D::GetRigidBodies(PODVector<RigidBody2D*>& results, const Rect& aabb, unsigned collisionMask = M_MAX_UNSIGNED) | File: ../Urho2D/PhysicsWorld2D.h
+// void PhysicsWorld2D::GetRigidBodies(Vector<RigidBody2D*>& results, const Rect& aabb, unsigned collisionMask = M_MAX_UNSIGNED) | File: ../Urho2D/PhysicsWorld2D.h
 template <class T> CScriptArray* PhysicsWorld2D_GetRigidBodies(const Rect& aabb, unsigned collisionMask, T* ptr)
 {
-    PODVector<RigidBody2D*> results;
+    Vector<RigidBody2D*> results;
     ptr->GetRigidBodies(results, aabb, collisionMask);
     return VectorToHandleArray<RigidBody2D>(results, "Array<RigidBody2D@>");
 }
 
 #define REGISTER_MEMBERS_MANUAL_PART_PhysicsWorld2D() \
-    /* void PhysicsWorld2D::Raycast(PODVector<PhysicsRaycastResult2D>& results, const Vector2& startPoint, const Vector2& endPoint, unsigned collisionMask = M_MAX_UNSIGNED) */ \
+    /* void PhysicsWorld2D::Raycast(Vector<PhysicsRaycastResult2D>& results, const Vector2& startPoint, const Vector2& endPoint, unsigned collisionMask = M_MAX_UNSIGNED) */ \
     engine->RegisterObjectMethod(className, "Array<PhysicsRaycastResult2D>@ Raycast(const Vector2&, const Vector2&, uint = 0xffff)", AS_FUNCTION_OBJLAST(PhysicsWorld2D_Raycast<T>), AS_CALL_CDECL_OBJLAST); \
     \
     /* void PhysicsWorld2D::RaycastSingle(PhysicsRaycastResult2D& result, const Vector2& startPoint, const Vector2& endPoint, unsigned collisionMask = M_MAX_UNSIGNED) | File: ../Urho2D/PhysicsWorld2D.h */ \
     engine->RegisterObjectMethod(className, "PhysicsRaycastResult2D RaycastSingle(const Vector2&, const Vector2&, uint = 0xffff)", AS_FUNCTION_OBJLAST(PhysicsWorld2D_RaycastSingle<T>), AS_CALL_CDECL_OBJLAST); \
     \
-    /* void PhysicsWorld2D::GetRigidBodies(PODVector<RigidBody2D*>& results, const Rect& aabb, unsigned collisionMask = M_MAX_UNSIGNED) | File: ../Urho2D/PhysicsWorld2D.h */ \
+    /* void PhysicsWorld2D::GetRigidBodies(Vector<RigidBody2D*>& results, const Rect& aabb, unsigned collisionMask = M_MAX_UNSIGNED) | File: ../Urho2D/PhysicsWorld2D.h */ \
     engine->RegisterObjectMethod(className, "Array<RigidBody2D@>@ GetRigidBodies(const Rect&in, uint = 0xffff)", AS_FUNCTION_OBJLAST(PhysicsWorld2D_GetRigidBodies<T>), AS_CALL_CDECL_OBJLAST);
 
 }

--- a/Source/Urho3D/AngelScript/Manual_Resource.h
+++ b/Source/Urho3D/AngelScript/Manual_Resource.h
@@ -113,16 +113,16 @@ template <class T> CScriptArray* XMLElement_GetVariantVector(T* ptr)
 
 // ========================================================================================
 
-// void ResourceCache::GetResources(PODVector<Resource*>& result, StringHash type) const | File: ../Resource/ResourceCache.h
+// void ResourceCache::GetResources(Vector<Resource*>& result, StringHash type) const | File: ../Resource/ResourceCache.h
 template <class T> CScriptArray* ResourceCache_GetResources(StringHash type, T* ptr)
 {
-    PODVector<Resource*> resources;
+    Vector<Resource*> resources;
     ptr->GetResources(resources, type);
     return VectorToHandleArray(resources, "Array<Resource@>");
 }
 
 #define REGISTER_MEMBERS_MANUAL_PART_ResourceCache() \
-    /* void ResourceCache::GetResources(PODVector<Resource*>& result, StringHash type) const | File: ../Resource/ResourceCache.h */ \
+    /* void ResourceCache::GetResources(Vector<Resource*>& result, StringHash type) const | File: ../Resource/ResourceCache.h */ \
     engine->RegisterObjectMethod(className, "Array<Resource@>@ GetResources(StringHash)", AS_FUNCTION_OBJLAST(ResourceCache_GetResources<T>), AS_CALL_CDECL_OBJLAST);
 
 // ========================================================================================

--- a/Source/Urho3D/AngelScript/Manual_Scene.h
+++ b/Source/Urho3D/AngelScript/Manual_Scene.h
@@ -61,23 +61,23 @@ template <class T> bool Node_SaveJSON_VectorBuffer(VectorBuffer& buffer, T* ptr)
     return ptr->SaveJSON(buffer);
 }
 
-// template <class T> void Node::GetChildrenWithComponent(PODVector<Node*>& dest, bool recursive = false) const | File: ../Scene/Node.h
+// template <class T> void Node::GetChildrenWithComponent(Vector<Node*>& dest, bool recursive = false) const | File: ../Scene/Node.h
 template <class T> CScriptArray* Node_GetChildren_Script(bool recursive, T* ptr)
 {
-    PODVector<Node*> nodes;
+    Vector<Node*> nodes;
     ptr->template GetChildrenWithComponent<ScriptInstance>(nodes, recursive);
     return VectorToHandleArray<Node>(nodes, "Array<Node@>");
 }
 
-// template <class T> void Node::GetChildrenWithComponent(PODVector<Node*>& dest, bool recursive = false) const | File: ../Scene/Node.h
+// template <class T> void Node::GetChildrenWithComponent(Vector<Node*>& dest, bool recursive = false) const | File: ../Scene/Node.h
 template <class T> CScriptArray* Node_GetChildren_Script_ClassName(const String& className, bool recursive, T* ptr)
 {
-    PODVector<Node*> nodes;
+    Vector<Node*> nodes;
     ptr->template GetChildrenWithComponent<ScriptInstance>(nodes, recursive);
 
-    PODVector<Node*> result;
+    Vector<Node*> result;
 
-    for (PODVector<Node*>::Iterator i = nodes.Begin(); i != nodes.End(); ++i)
+    for (Vector<Node*>::Iterator i = nodes.Begin(); i != nodes.End(); ++i)
     {
         Node* node = *i;
         const Vector<SharedPtr<Component>>& components = node->GetComponents();
@@ -94,10 +94,10 @@ template <class T> CScriptArray* Node_GetChildren_Script_ClassName(const String&
     return VectorToHandleArray<Node>(result, "Array<Node@>");
 }
 
-// void Node::GetComponents(PODVector<Component*>& dest, StringHash type, bool recursive = false) const | File: ../Scene/Node.h
+// void Node::GetComponents(Vector<Component*>& dest, StringHash type, bool recursive = false) const | File: ../Scene/Node.h
 template <class T> CScriptArray* Node_GetComponents_Type(const String& typeName, bool recursive, T* ptr)
 {
-    PODVector<Component*> components;
+    Vector<Component*> components;
     ptr->GetComponents(components, typeName, recursive);
     return VectorToHandleArray<Component>(components, "Array<Component@>");
 }
@@ -171,11 +171,11 @@ template <class T> VariantMap& Node_GetVars(T* ptr)
     engine->RegisterObjectMethod(className, "bool SaveJSON(File@+)", AS_FUNCTION_OBJLAST(Node_SaveJSON_File<T>), AS_CALL_CDECL_OBJLAST); \
     engine->RegisterObjectMethod(className, "bool SaveJSON(VectorBuffer&)", AS_FUNCTION_OBJLAST(Node_SaveJSON_VectorBuffer<T>), AS_CALL_CDECL_OBJLAST); \
     \
-    /* template <class T> void Node::GetChildrenWithComponent(PODVector<Node*>& dest, bool recursive = false) const | File: ../Scene/Node.h */ \
+    /* template <class T> void Node::GetChildrenWithComponent(Vector<Node*>& dest, bool recursive = false) const | File: ../Scene/Node.h */ \
     engine->RegisterObjectMethod(className, "Array<Node@>@ GetChildrenWithScript(bool = false) const", AS_FUNCTION_OBJLAST(Node_GetChildren_Script<T>), AS_CALL_CDECL_OBJLAST); \
     engine->RegisterObjectMethod(className, "Array<Node@>@ GetChildrenWithScript(const String&in, bool = false) const", AS_FUNCTION_OBJLAST(Node_GetChildren_Script_ClassName<T>), AS_CALL_CDECL_OBJLAST); \
     \
-    /* void Node::GetComponents(PODVector<Component*>& dest, StringHash type, bool recursive = false) const | File: ../Scene/Node.h */ \
+    /* void Node::GetComponents(Vector<Component*>& dest, StringHash type, bool recursive = false) const | File: ../Scene/Node.h */ \
     engine->RegisterObjectMethod(className, "Array<Component@>@ GetComponents(const String&in, bool = false) const", AS_FUNCTION_OBJLAST(Node_GetComponents_Type<T>), AS_CALL_CDECL_OBJLAST); \
     \
     /* unsigned Node::GetNumChildren(bool recursive = false) const | File: ../Scene/Node.h */ \
@@ -284,10 +284,10 @@ template <class T> Node* Scene_InstantiateJSON_JSONFile(JSONFile* json, const Ve
     return json ? ptr->InstantiateJSON(json->GetRoot(), position, rotation, mode) : nullptr;
 }
 
-// bool Scene::GetNodesWithTag(PODVector<Node*>& dest, const String& tag) const | File: ../Scene/Scene.h
+// bool Scene::GetNodesWithTag(Vector<Node*>& dest, const String& tag) const | File: ../Scene/Scene.h
 template <class T> CScriptArray* Scene_GetNodesWithTag(const String& tag, T* ptr)
 {
-    PODVector<Node*> nodes;
+    Vector<Node*> nodes;
     ptr->GetNodesWithTag(nodes, tag);
     return VectorToHandleArray<Node>(nodes, "Array<Node@>");
 }
@@ -331,7 +331,7 @@ template <class T> Octree* Scene_GetOctree(T* ptr)
     /* Node* Scene::InstantiateJSON(const JSONValue& source, const Vector3& position, const Quaternion& rotation, CreateMode mode = REPLICATED)  | File: ../Scene/Scene.h */ \
     engine->RegisterObjectMethod(className, "Node@+ InstantiateJSON(JSONFile@+, const Vector3&in, const Quaternion&in, CreateMode = REPLICATED)", AS_FUNCTION_OBJLAST(Scene_InstantiateJSON_JSONFile<T>), AS_CALL_CDECL_OBJLAST); \
     \
-    /* bool Scene::GetNodesWithTag(PODVector<Node*>& dest, const String& tag) const | File: ../Scene/Scene.h */ \
+    /* bool Scene::GetNodesWithTag(Vector<Node*>& dest, const String& tag) const | File: ../Scene/Scene.h */ \
     engine->RegisterObjectMethod(className, "Array<Node@>@ GetNodesWithTag(const String&in) const", AS_FUNCTION_OBJLAST(Scene_GetNodesWithTag<T>), AS_CALL_CDECL_OBJLAST); \
     \
     /* template <class T> T* Scene::GetComponent(bool recursive = false) const | File: ../Scene/Node.h */ \

--- a/Source/Urho3D/AngelScript/Script.cpp
+++ b/Source/Urho3D/AngelScript/Script.cpp
@@ -373,7 +373,7 @@ const char **Script::GetEnumValues(int asTypeID)
                       asTypeID,name,val,count);
 
             //fill with empty buffer
-            enumValues_[asTypeID] = PODVector<const char*>();
+            enumValues_[asTypeID] = Vector<const char*>();
             return nullptr;
         }
         else

--- a/Source/Urho3D/AngelScript/Script.h
+++ b/Source/Urho3D/AngelScript/Script.h
@@ -120,7 +120,7 @@ private:
     /// Search cache for inbuilt object types.
     HashMap<const char*, asITypeInfo*> objectTypes_;
     /// Cache of typeIds to array of enum value strings for attributes.
-    HashMap<int, PODVector<const char*>> enumValues_;
+    HashMap<int, Vector<const char*>> enumValues_;
     /// AngelScript resource router.
     SharedPtr<ResourceRouter> router_;
     /// Script module create/delete mutex.

--- a/Source/Urho3D/AngelScript/ScriptEventListener.h
+++ b/Source/Urho3D/AngelScript/ScriptEventListener.h
@@ -49,7 +49,7 @@ public:
     /// Remove all scripted event handlers.
     virtual void RemoveEventHandlers() = 0;
     /// Remove all scripted event handlers, except those listed.
-    virtual void RemoveEventHandlersExcept(const PODVector<StringHash>& exceptions) = 0;
+    virtual void RemoveEventHandlersExcept(const Vector<StringHash>& exceptions) = 0;
     /// Return whether has subscribed to an event.
     virtual bool HasEventHandler(StringHash eventType) const = 0;
     /// Return whether has subscribed to a specific sender's event.

--- a/Source/Urho3D/AngelScript/ScriptFile.cpp
+++ b/Source/Urho3D/AngelScript/ScriptFile.cpp
@@ -238,7 +238,7 @@ void ScriptFile::RemoveEventHandlers()
     }
 }
 
-void ScriptFile::RemoveEventHandlersExcept(const PODVector<StringHash>& exceptions)
+void ScriptFile::RemoveEventHandlersExcept(const Vector<StringHash>& exceptions)
 {
     auto* receiver = static_cast<asIScriptObject*>(asGetActiveContext()->GetThisPointer());
     HashMap<asIScriptObject*, SharedPtr<ScriptEventInvoker>>::Iterator i = eventInvokers_.Find(receiver);

--- a/Source/Urho3D/AngelScript/ScriptFile.h
+++ b/Source/Urho3D/AngelScript/ScriptFile.h
@@ -55,7 +55,7 @@ public:
     /// Remove all scripted event handlers.
     void RemoveEventHandlers() override;
     /// Remove all scripted event handlers, except those listed.
-    void RemoveEventHandlersExcept(const PODVector<StringHash>& exceptions) override;
+    void RemoveEventHandlersExcept(const Vector<StringHash>& exceptions) override;
     /// Return whether has subscribed to an event.
     bool HasEventHandler(StringHash eventType) const override;
     /// Return whether has subscribed to a specific sender's event.

--- a/Source/Urho3D/AngelScript/ScriptInstance.cpp
+++ b/Source/Urho3D/AngelScript/ScriptInstance.cpp
@@ -79,14 +79,14 @@ void ScriptInstance::RegisterObject(Context* context)
     context->RegisterFactory<ScriptInstance>(LOGIC_CATEGORY);
 
     URHO3D_ACCESSOR_ATTRIBUTE("Is Enabled", IsEnabled, SetEnabled, bool, true, AM_DEFAULT);
-    URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Delayed Method Calls", GetDelayedCallsAttr, SetDelayedCallsAttr, PODVector<unsigned char>,
+    URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Delayed Method Calls", GetDelayedCallsAttr, SetDelayedCallsAttr, Vector<unsigned char>,
         Variant::emptyBuffer, AM_FILE | AM_NOEDIT);
     URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Script File", GetScriptFileAttr, SetScriptFileAttr, ResourceRef,
         ResourceRef(ScriptFile::GetTypeStatic()), AM_DEFAULT);
     URHO3D_ACCESSOR_ATTRIBUTE("Class Name", GetClassName, SetClassName, String, String::EMPTY, AM_DEFAULT);
-    URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Script Data", GetScriptDataAttr, SetScriptDataAttr, PODVector<unsigned char>, Variant::emptyBuffer,
+    URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Script Data", GetScriptDataAttr, SetScriptDataAttr, Vector<unsigned char>, Variant::emptyBuffer,
         AM_FILE | AM_NOEDIT);
-    URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Script Network Data", GetScriptNetworkDataAttr, SetScriptNetworkDataAttr, PODVector<unsigned char>,
+    URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Script Network Data", GetScriptNetworkDataAttr, SetScriptNetworkDataAttr, Vector<unsigned char>,
         Variant::emptyBuffer, AM_NET | AM_NOEDIT);
 }
 
@@ -396,10 +396,10 @@ void ScriptInstance::RemoveEventHandlers(Object* sender)
 
 void ScriptInstance::RemoveEventHandlers()
 {
-    UnsubscribeFromAllEventsExcept(PODVector<StringHash>(), true);
+    UnsubscribeFromAllEventsExcept(Vector<StringHash>(), true);
 }
 
-void ScriptInstance::RemoveEventHandlersExcept(const PODVector<StringHash>& exceptions)
+void ScriptInstance::RemoveEventHandlersExcept(const Vector<StringHash>& exceptions)
 {
     UnsubscribeFromAllEventsExcept(exceptions, true);
 }
@@ -443,7 +443,7 @@ void ScriptInstance::SetScriptFileAttr(const ResourceRef& value)
     SetScriptFile(cache->GetResource<ScriptFile>(value.name_));
 }
 
-void ScriptInstance::SetDelayedCallsAttr(const PODVector<unsigned char>& value)
+void ScriptInstance::SetDelayedCallsAttr(const Vector<unsigned char>& value)
 {
     MemoryBuffer buf(value);
     delayedCalls_.Resize(buf.ReadVLE());
@@ -460,7 +460,7 @@ void ScriptInstance::SetDelayedCallsAttr(const PODVector<unsigned char>& value)
         UpdateEventSubscription();
 }
 
-void ScriptInstance::SetScriptDataAttr(const PODVector<unsigned char>& data)
+void ScriptInstance::SetScriptDataAttr(const Vector<unsigned char>& data)
 {
     if (scriptObject_ && methods_[METHOD_LOAD])
     {
@@ -471,7 +471,7 @@ void ScriptInstance::SetScriptDataAttr(const PODVector<unsigned char>& data)
     }
 }
 
-void ScriptInstance::SetScriptNetworkDataAttr(const PODVector<unsigned char>& data)
+void ScriptInstance::SetScriptNetworkDataAttr(const Vector<unsigned char>& data)
 {
     if (scriptObject_ && methods_[METHOD_READNETWORKUPDATE])
     {
@@ -487,7 +487,7 @@ ResourceRef ScriptInstance::GetScriptFileAttr() const
     return GetResourceRef(scriptFile_, ScriptFile::GetTypeStatic());
 }
 
-PODVector<unsigned char> ScriptInstance::GetDelayedCallsAttr() const
+Vector<unsigned char> ScriptInstance::GetDelayedCallsAttr() const
 {
     VectorBuffer buf;
     buf.WriteVLE(delayedCalls_.Size());
@@ -502,10 +502,10 @@ PODVector<unsigned char> ScriptInstance::GetDelayedCallsAttr() const
     return buf.GetBuffer();
 }
 
-PODVector<unsigned char> ScriptInstance::GetScriptDataAttr() const
+Vector<unsigned char> ScriptInstance::GetScriptDataAttr() const
 {
     if (!scriptObject_ || !methods_[METHOD_SAVE])
-        return PODVector<unsigned char>();
+        return Vector<unsigned char>();
     else
     {
         VectorBuffer buf;
@@ -516,10 +516,10 @@ PODVector<unsigned char> ScriptInstance::GetScriptDataAttr() const
     }
 }
 
-PODVector<unsigned char> ScriptInstance::GetScriptNetworkDataAttr() const
+Vector<unsigned char> ScriptInstance::GetScriptNetworkDataAttr() const
 {
     if (!scriptObject_ || !methods_[METHOD_WRITENETWORKUPDATE])
-        return PODVector<unsigned char>();
+        return Vector<unsigned char>();
     else
     {
         VectorBuffer buf;
@@ -592,7 +592,7 @@ void ScriptInstance::ReleaseObject()
         if (methods_[METHOD_STOP])
             executeScript(methods_[METHOD_STOP], [](asIScriptContext*) {});
 
-        PODVector<StringHash> exceptions;
+        Vector<StringHash> exceptions;
         exceptions.Push(E_RELOADSTARTED);
         exceptions.Push(E_RELOADFINISHED);
         UnsubscribeFromAllEventsExcept(exceptions, false);

--- a/Source/Urho3D/AngelScript/ScriptInstance.h
+++ b/Source/Urho3D/AngelScript/ScriptInstance.h
@@ -80,7 +80,7 @@ public:
     /// Remove all scripted event handlers.
     void RemoveEventHandlers() override;
     /// Remove all scripted event handlers, except those listed.
-    void RemoveEventHandlersExcept(const PODVector<StringHash>& exceptions) override;
+    void RemoveEventHandlersExcept(const Vector<StringHash>& exceptions) override;
     /// Return whether has subscribed to an event.
     bool HasEventHandler(StringHash eventType) const override;
     /// Return whether has subscribed to a specific sender's event.
@@ -119,19 +119,19 @@ public:
     /// Set script file attribute.
     void SetScriptFileAttr(const ResourceRef& value);
     /// Set delayed method calls attribute.
-    void SetDelayedCallsAttr(const PODVector<unsigned char>& value);
+    void SetDelayedCallsAttr(const Vector<unsigned char>& value);
     /// Set script file serialization attribute by calling a script function.
-    void SetScriptDataAttr(const PODVector<unsigned char>& data);
+    void SetScriptDataAttr(const Vector<unsigned char>& data);
     /// Set script network serialization attribute by calling a script function.
-    void SetScriptNetworkDataAttr(const PODVector<unsigned char>& data);
+    void SetScriptNetworkDataAttr(const Vector<unsigned char>& data);
     /// Return script file attribute.
     ResourceRef GetScriptFileAttr() const;
     /// Return delayed method calls attribute.
-    PODVector<unsigned char> GetDelayedCallsAttr() const;
+    Vector<unsigned char> GetDelayedCallsAttr() const;
     /// Get script file serialization attribute by calling a script function.
-    PODVector<unsigned char> GetScriptDataAttr() const;
+    Vector<unsigned char> GetScriptDataAttr() const;
     /// Get script network serialization attribute by calling a script function.
-    PODVector<unsigned char> GetScriptNetworkDataAttr() const;
+    Vector<unsigned char> GetScriptNetworkDataAttr() const;
 
 protected:
     /// Handle scene being assigned.

--- a/Source/Urho3D/Audio/Audio.cpp
+++ b/Source/Urho3D/Audio/Audio.cpp
@@ -153,7 +153,7 @@ void Audio::SetMasterGain(const String& type, float gain)
 {
     masterGain_[type] = Clamp(gain, 0.0f, 1.0f);
 
-    for (PODVector<SoundSource*>::Iterator i = soundSources_.Begin(); i != soundSources_.End(); ++i)
+    for (Vector<SoundSource*>::Iterator i = soundSources_.Begin(); i != soundSources_.End(); ++i)
         (*i)->UpdateMasterGain();
 }
 
@@ -186,7 +186,7 @@ void Audio::SetListener(SoundListener* listener)
 
 void Audio::StopSound(Sound* sound)
 {
-    for (PODVector<SoundSource*>::Iterator i = soundSources_.Begin(); i != soundSources_.End(); ++i)
+    for (Vector<SoundSource*>::Iterator i = soundSources_.Begin(); i != soundSources_.End(); ++i)
     {
         if ((*i)->GetSound() == sound)
             (*i)->Stop();
@@ -221,7 +221,7 @@ void Audio::AddSoundSource(SoundSource* soundSource)
 
 void Audio::RemoveSoundSource(SoundSource* soundSource)
 {
-    PODVector<SoundSource*>::Iterator i = soundSources_.Find(soundSource);
+    Vector<SoundSource*>::Iterator i = soundSources_.Find(soundSource);
     if (i != soundSources_.End())
     {
         MutexLock lock(audioMutex_);
@@ -274,7 +274,7 @@ void Audio::MixOutput(void* dest, u32 samples)
         memset(clipPtr, 0, clipSamples * sizeof(i32));
 
         // Mix samples to clip buffer
-        for (PODVector<SoundSource*>::Iterator i = soundSources_.Begin(); i != soundSources_.End(); ++i)
+        for (Vector<SoundSource*>::Iterator i = soundSources_.Begin(); i != soundSources_.End(); ++i)
         {
             SoundSource* source = *i;
 

--- a/Source/Urho3D/Audio/Audio.h
+++ b/Source/Urho3D/Audio/Audio.h
@@ -87,7 +87,7 @@ public:
     SoundListener* GetListener() const;
 
     /// Return all sound sources.
-    const PODVector<SoundSource*>& GetSoundSources() const { return soundSources_; }
+    const Vector<SoundSource*>& GetSoundSources() const { return soundSources_; }
 
     /// Return whether the specified master gain has been defined.
     bool HasMasterGain(const String& type) const { return masterGain_.Contains(type); }
@@ -137,7 +137,7 @@ private:
     /// Paused sound types.
     HashSet<StringHash> pausedSoundTypes_;
     /// Sound sources.
-    PODVector<SoundSource*> soundSources_;
+    Vector<SoundSource*> soundSources_;
     /// Sound listener.
     WeakPtr<SoundListener> listener_;
 };

--- a/Source/Urho3D/Container/Vector.h
+++ b/Source/Urho3D/Container/Vector.h
@@ -913,7 +913,7 @@ private:
         }
     }
 
-    /// Move a range of elements within the vector. Only for PODVector.
+    /// Move a range of elements within the vector. Only for POD Vector.
     void MoveRange(i32 dest, i32 src, i32 count)
     {
         assert(dest >= 0 && src >= 0 && count >= 0);
@@ -929,7 +929,7 @@ private:
         }
     }
 
-    /// Copy elements from one buffer to another. Only for PODVector.
+    /// Copy elements from one buffer to another. Only for POD Vector.
     static void CopyElements(T* dest, const T* src, i32 count)
     {
         assert(count >= 0);
@@ -945,10 +945,6 @@ private:
         }
     }
 };
-
-/// For backwards compatibility.
-template <typename T>
-using PODVector = Vector<T>;
 
 template <class T> typename Urho3D::Vector<T>::ConstIterator begin(const Urho3D::Vector<T>& v) { return v.Begin(); }
 

--- a/Source/Urho3D/Core/Context.cpp
+++ b/Source/Urho3D/Core/Context.cpp
@@ -68,7 +68,7 @@ void EventReceiverGroup::Remove(Object* object)
 {
     if (inSend_ > 0)
     {
-        PODVector<Object*>::Iterator i = receivers_.Find(object);
+        Vector<Object*>::Iterator i = receivers_.Find(object);
         if (i != receivers_.End())
         {
             (*i) = nullptr;
@@ -127,7 +127,7 @@ Context::~Context()
     factories_.Clear();
 
     // Delete allocated event data maps
-    for (PODVector<VariantMap*>::Iterator i = eventDataMaps_.Begin(); i != eventDataMaps_.End(); ++i)
+    for (Vector<VariantMap*>::Iterator i = eventDataMaps_.Begin(); i != eventDataMaps_.End(); ++i)
         delete *i;
     eventDataMaps_.Clear();
 }
@@ -407,7 +407,7 @@ void Context::RemoveEventSender(Object* sender)
     {
         for (HashMap<StringHash, SharedPtr<EventReceiverGroup>>::Iterator j = i->second_.Begin(); j != i->second_.End(); ++j)
         {
-            for (PODVector<Object*>::Iterator k = j->second_->receivers_.Begin(); k != j->second_->receivers_.End(); ++k)
+            for (Vector<Object*>::Iterator k = j->second_->receivers_.Begin(); k != j->second_->receivers_.End(); ++k)
             {
                 Object* receiver = *k;
                 if (receiver)

--- a/Source/Urho3D/Core/Context.h
+++ b/Source/Urho3D/Core/Context.h
@@ -34,7 +34,7 @@ public:
     void Remove(Object* object);
 
     /// Receivers. May contain holes during sending.
-    PODVector<Object*> receivers_;
+    Vector<Object*> receivers_;
 
 private:
     /// "In send" recursion counter.
@@ -216,9 +216,9 @@ private:
     /// Event receivers for specific senders' events.
     HashMap<Object*, HashMap<StringHash, SharedPtr<EventReceiverGroup>>> specificEventReceivers_;
     /// Event sender stack.
-    PODVector<Object*> eventSenders_;
+    Vector<Object*> eventSenders_;
     /// Event data stack.
-    PODVector<VariantMap*> eventDataMaps_;
+    Vector<VariantMap*> eventDataMaps_;
     /// Active event handler. Not stored in a stack for performance reasons; is needed only in esoteric cases.
     EventHandler* eventHandler_;
     /// Object categories.

--- a/Source/Urho3D/Core/EventProfiler.h
+++ b/Source/Urho3D/Core/EventProfiler.h
@@ -23,7 +23,7 @@ public:
     /// Return child block with the specified event ID.
     EventProfilerBlock* GetChild(StringHash eventID)
     {
-        for (PODVector<ProfilerBlock*>::Iterator i = children_.Begin(); i != children_.End(); ++i)
+        for (Vector<ProfilerBlock*>::Iterator i = children_.Begin(); i != children_.End(); ++i)
         {
             auto* eventProfilerBlock = static_cast<EventProfilerBlock*>(*i);
             if (eventProfilerBlock->eventID_ == eventID)

--- a/Source/Urho3D/Core/Object.cpp
+++ b/Source/Urho3D/Core/Object.cpp
@@ -247,7 +247,7 @@ void Object::UnsubscribeFromAllEvents()
     }
 }
 
-void Object::UnsubscribeFromAllEventsExcept(const PODVector<StringHash>& exceptions, bool onlyUserData)
+void Object::UnsubscribeFromAllEventsExcept(const Vector<StringHash>& exceptions, bool onlyUserData)
 {
     EventHandler* handler = eventHandlers_.First();
     EventHandler* previous = nullptr;

--- a/Source/Urho3D/Core/Object.h
+++ b/Source/Urho3D/Core/Object.h
@@ -112,7 +112,7 @@ public:
     /// Unsubscribe from all events.
     void UnsubscribeFromAllEvents();
     /// Unsubscribe from all events except those listed, and optionally only those with userdata (script registered events).
-    void UnsubscribeFromAllEventsExcept(const PODVector<StringHash>& exceptions, bool onlyUserData);
+    void UnsubscribeFromAllEventsExcept(const Vector<StringHash>& exceptions, bool onlyUserData);
     /// Send event to all subscribers.
     void SendEvent(StringHash eventType);
     /// Send event with parameters to all subscribers.

--- a/Source/Urho3D/Core/Profiler.cpp
+++ b/Source/Urho3D/Core/Profiler.cpp
@@ -118,7 +118,7 @@ void Profiler::PrintData(ProfilerBlock* block, String& output, unsigned depth, u
         output += String(line);
     }
 
-    for (PODVector<ProfilerBlock*>::ConstIterator i = block->children_.Begin(); i != block->children_.End(); ++i)
+    for (Vector<ProfilerBlock*>::ConstIterator i = block->children_.Begin(); i != block->children_.End(); ++i)
         PrintData(*i, output, depth, maxDepth, showUnused, showTotal);
 }
 

--- a/Source/Urho3D/Core/Profiler.h
+++ b/Source/Urho3D/Core/Profiler.h
@@ -48,7 +48,7 @@ public:
     /// Destruct. Free the child blocks.
     virtual ~ProfilerBlock()
     {
-        for (PODVector<ProfilerBlock*>::Iterator i = children_.Begin(); i != children_.End(); ++i)
+        for (Vector<ProfilerBlock*>::Iterator i = children_.Begin(); i != children_.End(); ++i)
         {
             delete *i;
             *i = nullptr;
@@ -91,7 +91,7 @@ public:
         maxTime_ = 0;
         count_ = 0;
 
-        for (PODVector<ProfilerBlock*>::Iterator i = children_.Begin(); i != children_.End(); ++i)
+        for (Vector<ProfilerBlock*>::Iterator i = children_.Begin(); i != children_.End(); ++i)
             (*i)->EndFrame();
     }
 
@@ -102,14 +102,14 @@ public:
         intervalMaxTime_ = 0;
         intervalCount_ = 0;
 
-        for (PODVector<ProfilerBlock*>::Iterator i = children_.Begin(); i != children_.End(); ++i)
+        for (Vector<ProfilerBlock*>::Iterator i = children_.Begin(); i != children_.End(); ++i)
             (*i)->BeginInterval();
     }
 
     /// Return child block with the specified name.
     ProfilerBlock* GetChild(const char* name)
     {
-        for (PODVector<ProfilerBlock*>::Iterator i = children_.Begin(); i != children_.End(); ++i)
+        for (Vector<ProfilerBlock*>::Iterator i = children_.Begin(); i != children_.End(); ++i)
         {
             if (!String::Compare((*i)->name_, name, true))
                 return *i;
@@ -134,7 +134,7 @@ public:
     /// Parent block.
     ProfilerBlock* parent_;
     /// Child blocks.
-    PODVector<ProfilerBlock*> children_;
+    Vector<ProfilerBlock*> children_;
     /// Time on the previous frame.
     long long frameTime_;
     /// Maximum time on the previous frame.

--- a/Source/Urho3D/Core/StringUtils.cpp
+++ b/Source/Urho3D/Core/StringUtils.cpp
@@ -603,12 +603,12 @@ void BufferToString(String& dest, const void* data, unsigned size)
     }
 }
 
-void StringToBuffer(PODVector<unsigned char>& dest, const String& source)
+void StringToBuffer(Vector<unsigned char>& dest, const String& source)
 {
     StringToBuffer(dest, source.CString());
 }
 
-void StringToBuffer(PODVector<unsigned char>& dest, const char* source)
+void StringToBuffer(Vector<unsigned char>& dest, const char* source)
 {
     if (!source)
     {
@@ -773,14 +773,14 @@ static inline bool IsBase64(char c) {
     return (isalnum(c) || (c == '+') || (c == '/'));
 }
 
-PODVector<unsigned char> DecodeBase64(String encodedString)
+Vector<unsigned char> DecodeBase64(String encodedString)
 {
     int inLen = encodedString.Length();
     int i = 0;
     int j = 0;
     int in_ = 0;
     unsigned char charArray4[4], charArray3[3];
-    PODVector<unsigned char> ret;
+    Vector<unsigned char> ret;
 
     while (inLen-- && (encodedString[in_] != '=') && IsBase64(encodedString[in_]))
     {

--- a/Source/Urho3D/Core/StringUtils.h
+++ b/Source/Urho3D/Core/StringUtils.h
@@ -95,9 +95,9 @@ URHO3D_API String ToStringHex(unsigned value);
 /// Convert a byte buffer to a string.
 URHO3D_API void BufferToString(String& dest, const void* data, unsigned size);
 /// Convert a string to a byte buffer.
-URHO3D_API void StringToBuffer(PODVector<unsigned char>& dest, const String& source);
+URHO3D_API void StringToBuffer(Vector<unsigned char>& dest, const String& source);
 /// Convert a C string to a byte buffer.
-URHO3D_API void StringToBuffer(PODVector<unsigned char>& dest, const char* source);
+URHO3D_API void StringToBuffer(Vector<unsigned char>& dest, const char* source);
 /// Return an index to a string list corresponding to the given string, or a default value if not found. The string list must be empty-terminated.
 URHO3D_API unsigned GetStringListIndex(const String& value, const String* strings, unsigned defaultIndex, bool caseSensitive = false);
 /// Return an index to a string list corresponding to the given C string, or a default value if not found. The string list must be empty-terminated.
@@ -117,7 +117,7 @@ URHO3D_API unsigned ToLower(unsigned ch);
 /// Convert a memory size into a formatted size string, of the style "1.5 Mb".
 URHO3D_API String GetFileSizeString(unsigned long long memorySize);
 /// Decode a base64-encoded string into buffer.
-URHO3D_API PODVector<unsigned char> DecodeBase64(String encodedString);
+URHO3D_API Vector<unsigned char> DecodeBase64(String encodedString);
 /// Parse type from a C string.
 template <class T> T FromString(const char* source);
 

--- a/Source/Urho3D/Core/Variant.cpp
+++ b/Source/Urho3D/Core/Variant.cpp
@@ -12,7 +12,7 @@ namespace Urho3D
 {
 
 const Variant Variant::EMPTY { };
-const PODVector<unsigned char> Variant::emptyBuffer { };
+const Vector<unsigned char> Variant::emptyBuffer { };
 const ResourceRef Variant::emptyResourceRef { };
 const ResourceRefList Variant::emptyResourceRefList { };
 const VariantMap Variant::emptyVariantMap;
@@ -216,10 +216,10 @@ bool Variant::operator ==(const Variant& rhs) const
     }
 }
 
-bool Variant::operator ==(const PODVector<unsigned char>& rhs) const
+bool Variant::operator ==(const Vector<unsigned char>& rhs) const
 {
-    // Use strncmp() instead of PODVector<unsigned char>::operator ==()
-    const PODVector<unsigned char>& buffer = value_.buffer_;
+    // Use strncmp() instead of Vector<unsigned char>::operator ==()
+    const Vector<unsigned char>& buffer = value_.buffer_;
     return type_ == VAR_BUFFER && buffer.Size() == rhs.Size() ?
         strncmp(reinterpret_cast<const char*>(&buffer[0]), reinterpret_cast<const char*>(&rhs[0]), buffer.Size()) == 0 :
         false;
@@ -227,7 +227,7 @@ bool Variant::operator ==(const PODVector<unsigned char>& rhs) const
 
 bool Variant::operator ==(const VectorBuffer& rhs) const
 {
-    const PODVector<unsigned char>& buffer = value_.buffer_;
+    const Vector<unsigned char>& buffer = value_.buffer_;
     return type_ == VAR_BUFFER && buffer.Size() == rhs.GetSize() ?
         strncmp(reinterpret_cast<const char*>(&buffer[0]), reinterpret_cast<const char*>(rhs.GetData()), buffer.Size()) == 0 :
         false;
@@ -376,7 +376,7 @@ void Variant::SetBuffer(const void* data, unsigned size)
         size = 0;
 
     SetType(VAR_BUFFER);
-    PODVector<unsigned char>& buffer = value_.buffer_;
+    Vector<unsigned char>& buffer = value_.buffer_;
     buffer.Resize(size);
     if (size)
         memcpy(&buffer[0], data, size);
@@ -454,7 +454,7 @@ String Variant::ToString() const
 
     case VAR_BUFFER:
         {
-            const PODVector<unsigned char>& buffer = value_.buffer_;
+            const Vector<unsigned char>& buffer = value_.buffer_;
             String ret;
             BufferToString(ret, buffer.Begin().ptr_, buffer.Size());
             return ret;
@@ -613,7 +613,7 @@ void Variant::SetType(VariantType newType)
         break;
 
     case VAR_BUFFER:
-        value_.buffer_.~PODVector<unsigned char>();
+        value_.buffer_.~Vector<unsigned char>();
         break;
 
     case VAR_RESOURCEREF:
@@ -673,7 +673,7 @@ void Variant::SetType(VariantType newType)
         break;
 
     case VAR_BUFFER:
-        new(&value_.buffer_) PODVector<unsigned char>();
+        new(&value_.buffer_) Vector<unsigned char>();
         break;
 
     case VAR_RESOURCEREF:
@@ -817,7 +817,7 @@ template <> const IntVector3& Variant::Get<const IntVector3&>() const
     return GetIntVector3();
 }
 
-template <> const PODVector<unsigned char>& Variant::Get<const PODVector<unsigned char>&>() const
+template <> const Vector<unsigned char>& Variant::Get<const Vector<unsigned char>&>() const
 {
     return GetBuffer();
 }
@@ -922,7 +922,7 @@ template <> IntVector3 Variant::Get<IntVector3>() const
     return GetIntVector3();
 }
 
-template <> PODVector<unsigned char> Variant::Get<PODVector<unsigned char>>() const
+template <> Vector<unsigned char> Variant::Get<Vector<unsigned char>>() const
 {
     return GetBuffer();
 }

--- a/Source/Urho3D/Core/Variant.h
+++ b/Source/Urho3D/Core/Variant.h
@@ -286,7 +286,7 @@ union VariantValue
     StringVector stringVector_;
     VariantVector variantVector_;
     VariantMap variantMap_;
-    PODVector<unsigned char> buffer_;
+    Vector<unsigned char> buffer_;
     ResourceRef resourceRef_;
     ResourceRefList resourceRefList_;
     CustomVariantValue* customValueHeap_;
@@ -410,7 +410,7 @@ public:
     }
 
     /// Construct from a buffer.
-    Variant(const PODVector<unsigned char>& value)      // NOLINT(google-explicit-constructor)
+    Variant(const Vector<unsigned char>& value)      // NOLINT(google-explicit-constructor)
     {
         *this = value;
     }
@@ -678,7 +678,7 @@ public:
     }
 
     /// Assign from a buffer.
-    Variant& operator =(const PODVector<unsigned char>& rhs)
+    Variant& operator =(const Vector<unsigned char>& rhs)
     {
         SetType(VAR_BUFFER);
         value_.buffer_ = rhs;
@@ -869,7 +869,7 @@ public:
     }
 
     /// Test for equality with a buffer. To return true, both the type and value must match.
-    bool operator ==(const PODVector<unsigned char>& rhs) const;
+    bool operator ==(const Vector<unsigned char>& rhs) const;
     /// Test for equality with a %VectorBuffer. To return true, both the type and value must match.
     bool operator ==(const VectorBuffer& rhs) const;
 
@@ -1010,7 +1010,7 @@ public:
     bool operator !=(const String& rhs) const { return !(*this == rhs); }
 
     /// Test for inequality with a buffer.
-    bool operator !=(const PODVector<unsigned char>& rhs) const { return !(*this == rhs); }
+    bool operator !=(const Vector<unsigned char>& rhs) const { return !(*this == rhs); }
 
     /// Test for inequality with a %VectorBuffer.
     bool operator !=(const VectorBuffer& rhs) const { return !(*this == rhs); }
@@ -1189,7 +1189,7 @@ public:
     const String& GetString() const { return type_ == VAR_STRING ? value_.string_ : String::EMPTY; }
 
     /// Return buffer or empty on type mismatch.
-    const PODVector<unsigned char>& GetBuffer() const
+    const Vector<unsigned char>& GetBuffer() const
     {
         return type_ == VAR_BUFFER ? value_.buffer_ : emptyBuffer;
     }
@@ -1341,7 +1341,7 @@ public:
     template <class T> T Get() const;
 
     /// Return a pointer to a modifiable buffer or null on type mismatch.
-    PODVector<unsigned char>* GetBufferPtr()
+    Vector<unsigned char>* GetBufferPtr()
     {
         return type_ == VAR_BUFFER ? &value_.buffer_ : nullptr;
     }
@@ -1376,7 +1376,7 @@ public:
     /// Empty variant.
     static const Variant EMPTY;
     /// Empty buffer.
-    static const PODVector<unsigned char> emptyBuffer;
+    static const Vector<unsigned char> emptyBuffer;
     /// Empty resource reference.
     static const ResourceRef emptyResourceRef;
     /// Empty resource reference list.
@@ -1430,7 +1430,7 @@ template <> inline VariantType GetVariantType<String>() { return VAR_STRING; }
 
 template <> inline VariantType GetVariantType<StringHash>() { return VAR_INT; }
 
-template <> inline VariantType GetVariantType<PODVector<unsigned char>>() { return VAR_BUFFER; }
+template <> inline VariantType GetVariantType<Vector<unsigned char>>() { return VAR_BUFFER; }
 
 template <> inline VariantType GetVariantType<ResourceRef>() { return VAR_RESOURCEREF; }
 
@@ -1493,7 +1493,7 @@ template <> URHO3D_API const IntVector2& Variant::Get<const IntVector2&>() const
 
 template <> URHO3D_API const IntVector3& Variant::Get<const IntVector3&>() const;
 
-template <> URHO3D_API const PODVector<unsigned char>& Variant::Get<const PODVector<unsigned char>&>() const;
+template <> URHO3D_API const Vector<unsigned char>& Variant::Get<const Vector<unsigned char>&>() const;
 
 template <> URHO3D_API void* Variant::Get<void*>() const;
 
@@ -1535,7 +1535,7 @@ template <> URHO3D_API IntVector2 Variant::Get<IntVector2>() const;
 
 template <> URHO3D_API IntVector3 Variant::Get<IntVector3>() const;
 
-template <> URHO3D_API PODVector<unsigned char> Variant::Get<PODVector<unsigned char>>() const;
+template <> URHO3D_API Vector<unsigned char> Variant::Get<Vector<unsigned char>>() const;
 
 template <> URHO3D_API Matrix3 Variant::Get<Matrix3>() const;
 

--- a/Source/Urho3D/Engine/Engine.h
+++ b/Source/Urho3D/Engine/Engine.h
@@ -125,7 +125,7 @@ private:
     /// Frame update timer.
     HiresTimer frameTimer_;
     /// Previous timesteps for smoothing.
-    PODVector<float> lastTimeSteps_;
+    Vector<float> lastTimeSteps_;
     /// Next frame timestep in seconds.
     float timeStep_;
     /// How many frames to average for the smoothed timestep.

--- a/Source/Urho3D/Graphics/AnimatedModel.cpp
+++ b/Source/Urho3D/Graphics/AnimatedModel.cpp
@@ -102,7 +102,7 @@ void AnimatedModel::RegisterObject(Context* context)
     URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Animation States", GetAnimationStatesAttr, SetAnimationStatesAttr,
         VariantVector, Variant::emptyVariantVector, AM_FILE)
         .SetMetadata(AttributeMetadata::P_VECTOR_STRUCT_ELEMENTS, animationStatesStructureElementNames);
-    URHO3D_ACCESSOR_ATTRIBUTE("Morphs", GetMorphsAttr, SetMorphsAttr, PODVector<unsigned char>, Variant::emptyBuffer,
+    URHO3D_ACCESSOR_ATTRIBUTE("Morphs", GetMorphsAttr, SetMorphsAttr, Vector<unsigned char>, Variant::emptyBuffer,
         AM_DEFAULT | AM_NOEDIT);
 }
 
@@ -139,7 +139,7 @@ void AnimatedModel::ApplyAttributes()
         AssignBoneNodes();
 }
 
-void AnimatedModel::ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQueryResult>& results)
+void AnimatedModel::ProcessRayQuery(const RayOctreeQuery& query, Vector<RayQueryResult>& results)
 {
     // If no bones or no bone-level testing, use the StaticModel test
     RayQueryLevel level = query.level_;
@@ -334,7 +334,7 @@ void AnimatedModel::SetModel(Model* model, bool createBones)
         // Copy the subgeometry & LOD level structure
         SetNumGeometries(model->GetNumGeometries());
         const Vector<Vector<SharedPtr<Geometry>>>& geometries = model->GetGeometries();
-        const PODVector<Vector3>& geometryCenters = model->GetGeometryCenters();
+        const Vector<Vector3>& geometryCenters = model->GetGeometryCenters();
         for (unsigned i = 0; i < geometries.Size(); ++i)
         {
             geometries_[i] = geometries[i];
@@ -342,7 +342,7 @@ void AnimatedModel::SetModel(Model* model, bool createBones)
         }
 
         // Copy geometry bone mappings
-        const Vector<PODVector<unsigned>>& geometryBoneMappings = model->GetGeometryBoneMappings();
+        const Vector<Vector<unsigned>>& geometryBoneMappings = model->GetGeometryBoneMappings();
         geometryBoneMappings_.Clear();
         geometryBoneMappings_.Reserve(geometryBoneMappings.Size());
         for (unsigned i = 0; i < geometryBoneMappings.Size(); ++i)
@@ -546,7 +546,7 @@ void AnimatedModel::SetMorphWeight(unsigned index, float weight)
         // For a master model, set the same morph weight on non-master models
         if (isMaster_)
         {
-            PODVector<AnimatedModel*> models;
+            Vector<AnimatedModel*> models;
             GetComponents<AnimatedModel>(models);
 
             // Indexing might not be the same, so use the name hash instead
@@ -594,7 +594,7 @@ void AnimatedModel::ResetMorphWeights()
     // For a master model, reset weights on non-master models
     if (isMaster_)
     {
-        PODVector<AnimatedModel*> models;
+        Vector<AnimatedModel*> models;
         GetComponents<AnimatedModel>(models);
 
         for (unsigned i = 1; i < models.Size(); ++i)
@@ -834,7 +834,7 @@ void AnimatedModel::SetAnimationStatesAttr(const VariantVector& value)
     }
 }
 
-void AnimatedModel::SetMorphsAttr(const PODVector<unsigned char>& value)
+void AnimatedModel::SetMorphsAttr(const Vector<unsigned char>& value)
 {
     for (unsigned index = 0; index < value.Size(); ++index)
         SetMorphWeight(index, (float)value[index] / 255.0f);
@@ -875,7 +875,7 @@ VariantVector AnimatedModel::GetAnimationStatesAttr() const
     return ret;
 }
 
-const PODVector<unsigned char>& AnimatedModel::GetMorphsAttr() const
+const Vector<unsigned char>& AnimatedModel::GetMorphsAttr() const
 {
     attrBuffer_.Clear();
     for (Vector<ModelMorph>::ConstIterator i = morphs_.Begin(); i != morphs_.End(); ++i)
@@ -994,7 +994,7 @@ void AnimatedModel::AssignBoneNodes()
 void AnimatedModel::FinalizeBoneBoundingBoxes()
 {
     Vector<Bone>& bones = skeleton_.GetModifiableBones();
-    PODVector<AnimatedModel*> models;
+    Vector<AnimatedModel*> models;
     GetComponents<AnimatedModel>(models);
 
     if (models.Size() > 1)
@@ -1013,7 +1013,7 @@ void AnimatedModel::FinalizeBoneBoundingBoxes()
 
         // Get matching bones from all non-master models and merge their bone bounding information
         // to prevent culling errors (master model may not have geometry in all bones, or the bounds are smaller)
-        for (PODVector<AnimatedModel*>::Iterator i = models.Begin(); i != models.End(); ++i)
+        for (Vector<AnimatedModel*>::Iterator i = models.Begin(); i != models.End(); ++i)
         {
             if ((*i) == this)
                 continue;

--- a/Source/Urho3D/Graphics/AnimatedModel.h
+++ b/Source/Urho3D/Graphics/AnimatedModel.h
@@ -38,7 +38,7 @@ public:
     /// Apply attribute changes that can not be applied immediately. Called after scene load or a network update.
     void ApplyAttributes() override;
     /// Process octree raycast. May be called from a worker thread.
-    void ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQueryResult>& results) override;
+    void ProcessRayQuery(const RayOctreeQuery& query, Vector<RayQueryResult>& results) override;
     /// Update before octree reinsertion. Is called from a worker thread.
     void Update(const FrameInfo& frame) override;
     /// Calculate distance and prepare batches for rendering. May be called from worker thread(s), possibly re-entrantly.
@@ -141,7 +141,7 @@ public:
     /// Set animation states attribute.
     void SetAnimationStatesAttr(const VariantVector& value);
     /// Set morphs attribute.
-    void SetMorphsAttr(const PODVector<unsigned char>& value);
+    void SetMorphsAttr(const Vector<unsigned char>& value);
     /// Return model attribute.
     ResourceRef GetModelAttr() const;
     /// Return bones' animation enabled attribute.
@@ -149,13 +149,13 @@ public:
     /// Return animation states attribute.
     VariantVector GetAnimationStatesAttr() const;
     /// Return morphs attribute.
-    const PODVector<unsigned char>& GetMorphsAttr() const;
+    const Vector<unsigned char>& GetMorphsAttr() const;
 
     /// Return per-geometry bone mappings.
-    const Vector<PODVector<unsigned>>& GetGeometryBoneMappings() const { return geometryBoneMappings_; }
+    const Vector<Vector<unsigned>>& GetGeometryBoneMappings() const { return geometryBoneMappings_; }
 
     /// Return per-geometry skin matrices. If empty, uses global skinning.
-    const Vector<PODVector<Matrix3x4>>& GetGeometrySkinMatrices() const { return geometrySkinMatrices_; }
+    const Vector<Vector<Matrix3x4>>& GetGeometrySkinMatrices() const { return geometrySkinMatrices_; }
 
     /// Recalculate the bone bounding box. Normally called internally, but can also be manually called if up-to-date information before rendering is necessary.
     void UpdateBoneBoundingBox();
@@ -210,13 +210,13 @@ private:
     /// Animation states.
     Vector<SharedPtr<AnimationState>> animationStates_;
     /// Skinning matrices.
-    PODVector<Matrix3x4> skinMatrices_;
+    Vector<Matrix3x4> skinMatrices_;
     /// Mapping of subgeometry bone indices, used if more bones than skinning shader can manage.
-    Vector<PODVector<unsigned>> geometryBoneMappings_;
+    Vector<Vector<unsigned>> geometryBoneMappings_;
     /// Subgeometry skinning matrices, used if more bones than skinning shader can manage.
-    Vector<PODVector<Matrix3x4>> geometrySkinMatrices_;
+    Vector<Vector<Matrix3x4>> geometrySkinMatrices_;
     /// Subgeometry skinning matrix pointers, if more bones than skinning shader can manage.
-    Vector<PODVector<Matrix3x4*>> geometrySkinMatrixPtrs_;
+    Vector<Vector<Matrix3x4*>> geometrySkinMatrixPtrs_;
     /// Bounding box calculated from bones.
     BoundingBox boneBoundingBox_;
     /// Attribute buffer.

--- a/Source/Urho3D/Graphics/AnimationController.cpp
+++ b/Source/Urho3D/Graphics/AnimationController.cpp
@@ -48,7 +48,7 @@ void AnimationController::RegisterObject(Context* context)
     URHO3D_ACCESSOR_ATTRIBUTE("Is Enabled", IsEnabled, SetEnabled, bool, true, AM_DEFAULT);
     URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Animations", GetAnimationsAttr, SetAnimationsAttr, VariantVector, Variant::emptyVariantVector,
         AM_FILE | AM_NOEDIT);
-    URHO3D_ACCESSOR_ATTRIBUTE("Network Animations", GetNetAnimationsAttr, SetNetAnimationsAttr, PODVector<unsigned char>,
+    URHO3D_ACCESSOR_ATTRIBUTE("Network Animations", GetNetAnimationsAttr, SetNetAnimationsAttr, Vector<unsigned char>,
         Variant::emptyBuffer, AM_NET | AM_LATESTDATA | AM_NOEDIT);
     URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Node Animation States", GetNodeAnimationStatesAttr, SetNodeAnimationStatesAttr, VariantVector,
         Variant::emptyVariantVector, AM_FILE | AM_NOEDIT);
@@ -590,7 +590,7 @@ void AnimationController::SetAnimationsAttr(const VariantVector& value)
     }
 }
 
-void AnimationController::SetNetAnimationsAttr(const PODVector<unsigned char>& value)
+void AnimationController::SetNetAnimationsAttr(const Vector<unsigned char>& value)
 {
     MemoryBuffer buf(value);
 
@@ -739,7 +739,7 @@ VariantVector AnimationController::GetAnimationsAttr() const
     return ret;
 }
 
-const PODVector<unsigned char>& AnimationController::GetNetAnimationsAttr() const
+const Vector<unsigned char>& AnimationController::GetNetAnimationsAttr() const
 {
     attrBuffer_.Clear();
 

--- a/Source/Urho3D/Graphics/AnimationController.h
+++ b/Source/Urho3D/Graphics/AnimationController.h
@@ -156,18 +156,19 @@ public:
     /// Find an animation state by animation name hash.
     AnimationState* GetAnimationState(StringHash nameHash) const;
     /// Return the animation control structures for inspection.
+    /// @nobindtemp
     const Vector<AnimationControl>& GetAnimations() const { return animations_; }
 
     /// Set animation control structures attribute.
     void SetAnimationsAttr(const VariantVector& value);
     /// Set animations attribute for network replication.
-    void SetNetAnimationsAttr(const PODVector<unsigned char>& value);
+    void SetNetAnimationsAttr(const Vector<unsigned char>& value);
     /// Set node animation states attribute.
     void SetNodeAnimationStatesAttr(const VariantVector& value);
     /// Return animation control structures attribute.
     VariantVector GetAnimationsAttr() const;
     /// Return animations attribute for network replication.
-    const PODVector<unsigned char>& GetNetAnimationsAttr() const;
+    const Vector<unsigned char>& GetNetAnimationsAttr() const;
     /// Return node animation states attribute.
     VariantVector GetNodeAnimationStatesAttr() const;
 

--- a/Source/Urho3D/Graphics/Batch.cpp
+++ b/Source/Urho3D/Graphics/Batch.cpp
@@ -526,7 +526,7 @@ void Batch::Prepare(View* view, Camera* camera, bool setModelTransform, bool all
                  graphics->NeedParameterUpdate(SP_LIGHT, lightQueue_))
         {
             Vector4 vertexLights[MAX_VERTEX_LIGHTS * 3];
-            const PODVector<Light*>& lights = lightQueue_->vertexLights_;
+            const Vector<Light*>& lights = lightQueue_->vertexLights_;
 
             for (unsigned i = 0; i < lights.Size(); ++i)
             {
@@ -755,7 +755,7 @@ void BatchQueue::SortFrontToBack()
         else
         {
             float minDistance = M_INFINITY;
-            for (PODVector<InstanceData>::ConstIterator j = i->second_.instances_.Begin(); j != i->second_.instances_.End(); ++j)
+            for (Vector<InstanceData>::ConstIterator j = i->second_.instances_.Begin(); j != i->second_.instances_.End(); ++j)
                 minDistance = Min(minDistance, j->distance_);
             i->second_.distance_ = minDistance;
         }
@@ -767,10 +767,10 @@ void BatchQueue::SortFrontToBack()
     for (HashMap<BatchGroupKey, BatchGroup>::Iterator i = batchGroups_.Begin(); i != batchGroups_.End(); ++i)
         sortedBatchGroups_[index++] = &i->second_;
 
-    SortFrontToBack2Pass(reinterpret_cast<PODVector<Batch*>& >(sortedBatchGroups_));
+    SortFrontToBack2Pass(reinterpret_cast<Vector<Batch*>& >(sortedBatchGroups_));
 }
 
-void BatchQueue::SortFrontToBack2Pass(PODVector<Batch*>& batches)
+void BatchQueue::SortFrontToBack2Pass(Vector<Batch*>& batches)
 {
     // Mobile devices likely use a tiled deferred approach, with which front-to-back sorting is irrelevant. The 2-pass
     // method is also time consuming, so just sort with state having priority
@@ -784,7 +784,7 @@ void BatchQueue::SortFrontToBack2Pass(PODVector<Batch*>& batches)
     unsigned short freeMaterialID = 0;
     unsigned short freeGeometryID = 0;
 
-    for (PODVector<Batch*>::Iterator i = batches.Begin(); i != batches.End(); ++i)
+    for (Vector<Batch*>::Iterator i = batches.Begin(); i != batches.End(); ++i)
     {
         Batch* batch = *i;
 
@@ -852,7 +852,7 @@ void BatchQueue::Draw(View* view, Camera* camera, bool markToStencil, bool using
     }
 
     // Instanced
-    for (PODVector<BatchGroup*>::ConstIterator i = sortedBatchGroups_.Begin(); i != sortedBatchGroups_.End(); ++i)
+    for (Vector<BatchGroup*>::ConstIterator i = sortedBatchGroups_.Begin(); i != sortedBatchGroups_.End(); ++i)
     {
         BatchGroup* group = *i;
         if (markToStencil)
@@ -861,7 +861,7 @@ void BatchQueue::Draw(View* view, Camera* camera, bool markToStencil, bool using
         group->Draw(view, camera, allowDepthWrite);
     }
     // Non-instanced
-    for (PODVector<Batch*>::ConstIterator i = sortedBatches_.Begin(); i != sortedBatches_.End(); ++i)
+    for (Vector<Batch*>::ConstIterator i = sortedBatches_.Begin(); i != sortedBatches_.End(); ++i)
     {
         Batch* batch = *i;
         if (markToStencil)

--- a/Source/Urho3D/Graphics/Batch.h
+++ b/Source/Urho3D/Graphics/Batch.h
@@ -150,7 +150,7 @@ struct BatchGroup : public Batch
     void Draw(View* view, Camera* camera, bool allowDepthWrite) const;
 
     /// Instance data.
-    PODVector<InstanceData> instances_;
+    Vector<InstanceData> instances_;
     /// Instance stream start index, or M_MAX_UNSIGNED if transforms not pre-set.
     unsigned startIndex_;
 };
@@ -214,7 +214,7 @@ public:
     /// Sort instanced and non-instanced draw calls front to back.
     void SortFrontToBack();
     /// Sort batches front to back while also maintaining state sorting.
-    void SortFrontToBack2Pass(PODVector<Batch*>& batches);
+    void SortFrontToBack2Pass(Vector<Batch*>& batches);
     /// Pre-set instance data of all groups. The vertex buffer must be big enough to hold all data.
     void SetInstancingData(void* lockedData, unsigned stride, unsigned& freeIndex);
     /// Draw.
@@ -235,11 +235,11 @@ public:
     HashMap<unsigned short, unsigned short> geometryRemapping_;
 
     /// Unsorted non-instanced draw calls.
-    PODVector<Batch> batches_;
+    Vector<Batch> batches_;
     /// Sorted non-instanced draw calls.
-    PODVector<Batch*> sortedBatches_;
+    Vector<Batch*> sortedBatches_;
     /// Sorted instanced draw calls.
-    PODVector<BatchGroup*> sortedBatchGroups_;
+    Vector<BatchGroup*> sortedBatchGroups_;
     /// Maximum sorted instances.
     unsigned maxSortedInstances_;
     /// Whether the pass command contains extra shader defines.
@@ -285,9 +285,9 @@ struct LightBatchQueue
     /// Shadow map split queues.
     Vector<ShadowBatchQueue> shadowSplits_;
     /// Per-vertex lights.
-    PODVector<Light*> vertexLights_;
+    Vector<Light*> vertexLights_;
     /// Light volume draw calls.
-    PODVector<Batch> volumeBatches_;
+    Vector<Batch> volumeBatches_;
 };
 
 }

--- a/Source/Urho3D/Graphics/BillboardSet.cpp
+++ b/Source/Urho3D/Graphics/BillboardSet.cpp
@@ -109,11 +109,11 @@ void BillboardSet::RegisterObject(Context* context)
     URHO3D_COPY_BASE_ATTRIBUTES(Drawable);
     URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Billboards", GetBillboardsAttr, SetBillboardsAttr, VariantVector, Variant::emptyVariantVector, AM_FILE)
         .SetMetadata(AttributeMetadata::P_VECTOR_STRUCT_ELEMENTS, billboardsStructureElementNames);
-    URHO3D_ACCESSOR_ATTRIBUTE("Network Billboards", GetNetBillboardsAttr, SetNetBillboardsAttr, PODVector<unsigned char>,
+    URHO3D_ACCESSOR_ATTRIBUTE("Network Billboards", GetNetBillboardsAttr, SetNetBillboardsAttr, Vector<unsigned char>,
         Variant::emptyBuffer, AM_NET | AM_NOEDIT);
 }
 
-void BillboardSet::ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQueryResult>& results)
+void BillboardSet::ProcessRayQuery(const RayOctreeQuery& query, Vector<RayQueryResult>& results)
 {
     // If no billboard-level testing, use the Drawable test
     if (query.level_ < RAY_TRIANGLE)
@@ -355,7 +355,7 @@ void BillboardSet::SetBillboardsAttr(const VariantVector& value)
     // Dealing with old billboard format
     if (value.Size() == billboards_.Size() * 6 + 1)
     {
-        for (PODVector<Billboard>::Iterator i = billboards_.Begin(); i != billboards_.End() && index < value.Size(); ++i)
+        for (Vector<Billboard>::Iterator i = billboards_.Begin(); i != billboards_.End() && index < value.Size(); ++i)
         {
             i->position_ = value[index++].GetVector3();
             i->size_ = value[index++].GetVector2();
@@ -369,7 +369,7 @@ void BillboardSet::SetBillboardsAttr(const VariantVector& value)
     // New billboard format
     else
     {
-        for (PODVector<Billboard>::Iterator i = billboards_.Begin(); i != billboards_.End() && index < value.Size(); ++i)
+        for (Vector<Billboard>::Iterator i = billboards_.Begin(); i != billboards_.End() && index < value.Size(); ++i)
         {
             i->position_ = value[index++].GetVector3();
             i->size_ = value[index++].GetVector2();
@@ -385,13 +385,13 @@ void BillboardSet::SetBillboardsAttr(const VariantVector& value)
     Commit();
 }
 
-void BillboardSet::SetNetBillboardsAttr(const PODVector<unsigned char>& value)
+void BillboardSet::SetNetBillboardsAttr(const Vector<unsigned char>& value)
 {
     MemoryBuffer buf(value);
     unsigned numBillboards = buf.ReadVLE();
     SetNumBillboards(numBillboards);
 
-    for (PODVector<Billboard>::Iterator i = billboards_.Begin(); i != billboards_.End(); ++i)
+    for (Vector<Billboard>::Iterator i = billboards_.Begin(); i != billboards_.End(); ++i)
     {
         i->position_ = buf.ReadVector3();
         i->size_ = buf.ReadVector2();
@@ -416,7 +416,7 @@ VariantVector BillboardSet::GetBillboardsAttr() const
     ret.Reserve(billboards_.Size() * 7 + 1);
     ret.Push(billboards_.Size());
 
-    for (PODVector<Billboard>::ConstIterator i = billboards_.Begin(); i != billboards_.End(); ++i)
+    for (Vector<Billboard>::ConstIterator i = billboards_.Begin(); i != billboards_.End(); ++i)
     {
         ret.Push(i->position_);
         ret.Push(i->size_);
@@ -430,12 +430,12 @@ VariantVector BillboardSet::GetBillboardsAttr() const
     return ret;
 }
 
-const PODVector<unsigned char>& BillboardSet::GetNetBillboardsAttr() const
+const Vector<unsigned char>& BillboardSet::GetNetBillboardsAttr() const
 {
     attrBuffer_.Clear();
     attrBuffer_.WriteVLE(billboards_.Size());
 
-    for (PODVector<Billboard>::ConstIterator i = billboards_.Begin(); i != billboards_.End(); ++i)
+    for (Vector<Billboard>::ConstIterator i = billboards_.Begin(); i != billboards_.End(); ++i)
     {
         attrBuffer_.WriteVector3(i->position_);
         attrBuffer_.WriteVector2(i->size_);

--- a/Source/Urho3D/Graphics/BillboardSet.h
+++ b/Source/Urho3D/Graphics/BillboardSet.h
@@ -54,7 +54,7 @@ public:
     static void RegisterObject(Context* context);
 
     /// Process octree raycast. May be called from a worker thread.
-    void ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQueryResult>& results) override;
+    void ProcessRayQuery(const RayOctreeQuery& query, Vector<RayQueryResult>& results) override;
     /// Calculate distance and prepare batches for rendering. May be called from worker thread(s), possibly re-entrantly.
     void UpdateBatches(const FrameInfo& frame) override;
     /// Prepare geometry for rendering. Called from a worker thread if possible (no GPU update).
@@ -101,7 +101,7 @@ public:
     unsigned GetNumBillboards() const { return billboards_.Size(); }
 
     /// Return all billboards.
-    PODVector<Billboard>& GetBillboards() { return billboards_; }
+    Vector<Billboard>& GetBillboards() { return billboards_; }
 
     /// Return billboard by index.
     /// @property{get_billboards}
@@ -140,13 +140,13 @@ public:
     /// Set billboards attribute.
     void SetBillboardsAttr(const VariantVector& value);
     /// Set billboards attribute for network replication.
-    void SetNetBillboardsAttr(const PODVector<unsigned char>& value);
+    void SetNetBillboardsAttr(const Vector<unsigned char>& value);
     /// Return material attribute.
     ResourceRef GetMaterialAttr() const;
     /// Return billboards attribute.
     VariantVector GetBillboardsAttr() const;
     /// Return billboards attribute for network replication.
-    const PODVector<unsigned char>& GetNetBillboardsAttr() const;
+    const Vector<unsigned char>& GetNetBillboardsAttr() const;
 
 protected:
     /// Recalculate the world-space bounding box.
@@ -155,7 +155,7 @@ protected:
     void MarkPositionsDirty();
 
     /// Billboards.
-    PODVector<Billboard> billboards_;
+    Vector<Billboard> billboards_;
     /// Animation LOD bias.
     float animationLodBias_;
     /// Animation LOD timer.

--- a/Source/Urho3D/Graphics/CustomGeometry.cpp
+++ b/Source/Urho3D/Graphics/CustomGeometry.cpp
@@ -45,7 +45,7 @@ void CustomGeometry::RegisterObject(Context* context)
 
     URHO3D_ACCESSOR_ATTRIBUTE("Is Enabled", IsEnabled, SetEnabled, bool, true, AM_DEFAULT);
     URHO3D_ATTRIBUTE("Dynamic Vertex Buffer", bool, dynamic_, false, AM_DEFAULT);
-    URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Geometry Data", GetGeometryDataAttr, SetGeometryDataAttr, PODVector<unsigned char>,
+    URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Geometry Data", GetGeometryDataAttr, SetGeometryDataAttr, Vector<unsigned char>,
                                     Variant::emptyBuffer, AM_FILE | AM_NOEDIT);
     URHO3D_ACCESSOR_ATTRIBUTE("Materials", GetMaterialsAttr, SetMaterialsAttr, ResourceRefList,
                               ResourceRefList(Material::GetTypeStatic()), AM_DEFAULT);
@@ -58,7 +58,7 @@ void CustomGeometry::RegisterObject(Context* context)
     URHO3D_COPY_BASE_ATTRIBUTES(Drawable);
 }
 
-void CustomGeometry::ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQueryResult>& results)
+void CustomGeometry::ProcessRayQuery(const RayOctreeQuery& query, Vector<RayQueryResult>& results)
 {
     RayQueryLevel level = query.level_;
 
@@ -167,7 +167,7 @@ bool CustomGeometry::DrawOcclusion(OcclusionBuffer* buffer)
         unsigned vertexSize;
         const unsigned char* indexData;
         unsigned indexSize;
-        const PODVector<VertexElement>* elements;
+        const Vector<VertexElement>* elements;
 
         geometry->GetRawData(vertexData, vertexSize, indexData, indexSize, elements);
         // Check for valid geometry data
@@ -428,7 +428,7 @@ CustomGeometryVertex* CustomGeometry::GetVertex(unsigned geometryIndex, unsigned
                : nullptr;
 }
 
-void CustomGeometry::SetGeometryDataAttr(const PODVector<unsigned char>& value)
+void CustomGeometry::SetGeometryDataAttr(const Vector<unsigned char>& value)
 {
     if (value.Empty())
         return;
@@ -469,7 +469,7 @@ void CustomGeometry::SetMaterialsAttr(const ResourceRefList& value)
         SetMaterial(i, cache->GetResource<Material>(value.names_[i]));
 }
 
-PODVector<unsigned char> CustomGeometry::GetGeometryDataAttr() const
+Vector<unsigned char> CustomGeometry::GetGeometryDataAttr() const
 {
     VectorBuffer ret;
 

--- a/Source/Urho3D/Graphics/CustomGeometry.h
+++ b/Source/Urho3D/Graphics/CustomGeometry.h
@@ -41,7 +41,7 @@ public:
     static void RegisterObject(Context* context);
 
     /// Process octree raycast. May be called from a worker thread.
-    void ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQueryResult>& results) override;
+    void ProcessRayQuery(const RayOctreeQuery& query, Vector<RayQueryResult>& results) override;
     /// Return the geometry for a specific LOD level.
     Geometry* GetLodGeometry(unsigned batchIndex, unsigned level) override;
     /// Return number of occlusion geometry triangles.
@@ -99,17 +99,17 @@ public:
     Material* GetMaterial(unsigned index = 0) const;
 
     /// Return all vertices. These can be edited; calling Commit() updates the vertex buffer.
-    Vector<PODVector<CustomGeometryVertex>>& GetVertices() { return vertices_; }
+    Vector<Vector<CustomGeometryVertex>>& GetVertices() { return vertices_; }
 
     /// Return a vertex in a geometry for editing, or null if out of bounds. After the edits are finished, calling Commit() updates  the vertex buffer.
     CustomGeometryVertex* GetVertex(unsigned geometryIndex, unsigned vertexNum);
 
     /// Set geometry data attribute.
-    void SetGeometryDataAttr(const PODVector<unsigned char>& value);
+    void SetGeometryDataAttr(const Vector<unsigned char>& value);
     /// Set materials attribute.
     void SetMaterialsAttr(const ResourceRefList& value);
     /// Return geometry data attribute.
-    PODVector<unsigned char> GetGeometryDataAttr() const;
+    Vector<unsigned char> GetGeometryDataAttr() const;
     /// Return materials attribute.
     const ResourceRefList& GetMaterialsAttr() const;
 
@@ -119,9 +119,9 @@ protected:
 
 private:
     /// Primitive type per geometry.
-    PODVector<PrimitiveType> primitiveTypes_;
+    Vector<PrimitiveType> primitiveTypes_;
     /// Source vertices per geometry.
-    Vector<PODVector<CustomGeometryVertex>> vertices_;
+    Vector<Vector<CustomGeometryVertex>> vertices_;
     /// All geometries.
     Vector<SharedPtr<Geometry>> geometries_;
     /// Vertex buffer.

--- a/Source/Urho3D/Graphics/DebugRenderer.cpp
+++ b/Source/Urho3D/Graphics/DebugRenderer.cpp
@@ -229,7 +229,7 @@ void DebugRenderer::AddPolyhedron(const Polyhedron& poly, const Color& color, bo
 
     for (unsigned i = 0; i < poly.faces_.Size(); ++i)
     {
-        const PODVector<Vector3>& face = poly.faces_[i];
+        const Vector<Vector3>& face = poly.faces_[i];
         if (face.Size() >= 3)
         {
             for (unsigned j = 0; j < face.Size(); ++j)

--- a/Source/Urho3D/Graphics/DebugRenderer.h
+++ b/Source/Urho3D/Graphics/DebugRenderer.h
@@ -157,13 +157,13 @@ private:
     void HandleEndFrame(StringHash eventType, VariantMap& eventData);
 
     /// Lines rendered with depth test.
-    PODVector<DebugLine> lines_;
+    Vector<DebugLine> lines_;
     /// Lines rendered without depth test.
-    PODVector<DebugLine> noDepthLines_;
+    Vector<DebugLine> noDepthLines_;
     /// Triangles rendered with depth test.
-    PODVector<DebugTriangle> triangles_;
+    Vector<DebugTriangle> triangles_;
     /// Triangles rendered without depth test.
-    PODVector<DebugTriangle> noDepthTriangles_;
+    Vector<DebugTriangle> noDepthTriangles_;
     /// View transform.
     Matrix3x4 view_;
     /// Projection transform.

--- a/Source/Urho3D/Graphics/DecalSet.h
+++ b/Source/Urho3D/Graphics/DecalSet.h
@@ -75,9 +75,9 @@ struct Decal
     /// Local-space bounding box.
     BoundingBox boundingBox_;
     /// Decal vertices.
-    PODVector<DecalVertex> vertices_;
+    Vector<DecalVertex> vertices_;
     /// Decal indices.
-    PODVector<unsigned short> indices_;
+    Vector<unsigned short> indices_;
 };
 
 /// %Decal renderer component.
@@ -99,7 +99,7 @@ public:
     /// Handle enabled/disabled state change.
     void OnSetEnabled() override;
     /// Process octree raycast. May be called from a worker thread.
-    void ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQueryResult>& results) override;
+    void ProcessRayQuery(const RayOctreeQuery& query, Vector<RayQueryResult>& results) override;
     /// Calculate distance and prepare batches for rendering. May be called from worker thread(s), possibly re-entrantly.
     void UpdateBatches(const FrameInfo& frame) override;
     /// Prepare geometry for rendering. Called from a worker thread if possible (no GPU update).
@@ -159,11 +159,11 @@ public:
     /// Set material attribute.
     void SetMaterialAttr(const ResourceRef& value);
     /// Set decals attribute.
-    void SetDecalsAttr(const PODVector<unsigned char>& value);
+    void SetDecalsAttr(const Vector<unsigned char>& value);
     /// Return material attribute.
     ResourceRef GetMaterialAttr() const;
     /// Return decals attribute.
-    PODVector<unsigned char> GetDecalsAttr() const;
+    Vector<unsigned char> GetDecalsAttr() const;
 
 protected:
     /// Recalculate the world-space bounding box.
@@ -173,11 +173,11 @@ protected:
 
 private:
     /// Get triangle faces from the target geometry.
-    void GetFaces(Vector<PODVector<DecalVertex>>& faces, Drawable* target, unsigned batchIndex, const Frustum& frustum,
+    void GetFaces(Vector<Vector<DecalVertex>>& faces, Drawable* target, unsigned batchIndex, const Frustum& frustum,
         const Vector3& decalNormal, float normalCutoff);
     /// Get triangle face from the target geometry.
     void GetFace
-        (Vector<PODVector<DecalVertex>>& faces, Drawable* target, unsigned batchIndex, unsigned i0, unsigned i1, unsigned i2,
+        (Vector<Vector<DecalVertex>>& faces, Drawable* target, unsigned batchIndex, unsigned i0, unsigned i1, unsigned i2,
             const unsigned char* positionData, const unsigned char* normalData, const unsigned char* skinningData,
             unsigned positionStride, unsigned normalStride, unsigned skinningStride, const Frustum& frustum,
             const Vector3& decalNormal, float normalCutoff);
@@ -219,7 +219,7 @@ private:
     /// Bones used for skinned decals.
     Vector<Bone> bones_;
     /// Skinning matrices.
-    PODVector<Matrix3x4> skinMatrices_;
+    Vector<Matrix3x4> skinMatrices_;
     /// Vertices in the current decals.
     unsigned numVertices_;
     /// Indices in the current decals.

--- a/Source/Urho3D/Graphics/Drawable.cpp
+++ b/Source/Urho3D/Graphics/Drawable.cpp
@@ -91,7 +91,7 @@ void Drawable::OnSetEnabled()
         RemoveFromOctree();
 }
 
-void Drawable::ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQueryResult>& results)
+void Drawable::ProcessRayQuery(const RayOctreeQuery& query, Vector<RayQueryResult>& results)
 {
     float distance = query.ray_.HitDistance(GetWorldBoundingBox());
     if (distance < query.maxDistance_)
@@ -395,7 +395,7 @@ void Drawable::RemoveFromOctree()
     }
 }
 
-bool WriteDrawablesToOBJ(const PODVector<Drawable*>& drawables, File* outputFile, bool asZUp, bool asRightHanded, bool writeLightmapUV)
+bool WriteDrawablesToOBJ(const Vector<Drawable*>& drawables, File* outputFile, bool asZUp, bool asRightHanded, bool writeLightmapUV)
 {
     // Must track indices independently to deal with potential mismatching of drawables vertex attributes (ie. one with UV, another without, then another with)
     unsigned currentPositionIndex = 1;
@@ -438,7 +438,7 @@ bool WriteDrawablesToOBJ(const PODVector<Drawable*>& drawables, File* outputFile
             const unsigned char* vertexData;
             const unsigned char* indexData;
             unsigned elementSize, indexSize;
-            const PODVector<VertexElement>* elements;
+            const Vector<VertexElement>* elements;
             geo->GetRawData(vertexData, elementSize, indexData, indexSize, elements);
             if (!vertexData || !elements)
                 continue;

--- a/Source/Urho3D/Graphics/Drawable.h
+++ b/Source/Urho3D/Graphics/Drawable.h
@@ -108,7 +108,7 @@ public:
     /// Handle enabled/disabled state change.
     void OnSetEnabled() override;
     /// Process octree raycast. May be called from a worker thread.
-    virtual void ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQueryResult>& results);
+    virtual void ProcessRayQuery(const RayOctreeQuery& query, Vector<RayQueryResult>& results);
     /// Update before octree reinsertion. Is called from a worker thread.
     virtual void Update(const FrameInfo& frame) { }
     /// Calculate distance and prepare batches for rendering. May be called from worker thread(s), possibly re-entrantly.
@@ -280,10 +280,10 @@ public:
     bool HasBasePass(unsigned batchIndex) const { return (basePassFlags_ & (1u << batchIndex)) != 0; }
 
     /// Return per-pixel lights.
-    const PODVector<Light*>& GetLights() const { return lights_; }
+    const Vector<Light*>& GetLights() const { return lights_; }
 
     /// Return per-vertex lights.
-    const PODVector<Light*>& GetVertexLights() const { return vertexLights_; }
+    const Vector<Light*>& GetVertexLights() const { return vertexLights_; }
 
     /// Return the first added per-pixel light.
     Light* GetFirstLight() const { return firstLight_; }
@@ -388,13 +388,13 @@ protected:
     /// Maximum per-pixel lights.
     unsigned maxLights_;
     /// List of cameras from which is seen on the current frame.
-    PODVector<Camera*> viewCameras_;
+    Vector<Camera*> viewCameras_;
     /// First per-pixel light added this frame.
     Light* firstLight_;
     /// Per-pixel lights affecting this drawable.
-    PODVector<Light*> lights_;
+    Vector<Light*> lights_;
     /// Per-vertex lights affecting this drawable.
-    PODVector<Light*> vertexLights_;
+    Vector<Light*> vertexLights_;
 };
 
 inline bool CompareDrawables(Drawable* lhs, Drawable* rhs)
@@ -402,6 +402,6 @@ inline bool CompareDrawables(Drawable* lhs, Drawable* rhs)
     return lhs->GetSortValue() < rhs->GetSortValue();
 }
 
-URHO3D_API bool WriteDrawablesToOBJ(const PODVector<Drawable*>& drawables, File* outputFile, bool asZUp, bool asRightHanded, bool writeLightmapUV = false);
+URHO3D_API bool WriteDrawablesToOBJ(const Vector<Drawable*>& drawables, File* outputFile, bool asZUp, bool asRightHanded, bool writeLightmapUV = false);
 
 }

--- a/Source/Urho3D/Graphics/Geometry.cpp
+++ b/Source/Urho3D/Graphics/Geometry.cpp
@@ -134,7 +134,7 @@ void Geometry::SetLodDistance(float distance)
     lodDistance_ = distance;
 }
 
-void Geometry::SetRawVertexData(const SharedArrayPtr<unsigned char>& data, const PODVector<VertexElement>& elements)
+void Geometry::SetRawVertexData(const SharedArrayPtr<unsigned char>& data, const Vector<VertexElement>& elements)
 {
     rawVertexData_ = data;
     rawVertexSize_ = VertexBuffer::GetVertexSize(elements);
@@ -191,7 +191,7 @@ unsigned short Geometry::GetBufferHash() const
 }
 
 void Geometry::GetRawData(const unsigned char*& vertexData, unsigned& vertexSize, const unsigned char*& indexData,
-    unsigned& indexSize, const PODVector<VertexElement>*& elements) const
+    unsigned& indexSize, const Vector<VertexElement>*& elements) const
 {
     if (rawVertexData_)
     {
@@ -236,7 +236,7 @@ void Geometry::GetRawData(const unsigned char*& vertexData, unsigned& vertexSize
 }
 
 void Geometry::GetRawDataShared(SharedArrayPtr<unsigned char>& vertexData, unsigned& vertexSize,
-    SharedArrayPtr<unsigned char>& indexData, unsigned& indexSize, const PODVector<VertexElement>*& elements) const
+    SharedArrayPtr<unsigned char>& indexData, unsigned& indexSize, const Vector<VertexElement>*& elements) const
 {
     if (rawVertexData_)
     {
@@ -286,7 +286,7 @@ float Geometry::GetHitDistance(const Ray& ray, Vector3* outNormal, Vector2* outU
     const unsigned char* indexData;
     unsigned vertexSize;
     unsigned indexSize;
-    const PODVector<VertexElement>* elements;
+    const Vector<VertexElement>* elements;
 
     GetRawData(vertexData, vertexSize, indexData, indexSize, elements);
 
@@ -313,7 +313,7 @@ bool Geometry::IsInside(const Ray& ray) const
     const unsigned char* indexData;
     unsigned vertexSize;
     unsigned indexSize;
-    const PODVector<VertexElement>* elements;
+    const Vector<VertexElement>* elements;
 
     GetRawData(vertexData, vertexSize, indexData, indexSize, elements);
 

--- a/Source/Urho3D/Graphics/Geometry.h
+++ b/Source/Urho3D/Graphics/Geometry.h
@@ -43,7 +43,7 @@ public:
     /// @property
     void SetLodDistance(float distance);
     /// Override raw vertex data to be returned for CPU-side operations.
-    void SetRawVertexData(const SharedArrayPtr<unsigned char>& data, const PODVector<VertexElement>& elements);
+    void SetRawVertexData(const SharedArrayPtr<unsigned char>& data, const Vector<VertexElement>& elements);
     /// Override raw vertex data to be returned for CPU-side operations using a legacy vertex bitmask.
     void SetRawVertexData(const SharedArrayPtr<unsigned char>& data, unsigned elementMask);
     /// Override raw index data to be returned for CPU-side operations.
@@ -93,10 +93,10 @@ public:
     /// Return buffers' combined hash value for state sorting.
     unsigned short GetBufferHash() const;
     /// Return raw vertex and index data for CPU operations, or null pointers if not available. Will return data of the first vertex buffer if override data not set.
-    void GetRawData(const unsigned char*& vertexData, unsigned& vertexSize, const unsigned char*& indexData, unsigned& indexSize, const PODVector<VertexElement>*& elements) const;
+    void GetRawData(const unsigned char*& vertexData, unsigned& vertexSize, const unsigned char*& indexData, unsigned& indexSize, const Vector<VertexElement>*& elements) const;
     /// Return raw vertex and index data for CPU operations, or null pointers if not available. Will return data of the first vertex buffer if override data not set.
     void GetRawDataShared(SharedArrayPtr<unsigned char>& vertexData, unsigned& vertexSize, SharedArrayPtr<unsigned char>& indexData,
-        unsigned& indexSize, const PODVector<VertexElement>*& elements) const;
+        unsigned& indexSize, const Vector<VertexElement>*& elements) const;
     /// Return ray hit distance or infinity if no hit. Requires raw data to be set. Optionally return hit normal and hit uv coordinates at intersect point.
     float GetHitDistance(const Ray& ray, Vector3* outNormal = nullptr, Vector2* outUV = nullptr) const;
     /// Return whether or not the ray is inside geometry.
@@ -124,7 +124,7 @@ private:
     /// LOD distance.
     float lodDistance_;
     /// Raw vertex data elements.
-    PODVector<VertexElement> rawElements_;
+    Vector<VertexElement> rawElements_;
     /// Raw vertex data override.
     SharedArrayPtr<unsigned char> rawVertexData_;
     /// Raw index data override.

--- a/Source/Urho3D/Graphics/Graphics.cpp
+++ b/Source/Urho3D/Graphics/Graphics.cpp
@@ -198,7 +198,7 @@ void Graphics::SetShaderParameter(StringHash param, const Variant& value)
 
     case VAR_BUFFER:
         {
-            const PODVector<unsigned char>& buffer = value.GetBuffer();
+            const Vector<unsigned char>& buffer = value.GetBuffer();
             if (buffer.Size() >= sizeof(float))
                 SetShaderParameter(param, reinterpret_cast<const float*>(&buffer[0]), buffer.Size() / sizeof(float));
         }
@@ -221,9 +221,9 @@ IntVector2 Graphics::GetWindowPosition() const
     return position_;
 }
 
-PODVector<IntVector3> Graphics::GetResolutions(int monitor) const
+Vector<IntVector3> Graphics::GetResolutions(int monitor) const
 {
-    PODVector<IntVector3> ret;
+    Vector<IntVector3> ret;
     // Emscripten is not able to return a valid list
 #ifndef __EMSCRIPTEN__
     auto numModes = (unsigned)SDL_GetNumDisplayModes(monitor);
@@ -257,7 +257,7 @@ PODVector<IntVector3> Graphics::GetResolutions(int monitor) const
 
 unsigned Graphics::FindBestResolutionIndex(int monitor, int width, int height, int refreshRate) const
 {
-    const PODVector<IntVector3> resolutions = GetResolutions(monitor);
+    const Vector<IntVector3> resolutions = GetResolutions(monitor);
     if (resolutions.Empty())
         return M_MAX_UNSIGNED;
 
@@ -524,7 +524,7 @@ void Graphics::AdjustScreenMode(int& newWidth, int& newHeight, ScreenModeParams&
 #ifdef DESKTOP_GRAPHICS
     if (params.fullscreen_)
     {
-        const PODVector<IntVector3> resolutions = GetResolutions(params.monitor_);
+        const Vector<IntVector3> resolutions = GetResolutions(params.monitor_);
         if (!resolutions.Empty())
         {
             const unsigned bestResolution = FindBestResolutionIndex(params.monitor_,
@@ -1027,7 +1027,7 @@ void Graphics::SetVertexBuffer(VertexBuffer* buffer)
 #endif
 }
 
-bool Graphics::SetVertexBuffers(const PODVector<VertexBuffer*>& buffers, unsigned instanceOffset)
+bool Graphics::SetVertexBuffers(const Vector<VertexBuffer*>& buffers, unsigned instanceOffset)
 {
     GAPI gapi = Graphics::GetGAPI();
 
@@ -1984,7 +1984,7 @@ bool Graphics::IsDeviceLost() const
     return {}; // Prevent warning
 }
 
-PODVector<int> Graphics::GetMultiSampleLevels() const
+Vector<int> Graphics::GetMultiSampleLevels() const
 {
     GAPI gapi = Graphics::GetGAPI();
 

--- a/Source/Urho3D/Graphics/Graphics.h
+++ b/Source/Urho3D/Graphics/Graphics.h
@@ -229,7 +229,7 @@ public:
     void SetVertexBuffer(VertexBuffer* buffer);
     /// Set multiple vertex buffers.
     /// @nobind
-    bool SetVertexBuffers(const PODVector<VertexBuffer*>& buffers, unsigned instanceOffset = 0);
+    bool SetVertexBuffers(const Vector<VertexBuffer*>& buffers, unsigned instanceOffset = 0);
     /// Set multiple vertex buffers.
     bool SetVertexBuffers(const Vector<SharedPtr<VertexBuffer>>& buffers, unsigned instanceOffset = 0);
     /// Set index buffer.
@@ -501,12 +501,12 @@ public:
 
     /// Return supported fullscreen resolutions (third component is refreshRate). Will be empty if listing the resolutions is not supported on the platform (e.g. Web).
     /// @property
-    PODVector<IntVector3> GetResolutions(int monitor) const;
+    Vector<IntVector3> GetResolutions(int monitor) const;
     /// Return index of the best resolution for requested width, height and refresh rate.
     unsigned FindBestResolutionIndex(int monitor, int width, int height, int refreshRate) const;
     /// Return supported multisampling levels.
     /// @property
-    PODVector<int> GetMultiSampleLevels() const;
+    Vector<int> GetMultiSampleLevels() const;
     /// Return the desktop resolution.
     /// @property
     IntVector2 GetDesktopResolution(int monitor) const;
@@ -903,7 +903,7 @@ private:
     void DrawInstanced_OGL(PrimitiveType type, unsigned indexStart, unsigned indexCount, unsigned minVertex, unsigned vertexCount, unsigned instanceCount);
     void DrawInstanced_OGL(PrimitiveType type, unsigned indexStart, unsigned indexCount, unsigned baseVertexIndex, unsigned minVertex, unsigned vertexCount, unsigned instanceCount);
     void SetVertexBuffer_OGL(VertexBuffer* buffer);
-    bool SetVertexBuffers_OGL(const PODVector<VertexBuffer*>& buffers, unsigned instanceOffset = 0);
+    bool SetVertexBuffers_OGL(const Vector<VertexBuffer*>& buffers, unsigned instanceOffset = 0);
     bool SetVertexBuffers_OGL(const Vector<SharedPtr<VertexBuffer>>& buffers, unsigned instanceOffset = 0);
     void SetIndexBuffer_OGL(IndexBuffer* buffer);
     void SetShaders_OGL(ShaderVariation* vs, ShaderVariation* ps);
@@ -950,7 +950,7 @@ private:
     bool IsInitialized_OGL() const;
     bool GetDither_OGL() const;
     bool IsDeviceLost_OGL() const;
-    PODVector<int> GetMultiSampleLevels_OGL() const;
+    Vector<int> GetMultiSampleLevels_OGL() const;
     unsigned GetFormat_OGL(CompressedFormat format) const;
     ShaderVariation* GetShader_OGL(ShaderType type, const String& name, const String& defines = String::EMPTY) const;
     ShaderVariation* GetShader_OGL(ShaderType type, const char* name, const char* defines) const;
@@ -1007,7 +1007,7 @@ private:
     void DrawInstanced_D3D9(PrimitiveType type, unsigned indexStart, unsigned indexCount, unsigned minVertex, unsigned vertexCount, unsigned instanceCount);
     void DrawInstanced_D3D9(PrimitiveType type, unsigned indexStart, unsigned indexCount, unsigned baseVertexIndex, unsigned minVertex, unsigned vertexCount, unsigned instanceCount);
     void SetVertexBuffer_D3D9(VertexBuffer* buffer);
-    bool SetVertexBuffers_D3D9(const PODVector<VertexBuffer*>& buffers, unsigned instanceOffset = 0);
+    bool SetVertexBuffers_D3D9(const Vector<VertexBuffer*>& buffers, unsigned instanceOffset = 0);
     bool SetVertexBuffers_D3D9(const Vector<SharedPtr<VertexBuffer>>& buffers, unsigned instanceOffset = 0);
     void SetIndexBuffer_D3D9(IndexBuffer* buffer);
     void SetShaders_D3D9(ShaderVariation* vs, ShaderVariation* ps);
@@ -1054,7 +1054,7 @@ private:
     bool IsInitialized_D3D9() const;
     bool GetDither_D3D9() const;
     bool IsDeviceLost_D3D9() const;
-    PODVector<int> GetMultiSampleLevels_D3D9() const;
+    Vector<int> GetMultiSampleLevels_D3D9() const;
     unsigned GetFormat_D3D9(CompressedFormat format) const;
     ShaderVariation* GetShader_D3D9(ShaderType type, const String& name, const String& defines = String::EMPTY) const;
     ShaderVariation* GetShader_D3D9(ShaderType type, const char* name, const char* defines) const;
@@ -1111,7 +1111,7 @@ private:
     void DrawInstanced_D3D11(PrimitiveType type, unsigned indexStart, unsigned indexCount, unsigned minVertex, unsigned vertexCount, unsigned instanceCount);
     void DrawInstanced_D3D11(PrimitiveType type, unsigned indexStart, unsigned indexCount, unsigned baseVertexIndex, unsigned minVertex, unsigned vertexCount, unsigned instanceCount);
     void SetVertexBuffer_D3D11(VertexBuffer* buffer);
-    bool SetVertexBuffers_D3D11(const PODVector<VertexBuffer*>& buffers, unsigned instanceOffset = 0);
+    bool SetVertexBuffers_D3D11(const Vector<VertexBuffer*>& buffers, unsigned instanceOffset = 0);
     bool SetVertexBuffers_D3D11(const Vector<SharedPtr<VertexBuffer>>& buffers, unsigned instanceOffset = 0);
     void SetIndexBuffer_D3D11(IndexBuffer* buffer);
     void SetShaders_D3D11(ShaderVariation* vs, ShaderVariation* ps);
@@ -1158,7 +1158,7 @@ private:
     bool IsInitialized_D3D11() const;
     bool GetDither_D3D11() const;
     bool IsDeviceLost_D3D11() const;
-    PODVector<int> GetMultiSampleLevels_D3D11() const;
+    Vector<int> GetMultiSampleLevels_D3D11() const;
     unsigned GetFormat_D3D11(CompressedFormat format) const;
     ShaderVariation* GetShader_D3D11(ShaderType type, const String& name, const String& defines = String::EMPTY) const;
     ShaderVariation* GetShader_D3D11(ShaderType type, const char* name, const char* defines) const;
@@ -1253,7 +1253,7 @@ private:
     /// Largest scratch buffer request this frame.
     unsigned maxScratchBufferRequest_{};
     /// GPU objects.
-    PODVector<GPUObject*> gpuObjects_;
+    Vector<GPUObject*> gpuObjects_;
     /// Scratch buffers.
     Vector<ScratchBuffer> scratchBuffers_;
     /// Shadow map dummy color texture format.

--- a/Source/Urho3D/Graphics/Light.cpp
+++ b/Source/Urho3D/Graphics/Light.cpp
@@ -145,7 +145,7 @@ void Light::RegisterObject(Context* context)
     URHO3D_ATTRIBUTE("Light Mask", int, lightMask_, DEFAULT_LIGHTMASK, AM_DEFAULT);
 }
 
-void Light::ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQueryResult>& results)
+void Light::ProcessRayQuery(const RayOctreeQuery& query, Vector<RayQueryResult>& results)
 {
     // Do not record a raycast result for a directional light, as it would block all other results
     if (lightType_ == LIGHT_DIRECTIONAL)

--- a/Source/Urho3D/Graphics/Light.h
+++ b/Source/Urho3D/Graphics/Light.h
@@ -144,7 +144,7 @@ public:
     static void RegisterObject(Context* context);
 
     /// Process octree raycast. May be called from a worker thread.
-    void ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQueryResult>& results) override;
+    void ProcessRayQuery(const RayOctreeQuery& query, Vector<RayQueryResult>& results) override;
     /// Calculate distance and prepare batches for rendering. May be called from worker thread(s), possibly re-entrantly.
     void UpdateBatches(const FrameInfo& frame) override;
     /// Visualize the component as debug geometry.

--- a/Source/Urho3D/Graphics/Model.cpp
+++ b/Source/Urho3D/Graphics/Model.cpp
@@ -178,7 +178,7 @@ bool Model::BeginLoad(Deserializer& source)
     {
         // Read bone mappings
         unsigned boneMappingCount = source.ReadUInt();
-        PODVector<unsigned> boneMapping(boneMappingCount);
+        Vector<unsigned> boneMapping(boneMappingCount);
         for (unsigned j = 0; j < boneMappingCount; ++j)
             boneMapping[j] = source.ReadUInt();
         geometryBoneMappings_.Push(boneMapping);
@@ -358,7 +358,7 @@ bool Model::Save(Serializer& dest) const
     {
         VertexBuffer* buffer = vertexBuffers_[i];
         dest.WriteUInt(buffer->GetVertexCount());
-        const PODVector<VertexElement>& elements = buffer->GetElements();
+        const Vector<VertexElement>& elements = buffer->GetElements();
         dest.WriteUInt(elements.Size());
         for (unsigned j = 0; j < elements.Size(); ++j)
         {
@@ -469,8 +469,8 @@ void Model::SetBoundingBox(const BoundingBox& box)
     boundingBox_ = box;
 }
 
-bool Model::SetVertexBuffers(const Vector<SharedPtr<VertexBuffer>>& buffers, const PODVector<unsigned>& morphRangeStarts,
-    const PODVector<unsigned>& morphRangeCounts)
+bool Model::SetVertexBuffers(const Vector<SharedPtr<VertexBuffer>>& buffers, const Vector<unsigned>& morphRangeStarts,
+    const Vector<unsigned>& morphRangeCounts)
 {
     for (unsigned i = 0; i < buffers.Size(); ++i)
     {
@@ -585,7 +585,7 @@ void Model::SetSkeleton(const Skeleton& skeleton)
     skeleton_ = skeleton;
 }
 
-void Model::SetGeometryBoneMappings(const Vector<PODVector<unsigned>>& geometryBoneMappings)
+void Model::SetGeometryBoneMappings(const Vector<Vector<unsigned>>& geometryBoneMappings)
 {
     geometryBoneMappings_ = geometryBoneMappings;
 }

--- a/Source/Urho3D/Graphics/Model.h
+++ b/Source/Urho3D/Graphics/Model.h
@@ -50,7 +50,7 @@ struct VertexBufferDesc
     /// Vertex count.
     unsigned vertexCount_;
     /// Vertex declaration.
-    PODVector<VertexElement> vertexElements_;
+    Vector<VertexElement> vertexElements_;
     /// Vertex data size.
     unsigned dataSize_;
     /// Vertex data.
@@ -110,8 +110,8 @@ public:
     /// @property
     void SetBoundingBox(const BoundingBox& box);
     /// Set vertex buffers and their morph ranges.
-    bool SetVertexBuffers(const Vector<SharedPtr<VertexBuffer>>& buffers, const PODVector<unsigned>& morphRangeStarts,
-        const PODVector<unsigned>& morphRangeCounts);
+    bool SetVertexBuffers(const Vector<SharedPtr<VertexBuffer>>& buffers, const Vector<unsigned>& morphRangeStarts,
+        const Vector<unsigned>& morphRangeCounts);
     /// Set index buffers.
     bool SetIndexBuffers(const Vector<SharedPtr<IndexBuffer>>& buffers);
     /// Set number of geometries.
@@ -128,7 +128,7 @@ public:
     /// Set skeleton.
     void SetSkeleton(const Skeleton& skeleton);
     /// Set bone mappings when model has more bones than the skinning shader can handle.
-    void SetGeometryBoneMappings(const Vector<PODVector<unsigned>>& geometryBoneMappings);
+    void SetGeometryBoneMappings(const Vector<Vector<unsigned>>& geometryBoneMappings);
     /// Set vertex morphs.
     void SetMorphs(const Vector<ModelMorph>& morphs);
     /// Clone the model. The geometry data is deep-copied and can be modified in the clone without affecting the original.
@@ -160,7 +160,7 @@ public:
     const Vector<Vector<SharedPtr<Geometry>>>& GetGeometries() const { return geometries_; }
 
     /// Return geometry center points.
-    const PODVector<Vector3>& GetGeometryCenters() const { return geometryCenters_; }
+    const Vector<Vector3>& GetGeometryCenters() const { return geometryCenters_; }
 
     /// Return geometry by index and LOD level. The LOD level is clamped if out of range.
     Geometry* GetGeometry(unsigned index, unsigned lodLevel) const;
@@ -173,7 +173,7 @@ public:
     }
 
     /// Return geometery bone mappings.
-    const Vector<PODVector<unsigned>>& GetGeometryBoneMappings() const { return geometryBoneMappings_; }
+    const Vector<Vector<unsigned>>& GetGeometryBoneMappings() const { return geometryBoneMappings_; }
 
     /// Return vertex morphs.
     const Vector<ModelMorph>& GetMorphs() const { return morphs_; }
@@ -205,21 +205,21 @@ private:
     /// Geometries.
     Vector<Vector<SharedPtr<Geometry>>> geometries_;
     /// Geometry bone mappings.
-    Vector<PODVector<unsigned>> geometryBoneMappings_;
+    Vector<Vector<unsigned>> geometryBoneMappings_;
     /// Geometry centers.
-    PODVector<Vector3> geometryCenters_;
+    Vector<Vector3> geometryCenters_;
     /// Vertex morphs.
     Vector<ModelMorph> morphs_;
     /// Vertex buffer morph range start.
-    PODVector<unsigned> morphRangeStarts_;
+    Vector<unsigned> morphRangeStarts_;
     /// Vertex buffer morph range vertex count.
-    PODVector<unsigned> morphRangeCounts_;
+    Vector<unsigned> morphRangeCounts_;
     /// Vertex buffer data for asynchronous loading.
     Vector<VertexBufferDesc> loadVBData_;
     /// Index buffer data for asynchronous loading.
     Vector<IndexBufferDesc> loadIBData_;
     /// Geometry definitions for asynchronous loading.
-    Vector<PODVector<GeometryDesc>> loadGeometries_;
+    Vector<Vector<GeometryDesc>> loadGeometries_;
 };
 
 }

--- a/Source/Urho3D/Graphics/OcclusionBuffer.h
+++ b/Source/Urho3D/Graphics/OcclusionBuffer.h
@@ -165,7 +165,7 @@ private:
     /// Reduced size depth buffers.
     Vector<SharedArrayPtr<DepthValue>> mipBuffers_;
     /// Submitted render jobs.
-    PODVector<OcclusionBatch> batches_;
+    Vector<OcclusionBatch> batches_;
     /// Buffer width.
     int width_{};
     /// Buffer height.

--- a/Source/Urho3D/Graphics/Octree.cpp
+++ b/Source/Urho3D/Graphics/Octree.cpp
@@ -63,7 +63,7 @@ Octant::~Octant()
     if (root_)
     {
         // Remove the drawables (if any) from this octant to the root octant
-        for (PODVector<Drawable*>::Iterator i = drawables_.Begin(); i != drawables_.End(); ++i)
+        for (Vector<Drawable*>::Iterator i = drawables_.Begin(); i != drawables_.End(); ++i)
         {
             (*i)->SetOctant(root_);
             root_->drawables_.Push(*i);
@@ -175,7 +175,7 @@ void Octant::ResetRoot()
     root_ = nullptr;
 
     // The whole octree is being destroyed, just detach the drawables
-    for (PODVector<Drawable*>::Iterator i = drawables_.Begin(); i != drawables_.End(); ++i)
+    for (Vector<Drawable*>::Iterator i = drawables_.Begin(); i != drawables_.End(); ++i)
         (*i)->SetOctant(nullptr);
 
     for (auto& child : children_)
@@ -262,7 +262,7 @@ void Octant::GetDrawablesInternal(RayOctreeQuery& query) const
     }
 }
 
-void Octant::GetDrawablesOnlyInternal(RayOctreeQuery& query, PODVector<Drawable*>& drawables) const
+void Octant::GetDrawablesOnlyInternal(RayOctreeQuery& query, Vector<Drawable*>& drawables) const
 {
     float octantDist = query.ray_.HitDistance(cullingBox_);
     if (octantDist >= query.maxDistance_)
@@ -364,7 +364,7 @@ void Octree::Update(const FrameInfo& frame)
         int numWorkItems = queue->GetNumThreads() + 1; // Worker threads + main thread
         int drawablesPerItem = Max((int)(drawableUpdates_.Size() / numWorkItems), 1);
 
-        PODVector<Drawable*>::Iterator start = drawableUpdates_.Begin();
+        Vector<Drawable*>::Iterator start = drawableUpdates_.Begin();
         // Create a work item for each thread
         for (int i = 0; i < numWorkItems; ++i)
         {
@@ -373,7 +373,7 @@ void Octree::Update(const FrameInfo& frame)
             item->workFunction_ = UpdateDrawablesWork;
             item->aux_ = const_cast<FrameInfo*>(&frame);
 
-            PODVector<Drawable*>::Iterator end = drawableUpdates_.End();
+            Vector<Drawable*>::Iterator end = drawableUpdates_.End();
             if (i < numWorkItems - 1 && end - start > drawablesPerItem)
                 end = start + drawablesPerItem;
 
@@ -393,7 +393,7 @@ void Octree::Update(const FrameInfo& frame)
     {
         URHO3D_PROFILE(UpdateDrawablesQueuedDuringUpdate);
 
-        for (PODVector<Drawable*>::ConstIterator i = threadedDrawableUpdates_.Begin(); i != threadedDrawableUpdates_.End(); ++i)
+        for (Vector<Drawable*>::ConstIterator i = threadedDrawableUpdates_.Begin(); i != threadedDrawableUpdates_.End(); ++i)
         {
             Drawable* drawable = *i;
             if (drawable)
@@ -424,7 +424,7 @@ void Octree::Update(const FrameInfo& frame)
     {
         URHO3D_PROFILE(ReinsertToOctree);
 
-        for (PODVector<Drawable*>::Iterator i = drawableUpdates_.Begin(); i != drawableUpdates_.End(); ++i)
+        for (Vector<Drawable*>::Iterator i = drawableUpdates_.Begin(); i != drawableUpdates_.End(); ++i)
         {
             Drawable* drawable = *i;
             drawable->updateQueued_ = false;
@@ -497,7 +497,7 @@ void Octree::RaycastSingle(RayOctreeQuery& query) const
     GetDrawablesOnlyInternal(query, rayQueryDrawables_);
 
     // Sort by increasing hit distance to AABB
-    for (PODVector<Drawable*>::Iterator i = rayQueryDrawables_.Begin(); i != rayQueryDrawables_.End(); ++i)
+    for (Vector<Drawable*>::Iterator i = rayQueryDrawables_.Begin(); i != rayQueryDrawables_.End(); ++i)
     {
         Drawable* drawable = *i;
         drawable->SetSortValue(query.ray_.HitDistance(drawable->GetWorldBoundingBox()));
@@ -507,7 +507,7 @@ void Octree::RaycastSingle(RayOctreeQuery& query) const
 
     // Then do the actual test according to the query, and early-out as possible
     float closestHit = M_INFINITY;
-    for (PODVector<Drawable*>::Iterator i = rayQueryDrawables_.Begin(); i != rayQueryDrawables_.End(); ++i)
+    for (Vector<Drawable*>::Iterator i = rayQueryDrawables_.Begin(); i != rayQueryDrawables_.End(); ++i)
     {
         Drawable* drawable = *i;
         if (drawable->GetSortValue() < Min(closestHit, query.maxDistance_))

--- a/Source/Urho3D/Graphics/Octree.h
+++ b/Source/Urho3D/Graphics/Octree.h
@@ -89,7 +89,7 @@ protected:
     /// Return drawable objects by a ray query, called internally.
     void GetDrawablesInternal(RayOctreeQuery& query) const;
     /// Return drawable objects only for a threaded ray query, called internally.
-    void GetDrawablesOnlyInternal(RayOctreeQuery& query, PODVector<Drawable*>& drawables) const;
+    void GetDrawablesOnlyInternal(RayOctreeQuery& query, Vector<Drawable*>& drawables) const;
 
     /// Increase drawable object count recursively.
     void IncDrawableCount()
@@ -120,7 +120,7 @@ protected:
     /// Bounding box used for drawable object fitting.
     BoundingBox cullingBox_;
     /// Drawable objects.
-    PODVector<Drawable*> drawables_;
+    Vector<Drawable*> drawables_;
     /// Child octants.
     Octant* children_[NUM_OCTANTS]{};
     /// World bounding box center.
@@ -191,13 +191,13 @@ private:
     void UpdateOctreeSize() { SetSize(worldBoundingBox_, numLevels_); }
 
     /// Drawable objects that require update.
-    PODVector<Drawable*> drawableUpdates_;
+    Vector<Drawable*> drawableUpdates_;
     /// Drawable objects that were inserted during threaded update phase.
-    PODVector<Drawable*> threadedDrawableUpdates_;
+    Vector<Drawable*> threadedDrawableUpdates_;
     /// Mutex for octree reinsertions.
     Mutex octreeMutex_;
     /// Ray query temporary list of drawables.
-    mutable PODVector<Drawable*> rayQueryDrawables_;
+    mutable Vector<Drawable*> rayQueryDrawables_;
     /// Subdivision level.
     unsigned numLevels_;
 };

--- a/Source/Urho3D/Graphics/OctreeQuery.h
+++ b/Source/Urho3D/Graphics/OctreeQuery.h
@@ -22,7 +22,7 @@ class URHO3D_API OctreeQuery
 {
 public:
     /// Construct with query parameters.
-    OctreeQuery(PODVector<Drawable*>& result, unsigned char drawableFlags, unsigned viewMask) :
+    OctreeQuery(Vector<Drawable*>& result, unsigned char drawableFlags, unsigned viewMask) :
         result_(result),
         drawableFlags_(drawableFlags),
         viewMask_(viewMask)
@@ -43,7 +43,7 @@ public:
     virtual void TestDrawables(Drawable** start, Drawable** end, bool inside) = 0;
 
     /// Result vector reference.
-    PODVector<Drawable*>& result_;
+    Vector<Drawable*>& result_;
     /// Drawable flags to include.
     unsigned char drawableFlags_;
     /// Drawable layers to include.
@@ -56,7 +56,7 @@ class URHO3D_API PointOctreeQuery : public OctreeQuery
 {
 public:
     /// Construct with point and query parameters.
-    PointOctreeQuery(PODVector<Drawable*>& result, const Vector3& point, unsigned char drawableFlags = DRAWABLE_ANY,
+    PointOctreeQuery(Vector<Drawable*>& result, const Vector3& point, unsigned char drawableFlags = DRAWABLE_ANY,
         unsigned viewMask = DEFAULT_VIEWMASK) :
         OctreeQuery(result, drawableFlags, viewMask),
         point_(point)
@@ -78,7 +78,7 @@ class URHO3D_API SphereOctreeQuery : public OctreeQuery
 {
 public:
     /// Construct with sphere and query parameters.
-    SphereOctreeQuery(PODVector<Drawable*>& result, const Sphere& sphere, unsigned char drawableFlags = DRAWABLE_ANY,
+    SphereOctreeQuery(Vector<Drawable*>& result, const Sphere& sphere, unsigned char drawableFlags = DRAWABLE_ANY,
         unsigned viewMask = DEFAULT_VIEWMASK) :
         OctreeQuery(result, drawableFlags, viewMask),
         sphere_(sphere)
@@ -100,7 +100,7 @@ class URHO3D_API BoxOctreeQuery : public OctreeQuery
 {
 public:
     /// Construct with bounding box and query parameters.
-    BoxOctreeQuery(PODVector<Drawable*>& result, const BoundingBox& box, unsigned char drawableFlags = DRAWABLE_ANY,
+    BoxOctreeQuery(Vector<Drawable*>& result, const BoundingBox& box, unsigned char drawableFlags = DRAWABLE_ANY,
         unsigned viewMask = DEFAULT_VIEWMASK) :
         OctreeQuery(result, drawableFlags, viewMask),
         box_(box)
@@ -122,7 +122,7 @@ class URHO3D_API FrustumOctreeQuery : public OctreeQuery
 {
 public:
     /// Construct with frustum and query parameters.
-    FrustumOctreeQuery(PODVector<Drawable*>& result, const Frustum& frustum, unsigned char drawableFlags = DRAWABLE_ANY,
+    FrustumOctreeQuery(Vector<Drawable*>& result, const Frustum& frustum, unsigned char drawableFlags = DRAWABLE_ANY,
         unsigned viewMask = DEFAULT_VIEWMASK) :
         OctreeQuery(result, drawableFlags, viewMask),
         frustum_(frustum)
@@ -210,7 +210,7 @@ class URHO3D_API RayOctreeQuery
 {
 public:
     /// Construct with ray and query parameters.
-    RayOctreeQuery(PODVector<RayQueryResult>& result, const Ray& ray, RayQueryLevel level = RAY_TRIANGLE,
+    RayOctreeQuery(Vector<RayQueryResult>& result, const Ray& ray, RayQueryLevel level = RAY_TRIANGLE,
         float maxDistance = M_INFINITY, unsigned char drawableFlags = DRAWABLE_ANY, unsigned viewMask = DEFAULT_VIEWMASK) :
         result_(result),
         ray_(ray),
@@ -227,7 +227,7 @@ public:
     RayOctreeQuery& operator =(const RayOctreeQuery& rhs) = delete;
 
     /// Result vector reference.
-    PODVector<RayQueryResult>& result_;
+    Vector<RayQueryResult>& result_;
     /// Ray.
     Ray ray_;
     /// Drawable flags to include.
@@ -245,7 +245,7 @@ class URHO3D_API AllContentOctreeQuery : public OctreeQuery
 {
 public:
     /// Construct.
-    AllContentOctreeQuery(PODVector<Drawable*>& result, unsigned char drawableFlags, unsigned viewMask) :
+    AllContentOctreeQuery(Vector<Drawable*>& result, unsigned char drawableFlags, unsigned viewMask) :
         OctreeQuery(result, drawableFlags, viewMask)
     {
     }

--- a/Source/Urho3D/Graphics/ParticleEffect.h
+++ b/Source/Urho3D/Graphics/ParticleEffect.h
@@ -215,6 +215,7 @@ public:
     /// Remove color frame at index.
     void RemoveColorFrame(unsigned index);
     /// Set color animation of particles.
+    /// @nobindtemp
     void SetColorFrames(const Vector<ColorFrame>& colorFrames);
     /// Set color animation frame at index. If index is greater than number of color frames, new color frames are added.
     void SetColorFrame(unsigned index, const ColorFrame& colorFrame);
@@ -231,6 +232,7 @@ public:
     /// Remove texture frame at index.
     void RemoveTextureFrame(unsigned index);
     /// Set particle texture animation.
+    /// @nobindtemp
     void SetTextureFrames(const Vector<TextureFrame>& textureFrames);
     /// Set number of texture animation frames.
     void SetTextureFrame(unsigned index, const TextureFrame& textureFrame);
@@ -363,6 +365,7 @@ public:
     float GetSizeMul() const { return sizeMul_; }
 
     /// Return all color animation frames.
+    /// @nobindtemp
     const Vector<ColorFrame>& GetColorFrames() const { return colorFrames_; }
 
     /// Return number of color animation frames.
@@ -373,6 +376,7 @@ public:
     const ColorFrame* GetColorFrame(unsigned index) const;
 
     /// Return all texture animation frames.
+    /// @nobindtemp
     const Vector<TextureFrame>& GetTextureFrames() const { return textureFrames_; }
 
     /// Return number of texture animation frames.

--- a/Source/Urho3D/Graphics/ParticleEmitter.cpp
+++ b/Source/Urho3D/Graphics/ParticleEmitter.cpp
@@ -303,7 +303,7 @@ void ParticleEmitter::ResetEmissionTimer()
 
 void ParticleEmitter::RemoveAllParticles()
 {
-    for (PODVector<Billboard>::Iterator i = billboards_.Begin(); i != billboards_.End(); ++i)
+    for (Vector<Billboard>::Iterator i = billboards_.Begin(); i != billboards_.End(); ++i)
         i->enabled_ = false;
 
     Commit();
@@ -352,7 +352,7 @@ void ParticleEmitter::SetParticlesAttr(const VariantVector& value)
     unsigned index = 0;
     SetNumParticles(index < value.Size() ? value[index++].GetUInt() : 0);
 
-    for (PODVector<Particle>::Iterator i = particles_.Begin(); i != particles_.End() && index < value.Size(); ++i)
+    for (Vector<Particle>::Iterator i = particles_.Begin(); i != particles_.End() && index < value.Size(); ++i)
     {
         i->velocity_ = value[index++].GetVector3();
         i->size_ = value[index++].GetVector2();
@@ -376,7 +376,7 @@ VariantVector ParticleEmitter::GetParticlesAttr() const
 
     ret.Reserve(particles_.Size() * 8 + 1);
     ret.Push(particles_.Size());
-    for (PODVector<Particle>::ConstIterator i = particles_.Begin(); i != particles_.End(); ++i)
+    for (Vector<Particle>::ConstIterator i = particles_.Begin(); i != particles_.End(); ++i)
     {
         ret.Push(i->velocity_);
         ret.Push(i->size_);
@@ -402,7 +402,7 @@ VariantVector ParticleEmitter::GetParticleBillboardsAttr() const
     ret.Reserve(billboards_.Size() * 7 + 1);
     ret.Push(billboards_.Size());
 
-    for (PODVector<Billboard>::ConstIterator i = billboards_.Begin(); i != billboards_.End(); ++i)
+    for (Vector<Billboard>::ConstIterator i = billboards_.Begin(); i != billboards_.End(); ++i)
     {
         ret.Push(i->position_);
         ret.Push(i->size_);

--- a/Source/Urho3D/Graphics/ParticleEmitter.h
+++ b/Source/Urho3D/Graphics/ParticleEmitter.h
@@ -125,7 +125,7 @@ private:
     /// Particle effect.
     SharedPtr<ParticleEffect> effect_;
     /// Particles.
-    PODVector<Particle> particles_;
+    Vector<Particle> particles_;
     /// Active/inactive period timer.
     float periodTimer_;
     /// New particle emission timer.

--- a/Source/Urho3D/Graphics/Renderer.cpp
+++ b/Source/Urho3D/Graphics/Renderer.cpp
@@ -231,12 +231,12 @@ static const unsigned MAX_BUFFER_AGE = 1000;
 
 static const int MAX_EXTRA_INSTANCING_BUFFER_ELEMENTS = 4;
 
-inline PODVector<VertexElement> CreateInstancingBufferElements(unsigned numExtraElements)
+inline Vector<VertexElement> CreateInstancingBufferElements(unsigned numExtraElements)
 {
     static const unsigned NUM_INSTANCEMATRIX_ELEMENTS = 3;
     static const unsigned FIRST_UNUSED_TEXCOORD = 4;
 
-    PODVector<VertexElement> elements;
+    Vector<VertexElement> elements;
     for (unsigned i = 0; i < NUM_INSTANCEMATRIX_ELEMENTS + numExtraElements; ++i)
         elements.Push(VertexElement(TYPE_VECTOR4, SEM_TEXCOORD, FIRST_UNUSED_TEXCOORD + i, true));
     return elements;
@@ -744,8 +744,8 @@ void Renderer::DrawDebugGeometry(bool depthTest)
             continue;
 
         // Process geometries / lights only once
-        const PODVector<Drawable*>& geometries = view->GetGeometries();
-        const PODVector<Light*>& lights = view->GetLights();
+        const Vector<Drawable*>& geometries = view->GetGeometries();
+        const Vector<Light*>& lights = view->GetLights();
 
         for (unsigned i = 0; i < geometries.Size(); ++i)
         {
@@ -1336,7 +1336,7 @@ bool Renderer::ResizeInstancingBuffer(unsigned numInstances)
     while (newSize < numInstances)
         newSize <<= 1;
 
-    const PODVector<VertexElement> instancingBufferElements = CreateInstancingBufferElements(numExtraInstancingBufferElements_);
+    const Vector<VertexElement> instancingBufferElements = CreateInstancingBufferElements(numExtraInstancingBufferElements_);
     if (!instancingBuffer_->SetSize(newSize, instancingBufferElements, true))
     {
         URHO3D_LOGERROR("Failed to resize instancing buffer to " + String(newSize));
@@ -1545,7 +1545,7 @@ void Renderer::RemoveUnusedBuffers()
 
 void Renderer::ResetShadowMapAllocations()
 {
-    for (HashMap<int, PODVector<Light*>>::Iterator i = shadowMapAllocations_.Begin(); i != shadowMapAllocations_.End(); ++i)
+    for (HashMap<int, Vector<Light*>>::Iterator i = shadowMapAllocations_.Begin(); i != shadowMapAllocations_.End(); ++i)
         i->second_.Clear();
 }
 
@@ -1721,7 +1721,7 @@ void Renderer::LoadPassShaders(Pass* pass, Vector<SharedPtr<ShaderVariation>>& v
 void Renderer::ReleaseMaterialShaders()
 {
     auto* cache = GetSubsystem<ResourceCache>();
-    PODVector<Material*> materials;
+    Vector<Material*> materials;
 
     cache->GetResources<Material>(materials);
 
@@ -1732,7 +1732,7 @@ void Renderer::ReleaseMaterialShaders()
 void Renderer::ReloadTextures()
 {
     auto* cache = GetSubsystem<ResourceCache>();
-    PODVector<Resource*> textures;
+    Vector<Resource*> textures;
 
     cache->GetResources(textures, Texture2D::GetTypeStatic());
     for (unsigned i = 0; i < textures.Size(); ++i)
@@ -1870,7 +1870,7 @@ void Renderer::CreateInstancingBuffer()
     }
 
     instancingBuffer_ = new VertexBuffer(context_);
-    const PODVector<VertexElement> instancingBufferElements = CreateInstancingBufferElements(numExtraInstancingBufferElements_);
+    const Vector<VertexElement> instancingBufferElements = CreateInstancingBufferElements(numExtraInstancingBufferElements_);
     if (!instancingBuffer_->SetSize(INSTANCING_BUFFER_DEFAULT_SIZE, instancingBufferElements, true))
     {
         instancingBuffer_.Reset();

--- a/Source/Urho3D/Graphics/Renderer.h
+++ b/Source/Urho3D/Graphics/Renderer.h
@@ -555,7 +555,7 @@ private:
     /// Shadow map dummy color buffers by resolution.
     HashMap<int, SharedPtr<Texture2D>> colorShadowMaps_;
     /// Shadow map allocations by resolution.
-    HashMap<int, PODVector<Light*>> shadowMapAllocations_;
+    HashMap<int, Vector<Light*>> shadowMapAllocations_;
     /// Instance of shadow map filter.
     Object* shadowMapFilterInstance_{};
     /// Function pointer of shadow map filter.

--- a/Source/Urho3D/Graphics/RibbonTrail.cpp
+++ b/Source/Urho3D/Graphics/RibbonTrail.cpp
@@ -106,7 +106,7 @@ void RibbonTrail::RegisterObject(Context* context)
     URHO3D_ACCESSOR_ATTRIBUTE("Sort By Distance", IsSorted, SetSorted, bool, false, AM_DEFAULT);
 }
 
-void RibbonTrail::ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQueryResult>& results)
+void RibbonTrail::ProcessRayQuery(const RayOctreeQuery& query, Vector<RayQueryResult>& results)
 {
     // If no trail-level testing, use the Drawable test
     if (query.level_ < RAY_TRIANGLE)

--- a/Source/Urho3D/Graphics/RibbonTrail.h
+++ b/Source/Urho3D/Graphics/RibbonTrail.h
@@ -56,7 +56,7 @@ public:
     /// @nobind
     static void RegisterObject(Context* context);
     /// Process octree raycast. May be called from a worker thread.
-    void ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQueryResult>& results) override;
+    void ProcessRayQuery(const RayOctreeQuery& query, Vector<RayQueryResult>& results) override;
     /// Handle enabled/disabled state change.
     void OnSetEnabled() override;
     /// Update before octree reinsertion. Is called from a main thread.
@@ -189,7 +189,7 @@ protected:
     /// Mark vertex buffer to need an update.
     void MarkPositionsDirty();
     /// Tails.
-    PODVector<TrailPoint> points_;
+    Vector<TrailPoint> points_;
     /// Tails sorted flag.
     bool sorted_;
     /// Animation LOD bias.

--- a/Source/Urho3D/Graphics/Skeleton.h
+++ b/Source/Urho3D/Graphics/Skeleton.h
@@ -88,6 +88,7 @@ public:
     void Reset();
 
     /// Return all bones.
+    /// @nobindtemp
     const Vector<Bone>& GetBones() const { return bones_; }
 
     /// Return modifiable bones.

--- a/Source/Urho3D/Graphics/Skybox.cpp
+++ b/Source/Urho3D/Graphics/Skybox.cpp
@@ -31,7 +31,7 @@ void Skybox::RegisterObject(Context* context)
     URHO3D_COPY_BASE_ATTRIBUTES(StaticModel);
 }
 
-void Skybox::ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQueryResult>& results)
+void Skybox::ProcessRayQuery(const RayOctreeQuery& query, Vector<RayQueryResult>& results)
 {
     // Do not record a raycast result for a skybox, as it would block all other results
 }

--- a/Source/Urho3D/Graphics/Skybox.h
+++ b/Source/Urho3D/Graphics/Skybox.h
@@ -23,7 +23,7 @@ public:
     static void RegisterObject(Context* context);
 
     /// Process octree raycast. May be called from a worker thread.
-    void ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQueryResult>& results) override;
+    void ProcessRayQuery(const RayOctreeQuery& query, Vector<RayQueryResult>& results) override;
     /// Calculate distance and prepare batches for rendering. May be called from worker thread(s), possibly re-entrantly.
     void UpdateBatches(const FrameInfo& frame) override;
 

--- a/Source/Urho3D/Graphics/StaticModel.cpp
+++ b/Source/Urho3D/Graphics/StaticModel.cpp
@@ -52,7 +52,7 @@ void StaticModel::RegisterObject(Context* context)
     URHO3D_ATTRIBUTE("Occlusion LOD Level", int, occlusionLodLevel_, M_MAX_UNSIGNED, AM_DEFAULT);
 }
 
-void StaticModel::ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQueryResult>& results)
+void StaticModel::ProcessRayQuery(const RayOctreeQuery& query, Vector<RayQueryResult>& results)
 {
     RayQueryLevel level = query.level_;
 
@@ -190,7 +190,7 @@ bool StaticModel::DrawOcclusion(OcclusionBuffer* buffer)
         unsigned vertexSize;
         const unsigned char* indexData;
         unsigned indexSize;
-        const PODVector<VertexElement>* elements;
+        const Vector<VertexElement>* elements;
 
         geometry->GetRawData(vertexData, vertexSize, indexData, indexSize, elements);
         // Check for valid geometry data
@@ -232,7 +232,7 @@ void StaticModel::SetModel(Model* model)
         // Copy the subgeometry & LOD level structure
         SetNumGeometries(model->GetNumGeometries());
         const Vector<Vector<SharedPtr<Geometry>>>& geometries = model->GetGeometries();
-        const PODVector<Vector3>& geometryCenters = model->GetGeometryCenters();
+        const Vector<Vector3>& geometryCenters = model->GetGeometryCenters();
         const Matrix3x4* worldTransform = node_ ? &node_->GetWorldTransform() : nullptr;
         for (unsigned i = 0; i < geometries.Size(); ++i)
         {

--- a/Source/Urho3D/Graphics/StaticModel.h
+++ b/Source/Urho3D/Graphics/StaticModel.h
@@ -34,7 +34,7 @@ public:
     static void RegisterObject(Context* context);
 
     /// Process octree raycast. May be called from a worker thread.
-    void ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQueryResult>& results) override;
+    void ProcessRayQuery(const RayOctreeQuery& query, Vector<RayQueryResult>& results) override;
     /// Calculate distance and prepare batches for rendering. May be called from worker thread(s), possibly re-entrantly.
     void UpdateBatches(const FrameInfo& frame) override;
     /// Return the geometry for a specific LOD level.
@@ -105,7 +105,7 @@ protected:
     void CalculateLodLevels();
 
     /// Extra per-geometry data.
-    PODVector<StaticModelGeometryData> geometryData_;
+    Vector<StaticModelGeometryData> geometryData_;
     /// All geometries.
     Vector<Vector<SharedPtr<Geometry>>> geometries_;
     /// Model.

--- a/Source/Urho3D/Graphics/StaticModelGroup.cpp
+++ b/Source/Urho3D/Graphics/StaticModelGroup.cpp
@@ -84,7 +84,7 @@ void StaticModelGroup::ApplyAttributes()
     OnMarkedDirty(GetNode());
 }
 
-void StaticModelGroup::ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQueryResult>& results)
+void StaticModelGroup::ProcessRayQuery(const RayOctreeQuery& query, Vector<RayQueryResult>& results)
 {
     // If no bones or no bone-level testing, use the Drawable test
     RayQueryLevel level = query.level_;
@@ -232,7 +232,7 @@ bool StaticModelGroup::DrawOcclusion(OcclusionBuffer* buffer)
             unsigned vertexSize;
             const unsigned char* indexData;
             unsigned indexSize;
-            const PODVector<VertexElement>* elements;
+            const Vector<VertexElement>* elements;
 
             geometry->GetRawData(vertexData, vertexSize, indexData, indexSize, elements);
             // Check for valid geometry data

--- a/Source/Urho3D/Graphics/StaticModelGroup.h
+++ b/Source/Urho3D/Graphics/StaticModelGroup.h
@@ -25,7 +25,7 @@ public:
     /// Apply attribute changes that can not be applied immediately. Called after scene load or a network update.
     void ApplyAttributes() override;
     /// Process octree raycast. May be called from a worker thread.
-    void ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQueryResult>& results) override;
+    void ProcessRayQuery(const RayOctreeQuery& query, Vector<RayQueryResult>& results) override;
     /// Calculate distance and prepare batches for rendering. May be called from worker thread(s), possibly re-entrantly.
     void UpdateBatches(const FrameInfo& frame) override;
     /// Return number of occlusion geometry triangles.
@@ -69,7 +69,7 @@ private:
     /// Instance nodes.
     Vector<WeakPtr<Node>> instanceNodes_;
     /// World transforms of valid (existing and visible) instances.
-    PODVector<Matrix3x4> worldTransforms_;
+    Vector<Matrix3x4> worldTransforms_;
     /// IDs of instance nodes for serialization.
     mutable VariantVector nodeIDsAttr_;
     /// Number of valid instance node transforms.

--- a/Source/Urho3D/Graphics/Technique.cpp
+++ b/Source/Urho3D/Graphics/Technique.cpp
@@ -461,9 +461,9 @@ Vector<String> Technique::GetPassNames() const
     return ret;
 }
 
-PODVector<Pass*> Technique::GetPasses() const
+Vector<Pass*> Technique::GetPasses() const
 {
-    PODVector<Pass*> ret;
+    Vector<Pass*> ret;
 
     for (Vector<SharedPtr<Pass>>::ConstIterator i = passes_.Begin(); i != passes_.End(); ++i)
     {

--- a/Source/Urho3D/Graphics/Technique.h
+++ b/Source/Urho3D/Graphics/Technique.h
@@ -262,7 +262,7 @@ public:
     Vector<String> GetPassNames() const;
     /// Return all passes.
     /// @property
-    PODVector<Pass*> GetPasses() const;
+    Vector<Pass*> GetPasses() const;
 
     /// Return a clone with added shader compilation defines. Called internally by Material.
     SharedPtr<Technique> CloneWithDefines(const String& vsDefines, const String& psDefines);

--- a/Source/Urho3D/Graphics/Terrain.cpp
+++ b/Source/Urho3D/Graphics/Terrain.cpp
@@ -891,9 +891,9 @@ void Terrain::CreateGeometry()
     {
         URHO3D_PROFILE(RemoveOldPatches);
 
-        PODVector<Node*> oldPatchNodes;
+        Vector<Node*> oldPatchNodes;
         node_->GetChildrenWithComponent<TerrainPatch>(oldPatchNodes);
-        for (PODVector<Node*>::Iterator i = oldPatchNodes.Begin(); i != oldPatchNodes.End(); ++i)
+        for (Vector<Node*>::Iterator i = oldPatchNodes.Begin(); i != oldPatchNodes.End(); ++i)
         {
             bool nodeOk = false;
             Vector<String> coords = (*i)->GetName().Substring(6).Split('_');
@@ -911,7 +911,7 @@ void Terrain::CreateGeometry()
     }
 
     // Keep track of which patches actually need an update
-    PODVector<bool> dirtyPatches((unsigned)(numPatches_.x_ * numPatches_.y_));
+    Vector<bool> dirtyPatches((unsigned)(numPatches_.x_ * numPatches_.y_));
     for (unsigned i = 0; i < dirtyPatches.Size(); ++i)
         dirtyPatches[i] = updateAll;
 
@@ -1119,7 +1119,7 @@ void Terrain::CreateIndexData()
 {
     URHO3D_PROFILE(CreateIndexData);
 
-    PODVector<unsigned short> indices;
+    Vector<unsigned short> indices;
     drawRanges_.Clear();
     auto row = (unsigned)(patchSize_ + 1);
 
@@ -1348,7 +1348,7 @@ void Terrain::CalculateLodErrors(TerrainPatch* patch)
     URHO3D_PROFILE(CalculateLodErrors);
 
     const IntVector2& coords = patch->GetCoordinates();
-    PODVector<float>& lodErrors = patch->GetLodErrors();
+    Vector<float>& lodErrors = patch->GetLodErrors();
     lodErrors.Clear();
     lodErrors.Reserve(numLodLevels_);
 

--- a/Source/Urho3D/Graphics/Terrain.h
+++ b/Source/Urho3D/Graphics/Terrain.h
@@ -283,7 +283,7 @@ private:
     /// Terrain patches.
     Vector<WeakPtr<TerrainPatch>> patches_;
     /// Draw ranges for different LODs and stitching combinations.
-    PODVector<Pair<unsigned, unsigned>> drawRanges_;
+    Vector<Pair<unsigned, unsigned>> drawRanges_;
     /// North neighbor terrain.
     WeakPtr<Terrain> north_;
     /// South neighbor terrain.

--- a/Source/Urho3D/Graphics/TerrainPatch.cpp
+++ b/Source/Urho3D/Graphics/TerrainPatch.cpp
@@ -51,7 +51,7 @@ void TerrainPatch::RegisterObject(Context* context)
     context->RegisterFactory<TerrainPatch>();
 }
 
-void TerrainPatch::ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQueryResult>& results)
+void TerrainPatch::ProcessRayQuery(const RayOctreeQuery& query, Vector<RayQueryResult>& results)
 {
     RayQueryLevel level = query.level_;
 
@@ -175,7 +175,7 @@ bool TerrainPatch::DrawOcclusion(OcclusionBuffer* buffer)
     unsigned vertexSize;
     const unsigned char* indexData;
     unsigned indexSize;
-    const PODVector<VertexElement>* elements;
+    const Vector<VertexElement>* elements;
 
     occlusionGeometry_->GetRawData(vertexData, vertexSize, indexData, indexSize, elements);
     // Check for valid geometry data

--- a/Source/Urho3D/Graphics/TerrainPatch.h
+++ b/Source/Urho3D/Graphics/TerrainPatch.h
@@ -27,7 +27,7 @@ public:
     static void RegisterObject(Context* context);
 
     /// Process octree raycast. May be called from a worker thread.
-    void ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQueryResult>& results) override;
+    void ProcessRayQuery(const RayOctreeQuery& query, Vector<RayQueryResult>& results) override;
     /// Calculate distance and prepare batches for rendering. May be called from worker thread(s), possibly re-entrantly.
     void UpdateBatches(const FrameInfo& frame) override;
     /// Prepare geometry for rendering. Called from a worker thread if possible (no GPU update).
@@ -80,7 +80,7 @@ public:
     TerrainPatch* GetEastPatch() const { return east_; }
 
     /// Return geometrical error array.
-    PODVector<float>& GetLodErrors() { return lodErrors_; }
+    Vector<float>& GetLodErrors() { return lodErrors_; }
 
     /// Return patch coordinates.
     const IntVector2& GetCoordinates() const { return coordinates_; }
@@ -115,7 +115,7 @@ private:
     /// East neighbor patch.
     WeakPtr<TerrainPatch> east_;
     /// Geometrical error per LOD level.
-    PODVector<float> lodErrors_;
+    Vector<float> lodErrors_;
     /// Patch coordinates in the terrain. (0,0) is the northwest corner.
     IntVector2 coordinates_;
     /// Current LOD level.

--- a/Source/Urho3D/Graphics/View.cpp
+++ b/Source/Urho3D/Graphics/View.cpp
@@ -41,7 +41,7 @@ class ShadowCasterOctreeQuery : public FrustumOctreeQuery
 {
 public:
     /// Construct with frustum and query parameters.
-    ShadowCasterOctreeQuery(PODVector<Drawable*>& result, const Frustum& frustum, unsigned char drawableFlags = DRAWABLE_ANY,
+    ShadowCasterOctreeQuery(Vector<Drawable*>& result, const Frustum& frustum, unsigned char drawableFlags = DRAWABLE_ANY,
         unsigned viewMask = DEFAULT_VIEWMASK) :
         FrustumOctreeQuery(result, frustum, drawableFlags, viewMask)
     {
@@ -69,7 +69,7 @@ class ZoneOccluderOctreeQuery : public FrustumOctreeQuery
 {
 public:
     /// Construct with frustum and query parameters.
-    ZoneOccluderOctreeQuery(PODVector<Drawable*>& result, const Frustum& frustum, unsigned char drawableFlags = DRAWABLE_ANY,
+    ZoneOccluderOctreeQuery(Vector<Drawable*>& result, const Frustum& frustum, unsigned char drawableFlags = DRAWABLE_ANY,
         unsigned viewMask = DEFAULT_VIEWMASK) :
         FrustumOctreeQuery(result, frustum, drawableFlags, viewMask)
     {
@@ -98,7 +98,7 @@ class OccludedFrustumOctreeQuery : public FrustumOctreeQuery
 {
 public:
     /// Construct with frustum, occlusion buffer and query parameters.
-    OccludedFrustumOctreeQuery(PODVector<Drawable*>& result, const Frustum& frustum, OcclusionBuffer* buffer,
+    OccludedFrustumOctreeQuery(Vector<Drawable*>& result, const Frustum& frustum, OcclusionBuffer* buffer,
         unsigned char drawableFlags = DRAWABLE_ANY, unsigned viewMask = DEFAULT_VIEWMASK) :
         FrustumOctreeQuery(result, frustum, drawableFlags, viewMask),
         buffer_(buffer)
@@ -786,7 +786,7 @@ void View::GetDrawables()
     URHO3D_PROFILE(GetDrawables);
 
     auto* queue = GetSubsystem<WorkQueue>();
-    PODVector<Drawable*>& tempDrawables = tempDrawables_[0];
+    Vector<Drawable*>& tempDrawables = tempDrawables_[0];
 
     // Get zones and occluders first
     {
@@ -800,7 +800,7 @@ void View::GetDrawables()
     Node* cameraNode = cullCamera_->GetNode();
     Vector3 cameraPos = cameraNode->GetWorldPosition();
 
-    for (PODVector<Drawable*>::ConstIterator i = tempDrawables.Begin(); i != tempDrawables.End(); ++i)
+    for (Vector<Drawable*>::ConstIterator i = tempDrawables.Begin(); i != tempDrawables.End(); ++i)
     {
         Drawable* drawable = *i;
         unsigned char flags = drawable->GetDrawableFlags();
@@ -829,7 +829,7 @@ void View::GetDrawables()
         Vector3 farClipPos = cameraPos + cameraNode->GetWorldDirection() * Vector3(0.0f, 0.0f, cullCamera_->GetFarClip());
         bestPriority = M_MIN_INT;
 
-        for (PODVector<Zone*>::Iterator i = zones_.Begin(); i != zones_.End(); ++i)
+        for (Vector<Zone*>::Iterator i = zones_.Begin(); i != zones_.End(); ++i)
         {
             int priority = (*i)->GetPriority();
             if (priority > bestPriority && (*i)->IsInside(farClipPos))
@@ -886,7 +886,7 @@ void View::GetDrawables()
         int numWorkItems = queue->GetNumThreads() + 1; // Worker threads + main thread
         int drawablesPerItem = tempDrawables.Size() / numWorkItems;
 
-        PODVector<Drawable*>::Iterator start = tempDrawables.Begin();
+        Vector<Drawable*>::Iterator start = tempDrawables.Begin();
         // Create a work item for each thread
         for (int i = 0; i < numWorkItems; ++i)
         {
@@ -895,7 +895,7 @@ void View::GetDrawables()
             item->workFunction_ = CheckVisibilityWork;
             item->aux_ = this;
 
-            PODVector<Drawable*>::Iterator end = tempDrawables.End();
+            Vector<Drawable*>::Iterator end = tempDrawables.End();
             if (i < numWorkItems - 1 && end - start > drawablesPerItem)
                 end = start + drawablesPerItem;
 
@@ -1070,7 +1070,7 @@ void View::GetLightBatches()
                     FinalizeShadowCamera(shadowCamera, light, shadowQueue.shadowViewport_, query.shadowCasterBox_[j]);
 
                     // Loop through shadow casters
-                    for (PODVector<Drawable*>::ConstIterator k = query.shadowCasters_.Begin() + query.shadowCasterBegin_[j];
+                    for (Vector<Drawable*>::ConstIterator k = query.shadowCasters_.Begin() + query.shadowCasterBegin_[j];
                          k < query.shadowCasters_.Begin() + query.shadowCasterEnd_[j]; ++k)
                     {
                         Drawable* drawable = *k;
@@ -1110,7 +1110,7 @@ void View::GetLightBatches()
                 }
 
                 // Process lit geometries
-                for (PODVector<Drawable*>::ConstIterator j = query.litGeometries_.Begin(); j != query.litGeometries_.End(); ++j)
+                for (Vector<Drawable*>::ConstIterator j = query.litGeometries_.Begin(); j != query.litGeometries_.End(); ++j)
                 {
                     Drawable* drawable = *j;
                     drawable->AddLight(light);
@@ -1146,7 +1146,7 @@ void View::GetLightBatches()
             else
             {
                 // Add the vertex light to lit drawables. It will be processed later during base pass batch generation
-                for (PODVector<Drawable*>::ConstIterator j = query.litGeometries_.Begin(); j != query.litGeometries_.End(); ++j)
+                for (Vector<Drawable*>::ConstIterator j = query.litGeometries_.Begin(); j != query.litGeometries_.End(); ++j)
                 {
                     Drawable* drawable = *j;
                     drawable->AddVertexLight(light);
@@ -1164,7 +1164,7 @@ void View::GetLightBatches()
         {
             Drawable* drawable = *i;
             drawable->LimitLights();
-            const PODVector<Light*>& lights = drawable->GetLights();
+            const Vector<Light*>& lights = drawable->GetLights();
 
             for (unsigned i = 0; i < lights.Size(); ++i)
             {
@@ -1182,7 +1182,7 @@ void View::GetBaseBatches()
 {
     URHO3D_PROFILE(GetBaseBatches);
 
-    for (PODVector<Drawable*>::ConstIterator i = geometries_.Begin(); i != geometries_.End(); ++i)
+    for (Vector<Drawable*>::ConstIterator i = geometries_.Begin(); i != geometries_.End(); ++i)
     {
         Drawable* drawable = *i;
         UpdateGeometryType type = drawable->GetUpdateGeometryType();
@@ -1227,7 +1227,7 @@ void View::GetBaseBatches()
 
                 if (info.vertexLights_)
                 {
-                    const PODVector<Light*>& drawableVertexLights = drawable->GetVertexLights();
+                    const Vector<Light*>& drawableVertexLights = drawable->GetVertexLights();
                     if (drawableVertexLights.Size() && !vertexLightsProcessed)
                     {
                         // Limit vertex lights. If this is a deferred opaque batch, remove converted per-pixel lights,
@@ -1324,7 +1324,7 @@ void View::UpdateGeometries()
             // In special cases (context loss, multi-view) a drawable may theoretically first have reported a threaded update, but will actually
             // require a main thread update. Check these cases first and move as applicable. The threaded work routine will tolerate the null
             // pointer holes that we leave to the threaded update queue.
-            for (PODVector<Drawable*>::Iterator i = threadedGeometries_.Begin(); i != threadedGeometries_.End(); ++i)
+            for (Vector<Drawable*>::Iterator i = threadedGeometries_.Begin(); i != threadedGeometries_.End(); ++i)
             {
                 if ((*i)->GetUpdateGeometryType() == UPDATE_MAIN_THREAD)
                 {
@@ -1336,10 +1336,10 @@ void View::UpdateGeometries()
             int numWorkItems = queue->GetNumThreads() + 1; // Worker threads + main thread
             int drawablesPerItem = threadedGeometries_.Size() / numWorkItems;
 
-            PODVector<Drawable*>::Iterator start = threadedGeometries_.Begin();
+            Vector<Drawable*>::Iterator start = threadedGeometries_.Begin();
             for (int i = 0; i < numWorkItems; ++i)
             {
-                PODVector<Drawable*>::Iterator end = threadedGeometries_.End();
+                Vector<Drawable*>::Iterator end = threadedGeometries_.End();
                 if (i < numWorkItems - 1 && end - start > drawablesPerItem)
                     end = start + drawablesPerItem;
 
@@ -1356,7 +1356,7 @@ void View::UpdateGeometries()
         }
 
         // While the work queue is processed, update non-threaded geometries
-        for (PODVector<Drawable*>::ConstIterator i = nonThreadedGeometries_.Begin(); i != nonThreadedGeometries_.End(); ++i)
+        for (Vector<Drawable*>::ConstIterator i = nonThreadedGeometries_.Begin(); i != nonThreadedGeometries_.End(); ++i)
             (*i)->UpdateGeometry(frame_);
     }
 
@@ -2165,13 +2165,13 @@ void View::DrawFullscreenQuad(bool setIdentityProjection)
     geometry->Draw(graphics_);
 }
 
-void View::UpdateOccluders(PODVector<Drawable*>& occluders, Camera* camera)
+void View::UpdateOccluders(Vector<Drawable*>& occluders, Camera* camera)
 {
     float occluderSizeThreshold_ = renderer_->GetOccluderSizeThreshold();
     float halfViewSize = camera->GetHalfViewSize();
     float invOrthoSize = 1.0f / camera->GetOrthoSize();
 
-    for (PODVector<Drawable*>::Iterator i = occluders.Begin(); i != occluders.End();)
+    for (Vector<Drawable*>::Iterator i = occluders.Begin(); i != occluders.End();)
     {
         Drawable* occluder = *i;
         bool erase = false;
@@ -2225,7 +2225,7 @@ void View::UpdateOccluders(PODVector<Drawable*>& occluders, Camera* camera)
         Sort(occluders.Begin(), occluders.End(), CompareDrawables);
 }
 
-void View::DrawOccluders(OcclusionBuffer* buffer, const PODVector<Drawable*>& occluders)
+void View::DrawOccluders(OcclusionBuffer* buffer, const Vector<Drawable*>& occluders)
 {
     buffer->SetMaxTriangles((unsigned)maxOccluderTriangles_);
     buffer->Clear();
@@ -2288,7 +2288,7 @@ void View::ProcessLight(LightQueryResult& query, unsigned threadIndex)
         isShadowed = false;
 #endif
     // Get lit geometries. They must match the light mask and be inside the main camera frustum to be considered
-    PODVector<Drawable*>& tempDrawables = tempDrawables_[threadIndex];
+    Vector<Drawable*>& tempDrawables = tempDrawables_[threadIndex];
     query.litGeometries_.Clear();
 
     switch (type)
@@ -2373,7 +2373,7 @@ void View::ProcessLight(LightQueryResult& query, unsigned threadIndex)
         query.numSplits_ = 0;
 }
 
-void View::ProcessShadowCasters(LightQueryResult& query, const PODVector<Drawable*>& drawables, unsigned splitIndex)
+void View::ProcessShadowCasters(LightQueryResult& query, const Vector<Drawable*>& drawables, unsigned splitIndex)
 {
     Light* light = query.light_;
     unsigned lightMask = light->GetLightMask();
@@ -2405,7 +2405,7 @@ void View::ProcessShadowCasters(LightQueryResult& query, const PODVector<Drawabl
     BoundingBox lightViewBox;
     BoundingBox lightProjBox;
 
-    for (PODVector<Drawable*>::ConstIterator i = drawables.Begin(); i != drawables.End(); ++i)
+    for (Vector<Drawable*>::ConstIterator i = drawables.Begin(); i != drawables.End(); ++i)
     {
         Drawable* drawable = *i;
         // In case this is a point or spot light query result reused for optimization, we may have non-shadowcasters included.
@@ -2791,7 +2791,7 @@ void View::FindZone(Drawable* drawable)
         newZone = lastZone;
     else
     {
-        for (PODVector<Zone*>::Iterator i = zones_.Begin(); i != zones_.End(); ++i)
+        for (Vector<Zone*>::Iterator i = zones_.Begin(); i != zones_.End(); ++i)
         {
             Zone* zone = *i;
             int priority = zone->GetPriority();

--- a/Source/Urho3D/Graphics/View.h
+++ b/Source/Urho3D/Graphics/View.h
@@ -37,9 +37,9 @@ struct LightQueryResult
     /// Light.
     Light* light_;
     /// Lit geometries.
-    PODVector<Drawable*> litGeometries_;
+    Vector<Drawable*> litGeometries_;
     /// Shadow casters.
-    PODVector<Drawable*> shadowCasters_;
+    Vector<Drawable*> shadowCasters_;
     /// Shadow cameras.
     Camera* shadowCameras_[MAX_LIGHT_SPLITS];
     /// Shadow caster start indices.
@@ -75,9 +75,9 @@ struct ScenePassInfo
 struct PerThreadSceneResult
 {
     /// Geometry objects.
-    PODVector<Drawable*> geometries_;
+    Vector<Drawable*> geometries_;
     /// Lights.
-    PODVector<Light*> lights_;
+    Vector<Light*> lights_;
     /// Scene minimum Z value.
     float minZ_;
     /// Scene maximum Z value.
@@ -140,13 +140,13 @@ public:
     const IntVector2& GetViewSize() const { return viewSize_; }
 
     /// Return geometry objects.
-    const PODVector<Drawable*>& GetGeometries() const { return geometries_; }
+    const Vector<Drawable*>& GetGeometries() const { return geometries_; }
 
     /// Return occluder objects.
-    const PODVector<Drawable*>& GetOccluders() const { return occluders_; }
+    const Vector<Drawable*>& GetOccluders() const { return occluders_; }
 
     /// Return lights.
-    const PODVector<Light*>& GetLights() const { return lights_; }
+    const Vector<Light*>& GetLights() const { return lights_; }
 
     /// Return light batch queues.
     const Vector<LightBatchQueue>& GetLightQueues() const { return lightQueues_; }
@@ -211,13 +211,13 @@ private:
     /// Blit the viewport from one surface to another.
     void BlitFramebuffer(Texture* source, RenderSurface* destination, bool depthWrite);
     /// Query for occluders as seen from a camera.
-    void UpdateOccluders(PODVector<Drawable*>& occluders, Camera* camera);
+    void UpdateOccluders(Vector<Drawable*>& occluders, Camera* camera);
     /// Draw occluders to occlusion buffer.
-    void DrawOccluders(OcclusionBuffer* buffer, const PODVector<Drawable*>& occluders);
+    void DrawOccluders(OcclusionBuffer* buffer, const Vector<Drawable*>& occluders);
     /// Query for lit geometries and shadow casters for a light.
     void ProcessLight(LightQueryResult& query, unsigned threadIndex);
     /// Process shadow casters' visibilities and build their combined view- or projection-space bounding box.
-    void ProcessShadowCasters(LightQueryResult& query, const PODVector<Drawable*>& drawables, unsigned splitIndex);
+    void ProcessShadowCasters(LightQueryResult& query, const Vector<Drawable*>& drawables, unsigned splitIndex);
     /// Set up initial shadow camera view(s).
     void SetupShadowCameras(LightQueryResult& query);
     /// Set up a directional light shadow camera.
@@ -280,10 +280,10 @@ private:
     }
 
     /// Return hash code for a vertex light queue.
-    unsigned long long GetVertexLightQueueHash(const PODVector<Light*>& vertexLights)
+    unsigned long long GetVertexLightQueueHash(const Vector<Light*>& vertexLights)
     {
         unsigned long long hash = 0;
-        for (PODVector<Light*>::ConstIterator i = vertexLights.Begin(); i != vertexLights.End(); ++i)
+        for (Vector<Light*>::ConstIterator i = vertexLights.Begin(); i != vertexLights.End(); ++i)
             hash += (unsigned long long)(*i);
         return hash;
     }
@@ -365,21 +365,21 @@ private:
     /// Renderpath.
     RenderPath* renderPath_{};
     /// Per-thread octree query results.
-    Vector<PODVector<Drawable*>> tempDrawables_;
+    Vector<Vector<Drawable*>> tempDrawables_;
     /// Per-thread geometries, lights and Z range collection results.
     Vector<PerThreadSceneResult> sceneResults_;
     /// Visible zones.
-    PODVector<Zone*> zones_;
+    Vector<Zone*> zones_;
     /// Visible geometry objects.
-    PODVector<Drawable*> geometries_;
+    Vector<Drawable*> geometries_;
     /// Geometry objects that will be updated in the main thread.
-    PODVector<Drawable*> nonThreadedGeometries_;
+    Vector<Drawable*> nonThreadedGeometries_;
     /// Geometry objects that will be updated in worker threads.
-    PODVector<Drawable*> threadedGeometries_;
+    Vector<Drawable*> threadedGeometries_;
     /// Occluder objects.
-    PODVector<Drawable*> occluders_;
+    Vector<Drawable*> occluders_;
     /// Lights.
-    PODVector<Light*> lights_;
+    Vector<Light*> lights_;
     /// Number of active occluders.
     unsigned activeOccluders_{};
 
@@ -390,7 +390,7 @@ private:
     /// Intermediate light processing results.
     Vector<LightQueryResult> lightQueryResults_;
     /// Info for scene render passes defined by the renderpath.
-    PODVector<ScenePassInfo> scenePasses_;
+    Vector<ScenePassInfo> scenePasses_;
     /// Per-pixel light queues.
     Vector<LightBatchQueue> lightQueues_;
     /// Per-vertex light queues.

--- a/Source/Urho3D/Graphics/Zone.cpp
+++ b/Source/Urho3D/Graphics/Zone.cpp
@@ -245,16 +245,16 @@ void Zone::UpdateAmbientGradient()
         Vector3 minZPosition = worldTransform * Vector3(center.x_, center.y_, boundingBox_.min_.z_);
         Vector3 maxZPosition = worldTransform * Vector3(center.x_, center.y_, boundingBox_.max_.z_);
 
-        PODVector<Zone*> result;
+        Vector<Zone*> result;
         {
-            PointOctreeQuery query(reinterpret_cast<PODVector<Drawable*>&>(result), minZPosition, DRAWABLE_ZONE);
+            PointOctreeQuery query(reinterpret_cast<Vector<Drawable*>&>(result), minZPosition, DRAWABLE_ZONE);
             octant_->GetRoot()->GetDrawables(query);
         }
 
         // Gradient start position: get the highest priority zone that is not this zone
         int bestPriority = M_MIN_INT;
         Zone* bestZone = nullptr;
-        for (PODVector<Zone*>::ConstIterator i = result.Begin(); i != result.End(); ++i)
+        for (Vector<Zone*>::ConstIterator i = result.Begin(); i != result.End(); ++i)
         {
             Zone* zone = *i;
             int priority = zone->GetPriority();
@@ -273,13 +273,13 @@ void Zone::UpdateAmbientGradient()
 
         // Do the same for gradient end position
         {
-            PointOctreeQuery query(reinterpret_cast<PODVector<Drawable*>&>(result), maxZPosition, DRAWABLE_ZONE);
+            PointOctreeQuery query(reinterpret_cast<Vector<Drawable*>&>(result), maxZPosition, DRAWABLE_ZONE);
             octant_->GetRoot()->GetDrawables(query);
         }
         bestPriority = M_MIN_INT;
         bestZone = nullptr;
 
-        for (PODVector<Zone*>::ConstIterator i = result.Begin(); i != result.End(); ++i)
+        for (Vector<Zone*>::ConstIterator i = result.Begin(); i != result.End(); ++i)
         {
             Zone* zone = *i;
             int priority = zone->GetPriority();
@@ -307,11 +307,11 @@ void Zone::ClearDrawablesZone()
 {
     if (octant_ && lastWorldBoundingBox_.Defined())
     {
-        PODVector<Drawable*> result;
+        Vector<Drawable*> result;
         BoxOctreeQuery query(result, lastWorldBoundingBox_, DRAWABLE_GEOMETRY | DRAWABLE_ZONE);
         octant_->GetRoot()->GetDrawables(query);
 
-        for (PODVector<Drawable*>::Iterator i = result.Begin(); i != result.End(); ++i)
+        for (Vector<Drawable*>::Iterator i = result.Begin(); i != result.End(); ++i)
         {
             Drawable* drawable = *i;
             unsigned drawableFlags = drawable->GetDrawableFlags();

--- a/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11Graphics.cpp
+++ b/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11Graphics.cpp
@@ -195,7 +195,7 @@ void Graphics::Destructor_D3D11()
         MutexLock lock(gpuObjectMutex_);
 
         // Release all GPU objects that still exist
-        for (PODVector<GPUObject*>::Iterator i = gpuObjects_.Begin(); i != gpuObjects_.End(); ++i)
+        for (Vector<GPUObject*>::Iterator i = gpuObjects_.Begin(); i != gpuObjects_.End(); ++i)
             (*i)->Release();
         gpuObjects_.Clear();
     }
@@ -791,12 +791,12 @@ void Graphics::DrawInstanced_D3D11(PrimitiveType type, unsigned indexStart, unsi
 void Graphics::SetVertexBuffer_D3D11(VertexBuffer* buffer)
 {
     // Note: this is not multi-instance safe
-    static PODVector<VertexBuffer*> vertexBuffers(1);
+    static Vector<VertexBuffer*> vertexBuffers(1);
     vertexBuffers[0] = buffer;
     SetVertexBuffers_D3D11(vertexBuffers);
 }
 
-bool Graphics::SetVertexBuffers_D3D11(const PODVector<VertexBuffer*>& buffers, unsigned instanceOffset)
+bool Graphics::SetVertexBuffers_D3D11(const Vector<VertexBuffer*>& buffers, unsigned instanceOffset)
 {
     if (buffers.Size() > MAX_VERTEX_STREAMS)
     {
@@ -814,7 +814,7 @@ bool Graphics::SetVertexBuffers_D3D11(const PODVector<VertexBuffer*>& buffers, u
         buffer = i < buffers.Size() ? buffers[i] : nullptr;
         if (buffer)
         {
-            const PODVector<VertexElement>& elements = buffer->GetElements();
+            const Vector<VertexElement>& elements = buffer->GetElements();
             // Check if buffer has per-instance data
             bool hasInstanceData = elements.Size() && elements[0].perInstance_;
             unsigned offset = hasInstanceData ? instanceOffset * buffer->GetVertexSize() : 0;
@@ -858,7 +858,7 @@ bool Graphics::SetVertexBuffers_D3D11(const PODVector<VertexBuffer*>& buffers, u
 
 bool Graphics::SetVertexBuffers_D3D11(const Vector<SharedPtr<VertexBuffer>>& buffers, unsigned instanceOffset)
 {
-    return SetVertexBuffers_D3D11(reinterpret_cast<const PODVector<VertexBuffer*>&>(buffers), instanceOffset);
+    return SetVertexBuffers_D3D11(reinterpret_cast<const Vector<VertexBuffer*>&>(buffers), instanceOffset);
 }
 
 void Graphics::SetIndexBuffer_D3D11(IndexBuffer* buffer)
@@ -1265,7 +1265,7 @@ void Graphics::SetTextureParametersDirty_D3D11()
 {
     MutexLock lock(gpuObjectMutex_);
 
-    for (PODVector<GPUObject*>::Iterator i = gpuObjects_.Begin(); i != gpuObjects_.End(); ++i)
+    for (Vector<GPUObject*>::Iterator i = gpuObjects_.Begin(); i != gpuObjects_.End(); ++i)
     {
         Texture* texture = dynamic_cast<Texture*>(*i);
         if (texture)
@@ -1613,9 +1613,9 @@ bool Graphics::IsInitialized_D3D11() const
     return window_ != nullptr && GetImpl_D3D11()->GetDevice() != nullptr;
 }
 
-PODVector<int> Graphics::GetMultiSampleLevels_D3D11() const
+Vector<int> Graphics::GetMultiSampleLevels_D3D11() const
 {
-    PODVector<int> ret;
+    Vector<int> ret;
     ret.Push(1);
 
     GraphicsImpl_D3D11* impl = GetImpl_D3D11();
@@ -2090,7 +2090,7 @@ bool Graphics::CreateDevice_D3D11(int width, int height)
     }
 
     // Check that multisample level is supported
-    PODVector<int> multiSampleLevels = GetMultiSampleLevels_D3D11();
+    Vector<int> multiSampleLevels = GetMultiSampleLevels_D3D11();
     if (!multiSampleLevels.Contains(screenParams_.multiSample_))
         screenParams_.multiSample_ = 1;
 

--- a/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11GraphicsImpl.h
+++ b/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11GraphicsImpl.h
@@ -119,7 +119,7 @@ private:
     /// Constant buffer search map.
     ConstantBufferMap allConstantBuffers_;
     /// Currently dirty constant buffers.
-    PODVector<ConstantBuffer*> dirtyConstantBuffers_;
+    Vector<ConstantBuffer*> dirtyConstantBuffers_;
     /// Shader programs.
     ShaderProgramMap_D3D11 shaderPrograms_;
     /// Shader program in use.

--- a/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11ShaderVariation.cpp
+++ b/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11ShaderVariation.cpp
@@ -243,7 +243,7 @@ bool ShaderVariation::Compile_D3D11()
 
     // Collect defines into macros
     Vector<String> defineValues;
-    PODVector<D3D_SHADER_MACRO> macros;
+    Vector<D3D_SHADER_MACRO> macros;
 
     for (unsigned i = 0; i < defines.Size(); ++i)
     {

--- a/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11VertexDeclaration.cpp
+++ b/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11VertexDeclaration.cpp
@@ -29,7 +29,7 @@ static const DXGI_FORMAT d3dElementFormats[] =
 VertexDeclaration_D3D11::VertexDeclaration_D3D11(Graphics* graphics, ShaderVariation* vertexShader, VertexBuffer** vertexBuffers) :
     inputLayout_(nullptr)
 {
-    PODVector<D3D11_INPUT_ELEMENT_DESC> elementDescs;
+    Vector<D3D11_INPUT_ELEMENT_DESC> elementDescs;
     unsigned prevBufferDescs = 0;
 
     for (unsigned i = 0; i < MAX_VERTEX_STREAMS; ++i)
@@ -37,7 +37,7 @@ VertexDeclaration_D3D11::VertexDeclaration_D3D11(Graphics* graphics, ShaderVaria
         if (!vertexBuffers[i])
             continue;
 
-        const PODVector<VertexElement>& srcElements = vertexBuffers[i]->GetElements();
+        const Vector<VertexElement>& srcElements = vertexBuffers[i]->GetElements();
         bool isExisting = false;
 
         for (unsigned j = 0; j < srcElements.Size(); ++j)
@@ -79,7 +79,7 @@ VertexDeclaration_D3D11::VertexDeclaration_D3D11(Graphics* graphics, ShaderVaria
     if (elementDescs.Empty())
         return;
 
-    const PODVector<unsigned char>& byteCode = vertexShader->GetByteCode();
+    const Vector<unsigned char>& byteCode = vertexShader->GetByteCode();
 
     HRESULT hr = graphics->GetImpl_D3D11()->GetDevice()->CreateInputLayout(&elementDescs[0], (UINT)elementDescs.Size(), &byteCode[0],
         byteCode.Size(), (ID3D11InputLayout**)&inputLayout_);

--- a/Source/Urho3D/GraphicsAPI/Direct3D9/D3D9Graphics.cpp
+++ b/Source/Urho3D/GraphicsAPI/Direct3D9/D3D9Graphics.cpp
@@ -249,7 +249,7 @@ void Graphics::Destructor_D3D9()
         MutexLock lock(gpuObjectMutex_);
 
         // Release all GPU objects that still exist
-        for (PODVector<GPUObject*>::Iterator i = gpuObjects_.Begin(); i != gpuObjects_.End(); ++i)
+        for (Vector<GPUObject*>::Iterator i = gpuObjects_.Begin(); i != gpuObjects_.End(); ++i)
             (*i)->Release();
         gpuObjects_.Clear();
     }
@@ -397,7 +397,7 @@ bool Graphics::SetScreenMode_D3D9(int width, int height, const ScreenModeParams&
             {
                 MutexLock lock(gpuObjectMutex_);
                 // Release all GPU objects that still exist
-                for (PODVector<GPUObject*>::Iterator i = gpuObjects_.Begin(); i != gpuObjects_.End(); ++i)
+                for (Vector<GPUObject*>::Iterator i = gpuObjects_.Begin(); i != gpuObjects_.End(); ++i)
                     (*i)->Release();
             }
 
@@ -895,7 +895,7 @@ void Graphics::DrawInstanced_D3D9(PrimitiveType type, unsigned indexStart, unsig
         VertexBuffer* buffer = vertexBuffers_[i];
         if (buffer)
         {
-            const PODVector<VertexElement>& elements = buffer->GetElements();
+            const Vector<VertexElement>& elements = buffer->GetElements();
             // Check if buffer has per-instance data
             if (elements.Size() && elements[0].perInstance_)
                 SetStreamFrequency_D3D9(i, D3DSTREAMSOURCE_INSTANCEDATA | 1u);
@@ -925,7 +925,7 @@ void Graphics::DrawInstanced_D3D9(PrimitiveType type, unsigned indexStart, unsig
         VertexBuffer* buffer = vertexBuffers_[i];
         if (buffer)
         {
-            const PODVector<VertexElement>& elements = buffer->GetElements();
+            const Vector<VertexElement>& elements = buffer->GetElements();
             // Check if buffer has per-instance data
             if (elements.Size() && elements[0].perInstance_)
                 SetStreamFrequency_D3D9(i, D3DSTREAMSOURCE_INSTANCEDATA | 1u);
@@ -947,12 +947,12 @@ void Graphics::DrawInstanced_D3D9(PrimitiveType type, unsigned indexStart, unsig
 void Graphics::SetVertexBuffer_D3D9(VertexBuffer* buffer)
 {
     // Note: this is not multi-instance safe
-    static PODVector<VertexBuffer*> vertexBuffers(1);
+    static Vector<VertexBuffer*> vertexBuffers(1);
     vertexBuffers[0] = buffer;
     SetVertexBuffers_D3D9(vertexBuffers);
 }
 
-bool Graphics::SetVertexBuffers_D3D9(const PODVector<VertexBuffer*>& buffers, unsigned instanceOffset)
+bool Graphics::SetVertexBuffers_D3D9(const Vector<VertexBuffer*>& buffers, unsigned instanceOffset)
 {
     if (buffers.Size() > MAX_VERTEX_STREAMS)
     {
@@ -1001,7 +1001,7 @@ bool Graphics::SetVertexBuffers_D3D9(const PODVector<VertexBuffer*>& buffers, un
         if (i < buffers.Size() && buffers[i])
         {
             buffer = buffers[i];
-            const PODVector<VertexElement>& elements = buffer->GetElements();
+            const Vector<VertexElement>& elements = buffer->GetElements();
             // Check if buffer has per-instance data; add instance offset in that case
             if (elements.Size() && elements[0].perInstance_)
                 offset = instanceOffset * buffer->GetVertexSize();
@@ -1025,7 +1025,7 @@ bool Graphics::SetVertexBuffers_D3D9(const PODVector<VertexBuffer*>& buffers, un
 
 bool Graphics::SetVertexBuffers_D3D9(const Vector<SharedPtr<VertexBuffer>>& buffers, unsigned instanceOffset)
 {
-    return SetVertexBuffers_D3D9(reinterpret_cast<const PODVector<VertexBuffer*>&>(buffers), instanceOffset);
+    return SetVertexBuffers_D3D9(reinterpret_cast<const Vector<VertexBuffer*>&>(buffers), instanceOffset);
 }
 
 void Graphics::SetIndexBuffer_D3D9(IndexBuffer* buffer)
@@ -1906,9 +1906,9 @@ bool Graphics::IsInitialized_D3D9() const
     return window_ != nullptr && GetImpl_D3D9()->GetDevice() != nullptr;
 }
 
-PODVector<int> Graphics::GetMultiSampleLevels_D3D9() const
+Vector<int> Graphics::GetMultiSampleLevels_D3D9() const
 {
-    PODVector<int> ret;
+    Vector<int> ret;
     // No multisampling always supported
     ret.Push(1);
 
@@ -2557,7 +2557,7 @@ void Graphics::OnDeviceLost_D3D9()
     {
         MutexLock lock(gpuObjectMutex_);
 
-        for (PODVector<GPUObject*>::Iterator i = gpuObjects_.Begin(); i != gpuObjects_.End(); ++i)
+        for (Vector<GPUObject*>::Iterator i = gpuObjects_.Begin(); i != gpuObjects_.End(); ++i)
             (*i)->OnDeviceLost();
     }
 
@@ -2569,7 +2569,7 @@ void Graphics::OnDeviceReset_D3D9()
     {
         MutexLock lock(gpuObjectMutex_);
 
-        for (PODVector<GPUObject*>::Iterator i = gpuObjects_.Begin(); i != gpuObjects_.End(); ++i)
+        for (Vector<GPUObject*>::Iterator i = gpuObjects_.Begin(); i != gpuObjects_.End(); ++i)
             (*i)->OnDeviceReset();
     }
 

--- a/Source/Urho3D/GraphicsAPI/Direct3D9/D3D9ShaderVariation.cpp
+++ b/Source/Urho3D/GraphicsAPI/Direct3D9/D3D9ShaderVariation.cpp
@@ -20,7 +20,7 @@
 namespace Urho3D
 {
 
-static void CopyStrippedCode(PODVector<unsigned char>& byteCode, unsigned char* bufData, unsigned bufSize)
+static void CopyStrippedCode(Vector<unsigned char>& byteCode, unsigned char* bufData, unsigned bufSize)
 {
     unsigned const D3DSIO_COMMENT = 0xFFFE;
     unsigned* srcWords = (unsigned*)bufData;
@@ -241,7 +241,7 @@ bool ShaderVariation::Compile_D3D9()
 
     // Collect defines into macros
     Vector<String> defineValues;
-    PODVector<D3D_SHADER_MACRO> macros;
+    Vector<D3D_SHADER_MACRO> macros;
 
     for (unsigned i = 0; i < defines.Size(); ++i)
     {

--- a/Source/Urho3D/GraphicsAPI/Direct3D9/D3D9VertexDeclaration.cpp
+++ b/Source/Urho3D/GraphicsAPI/Direct3D9/D3D9VertexDeclaration.cpp
@@ -38,10 +38,10 @@ const BYTE d3dElementUsage[] =
     D3DDECLUSAGE_TEXCOORD // Object index (not supported by D3D9)
 };
 
-VertexDeclaration_D3D9::VertexDeclaration_D3D9(Graphics* graphics, const PODVector<VertexElement>& srcElements) :
+VertexDeclaration_D3D9::VertexDeclaration_D3D9(Graphics* graphics, const Vector<VertexElement>& srcElements) :
     declaration_(nullptr)
 {
-    PODVector<VertexDeclarationElement_D3D9> elements;
+    Vector<VertexDeclarationElement_D3D9> elements;
 
     for (unsigned i = 0; i < srcElements.Size(); ++i)
     {
@@ -65,10 +65,10 @@ VertexDeclaration_D3D9::VertexDeclaration_D3D9(Graphics* graphics, const PODVect
     Create(graphics, elements);
 }
 
-VertexDeclaration_D3D9::VertexDeclaration_D3D9(Graphics* graphics, const PODVector<VertexBuffer*>& buffers) :
+VertexDeclaration_D3D9::VertexDeclaration_D3D9(Graphics* graphics, const Vector<VertexBuffer*>& buffers) :
     declaration_(nullptr)
 {
-    PODVector<VertexDeclarationElement_D3D9> elements;
+    Vector<VertexDeclarationElement_D3D9> elements;
     unsigned prevBufferElements = 0;
 
     for (unsigned i = 0; i < buffers.Size(); ++i)
@@ -76,7 +76,7 @@ VertexDeclaration_D3D9::VertexDeclaration_D3D9(Graphics* graphics, const PODVect
         if (!buffers[i])
             continue;
 
-        const PODVector<VertexElement>& srcElements = buffers[i]->GetElements();
+        const Vector<VertexElement>& srcElements = buffers[i]->GetElements();
         bool isExisting = false;
 
         for (unsigned j = 0; j < srcElements.Size(); ++j)
@@ -122,7 +122,7 @@ VertexDeclaration_D3D9::VertexDeclaration_D3D9(Graphics* graphics, const PODVect
 VertexDeclaration_D3D9::VertexDeclaration_D3D9(Graphics* graphics, const Vector<SharedPtr<VertexBuffer>>& buffers) :
     declaration_(nullptr)
 {
-    PODVector<VertexDeclarationElement_D3D9> elements;
+    Vector<VertexDeclarationElement_D3D9> elements;
     unsigned prevBufferElements = 0;
 
     for (unsigned i = 0; i < buffers.Size(); ++i)
@@ -130,7 +130,7 @@ VertexDeclaration_D3D9::VertexDeclaration_D3D9(Graphics* graphics, const Vector<
         if (!buffers[i])
             continue;
 
-        const PODVector<VertexElement>& srcElements = buffers[i]->GetElements();
+        const Vector<VertexElement>& srcElements = buffers[i]->GetElements();
         bool isExisting = false;
 
         for (unsigned j = 0; j < srcElements.Size(); ++j)
@@ -178,7 +178,7 @@ VertexDeclaration_D3D9::~VertexDeclaration_D3D9()
     Release();
 }
 
-void VertexDeclaration_D3D9::Create(Graphics* graphics, const PODVector<VertexDeclarationElement_D3D9>& elements)
+void VertexDeclaration_D3D9::Create(Graphics* graphics, const Vector<VertexDeclarationElement_D3D9>& elements)
 {
     SharedArrayPtr<D3DVERTEXELEMENT9> elementArray(new D3DVERTEXELEMENT9[elements.Size() + 1]);
 

--- a/Source/Urho3D/GraphicsAPI/Direct3D9/D3D9VertexDeclaration.h
+++ b/Source/Urho3D/GraphicsAPI/Direct3D9/D3D9VertexDeclaration.h
@@ -35,9 +35,9 @@ class URHO3D_API VertexDeclaration_D3D9 : public RefCounted
 {
 public:
     /// Construct with a single buffer's vertex element list.
-    VertexDeclaration_D3D9(Graphics* graphics, const PODVector<VertexElement>& srcElements);
+    VertexDeclaration_D3D9(Graphics* graphics, const Vector<VertexElement>& srcElements);
     /// Construct with vertex buffers to base declaration on. Higher index buffers will override semantics on lower indices.
-    VertexDeclaration_D3D9(Graphics* graphics, const PODVector<VertexBuffer*>& buffers);
+    VertexDeclaration_D3D9(Graphics* graphics, const Vector<VertexBuffer*>& buffers);
     /// Construct with vertex buffers (shared pointer vector) to base declaration on. Higher index buffers will override semantics on lower indices.
     VertexDeclaration_D3D9(Graphics* graphics, const Vector<SharedPtr<VertexBuffer>>& buffers);
     /// Destruct.
@@ -48,7 +48,7 @@ public:
 
 private:
     /// Create declaration.
-    void Create(Graphics* graphics, const PODVector<VertexDeclarationElement_D3D9>& elements);
+    void Create(Graphics* graphics, const Vector<VertexDeclarationElement_D3D9>& elements);
     /// Release declaration.
     void Release();
 

--- a/Source/Urho3D/GraphicsAPI/OpenGL/OGLGraphics.cpp
+++ b/Source/Urho3D/GraphicsAPI/OpenGL/OGLGraphics.cpp
@@ -946,12 +946,12 @@ void Graphics::DrawInstanced_OGL(PrimitiveType type, unsigned indexStart, unsign
 void Graphics::SetVertexBuffer_OGL(VertexBuffer* buffer)
 {
     // Note: this is not multi-instance safe
-    static PODVector<VertexBuffer*> vertexBuffers(1);
+    static Vector<VertexBuffer*> vertexBuffers(1);
     vertexBuffers[0] = buffer;
     SetVertexBuffers_OGL(vertexBuffers);
 }
 
-bool Graphics::SetVertexBuffers_OGL(const PODVector<VertexBuffer*>& buffers, unsigned instanceOffset)
+bool Graphics::SetVertexBuffers_OGL(const Vector<VertexBuffer*>& buffers, unsigned instanceOffset)
 {
     if (buffers.Size() > MAX_VERTEX_STREAMS)
     {
@@ -984,7 +984,7 @@ bool Graphics::SetVertexBuffers_OGL(const PODVector<VertexBuffer*>& buffers, uns
 
 bool Graphics::SetVertexBuffers_OGL(const Vector<SharedPtr<VertexBuffer>>& buffers, unsigned instanceOffset)
 {
-    return SetVertexBuffers_OGL(reinterpret_cast<const PODVector<VertexBuffer*>&>(buffers), instanceOffset);
+    return SetVertexBuffers_OGL(reinterpret_cast<const Vector<VertexBuffer*>&>(buffers), instanceOffset);
 }
 
 void Graphics::SetIndexBuffer_OGL(IndexBuffer* buffer)
@@ -1620,7 +1620,7 @@ void Graphics::SetTextureParametersDirty_OGL()
 {
     MutexLock lock(gpuObjectMutex_);
 
-    for (PODVector<GPUObject*>::Iterator i = gpuObjects_.Begin(); i != gpuObjects_.End(); ++i)
+    for (Vector<GPUObject*>::Iterator i = gpuObjects_.Begin(); i != gpuObjects_.End(); ++i)
     {
         auto* texture = dynamic_cast<Texture*>(*i);
         if (texture)
@@ -2065,9 +2065,9 @@ bool Graphics::IsDeviceLost_OGL() const
     return GetImpl_OGL()->context_ == nullptr;
 }
 
-PODVector<int> Graphics::GetMultiSampleLevels_OGL() const
+Vector<int> Graphics::GetMultiSampleLevels_OGL() const
 {
-    PODVector<int> ret;
+    Vector<int> ret;
     // No multisampling always supported
     ret.Push(1);
 
@@ -2390,14 +2390,14 @@ void Graphics::Release_OGL(bool clearGPUObjects, bool closeWindow)
             // Shader programs are also GPU objects; clear them first to avoid list modification during iteration
             impl->shaderPrograms_.Clear();
 
-            for (PODVector<GPUObject*>::Iterator i = gpuObjects_.Begin(); i != gpuObjects_.End(); ++i)
+            for (Vector<GPUObject*>::Iterator i = gpuObjects_.Begin(); i != gpuObjects_.End(); ++i)
                 (*i)->Release();
             gpuObjects_.Clear();
         }
         else
         {
             // We are not shutting down, but recreating the context: mark GPU objects lost
-            for (PODVector<GPUObject*>::Iterator i = gpuObjects_.Begin(); i != gpuObjects_.End(); ++i)
+            for (Vector<GPUObject*>::Iterator i = gpuObjects_.Begin(); i != gpuObjects_.End(); ++i)
                 (*i)->OnDeviceLost();
 
             // In this case clear shader programs last so that they do not attempt to delete their OpenGL program
@@ -2542,7 +2542,7 @@ void Graphics::Restore_OGL()
     {
         MutexLock lock(gpuObjectMutex_);
 
-        for (PODVector<GPUObject*>::Iterator i = gpuObjects_.Begin(); i != gpuObjects_.End(); ++i)
+        for (Vector<GPUObject*>::Iterator i = gpuObjects_.Begin(); i != gpuObjects_.End(); ++i)
             (*i)->OnDeviceReset();
     }
 
@@ -2863,7 +2863,7 @@ void Graphics::PrepareDraw_OGL()
 #ifndef GL_ES_VERSION_2_0
     if (gl3Support)
     {
-        for (PODVector<ConstantBuffer*>::Iterator i = impl->dirtyConstantBuffers_.Begin(); i != impl->dirtyConstantBuffers_.End(); ++i)
+        for (Vector<ConstantBuffer*>::Iterator i = impl->dirtyConstantBuffers_.Begin(); i != impl->dirtyConstantBuffers_.End(); ++i)
             (*i)->Apply();
         impl->dirtyConstantBuffers_.Clear();
     }
@@ -3101,9 +3101,9 @@ void Graphics::PrepareDraw_OGL()
             if (!buffer || !buffer->GetGPUObjectName() || !impl->vertexAttributes_)
                 continue;
 
-            const PODVector<VertexElement>& elements = buffer->GetElements();
+            const Vector<VertexElement>& elements = buffer->GetElements();
 
-            for (PODVector<VertexElement>::ConstIterator j = elements.Begin(); j != elements.End(); ++j)
+            for (Vector<VertexElement>::ConstIterator j = elements.Begin(); j != elements.End(); ++j)
             {
                 const VertexElement& element = *j;
                 HashMap<Pair<unsigned char, unsigned char>, unsigned>::ConstIterator k =

--- a/Source/Urho3D/GraphicsAPI/OpenGL/OGLGraphicsImpl.h
+++ b/Source/Urho3D/GraphicsAPI/OpenGL/OGLGraphicsImpl.h
@@ -124,7 +124,7 @@ private:
     /// Currently bound constant buffers.
     ConstantBuffer* constantBuffers_[MAX_SHADER_PARAMETER_GROUPS * 2]{};
     /// Dirty constant buffers.
-    PODVector<ConstantBuffer*> dirtyConstantBuffers_;
+    Vector<ConstantBuffer*> dirtyConstantBuffers_;
     /// Last used instance data offset.
     unsigned lastInstanceOffset_{};
     /// Map for additional depth textures, to emulate Direct3D9 ability to mix render texture and backbuffer rendering.

--- a/Source/Urho3D/GraphicsAPI/ShaderVariation.h
+++ b/Source/Urho3D/GraphicsAPI/ShaderVariation.h
@@ -104,7 +104,7 @@ public:
     unsigned long long GetElementHash() const { return elementHash_; }
 
     /// Return shader bytecode. Stored persistently on Direct3D11 only.
-    const PODVector<unsigned char>& GetByteCode() const { return byteCode_; }
+    const Vector<unsigned char>& GetByteCode() const { return byteCode_; }
 
     /// Return defines.
     const String& GetDefines() const { return defines_; }
@@ -195,7 +195,7 @@ private:
     /// Constant buffer sizes. 0 if a constant buffer slot is not in use.
     unsigned constantBufferSizes_[MAX_SHADER_PARAMETER_GROUPS]{};
     /// Shader bytecode. Needed for inspecting the input signature and parameters. Not used on OpenGL.
-    PODVector<unsigned char> byteCode_;
+    Vector<unsigned char> byteCode_;
     /// Shader name.
     String name_;
     /// Defines to use in compiling.

--- a/Source/Urho3D/GraphicsAPI/Texture2DArray.h
+++ b/Source/Urho3D/GraphicsAPI/Texture2DArray.h
@@ -105,7 +105,7 @@ private:
     /// Render surface.
     SharedPtr<RenderSurface> renderSurface_;
     /// Memory use per layer.
-    PODVector<unsigned> layerMemoryUse_;
+    Vector<unsigned> layerMemoryUse_;
     /// Layer image files acquired during BeginLoad.
     Vector<SharedPtr<Image>> loadImages_;
     /// Parameter file acquired during BeginLoad.

--- a/Source/Urho3D/GraphicsAPI/VertexBuffer.cpp
+++ b/Source/Urho3D/GraphicsAPI/VertexBuffer.cpp
@@ -52,7 +52,7 @@ bool VertexBuffer::SetSize(unsigned vertexCount, unsigned elementMask, bool dyna
     return SetSize(vertexCount, GetElements(elementMask), dynamic);
 }
 
-bool VertexBuffer::SetSize(unsigned vertexCount, const PODVector<VertexElement>& elements, bool dynamic)
+bool VertexBuffer::SetSize(unsigned vertexCount, const Vector<VertexElement>& elements, bool dynamic)
 {
     Unlock();
 
@@ -76,7 +76,7 @@ void VertexBuffer::UpdateOffsets()
     elementHash_ = 0;
     elementMask_ = MASK_NONE;
 
-    for (PODVector<VertexElement>::Iterator i = elements_.Begin(); i != elements_.End(); ++i)
+    for (Vector<VertexElement>::Iterator i = elements_.Begin(); i != elements_.End(); ++i)
     {
         i->offset_ = elementOffset;
         elementOffset += ELEMENT_TYPESIZES[i->type_];
@@ -96,7 +96,7 @@ void VertexBuffer::UpdateOffsets()
 
 const VertexElement* VertexBuffer::GetElement(VertexElementSemantic semantic, unsigned char index) const
 {
-    for (PODVector<VertexElement>::ConstIterator i = elements_.Begin(); i != elements_.End(); ++i)
+    for (Vector<VertexElement>::ConstIterator i = elements_.Begin(); i != elements_.End(); ++i)
     {
         if (i->semantic_ == semantic && i->index_ == index)
             return &(*i);
@@ -107,7 +107,7 @@ const VertexElement* VertexBuffer::GetElement(VertexElementSemantic semantic, un
 
 const VertexElement* VertexBuffer::GetElement(VertexElementType type, VertexElementSemantic semantic, unsigned char index) const
 {
-    for (PODVector<VertexElement>::ConstIterator i = elements_.Begin(); i != elements_.End(); ++i)
+    for (Vector<VertexElement>::ConstIterator i = elements_.Begin(); i != elements_.End(); ++i)
     {
         if (i->type_ == type && i->semantic_ == semantic && i->index_ == index)
             return &(*i);
@@ -116,9 +116,9 @@ const VertexElement* VertexBuffer::GetElement(VertexElementType type, VertexElem
     return nullptr;
 }
 
-const VertexElement* VertexBuffer::GetElement(const PODVector<VertexElement>& elements, VertexElementType type, VertexElementSemantic semantic, unsigned char index)
+const VertexElement* VertexBuffer::GetElement(const Vector<VertexElement>& elements, VertexElementType type, VertexElementSemantic semantic, unsigned char index)
 {
-    for (PODVector<VertexElement>::ConstIterator i = elements.Begin(); i != elements.End(); ++i)
+    for (Vector<VertexElement>::ConstIterator i = elements.Begin(); i != elements.End(); ++i)
     {
         if (i->type_ == type && i->semantic_ == semantic && i->index_ == index)
             return &(*i);
@@ -127,20 +127,20 @@ const VertexElement* VertexBuffer::GetElement(const PODVector<VertexElement>& el
     return nullptr;
 }
 
-bool VertexBuffer::HasElement(const PODVector<VertexElement>& elements, VertexElementType type, VertexElementSemantic semantic, unsigned char index)
+bool VertexBuffer::HasElement(const Vector<VertexElement>& elements, VertexElementType type, VertexElementSemantic semantic, unsigned char index)
 {
     return GetElement(elements, type, semantic, index) != nullptr;
 }
 
-unsigned VertexBuffer::GetElementOffset(const PODVector<VertexElement>& elements, VertexElementType type, VertexElementSemantic semantic, unsigned char index)
+unsigned VertexBuffer::GetElementOffset(const Vector<VertexElement>& elements, VertexElementType type, VertexElementSemantic semantic, unsigned char index)
 {
     const VertexElement* element = GetElement(elements, type, semantic, index);
     return element ? element->offset_ : M_MAX_UNSIGNED;
 }
 
-PODVector<VertexElement> VertexBuffer::GetElements(unsigned elementMask)
+Vector<VertexElement> VertexBuffer::GetElements(unsigned elementMask)
 {
-    PODVector<VertexElement> ret;
+    Vector<VertexElement> ret;
 
     for (unsigned i = 0; i < MAX_LEGACY_VERTEX_ELEMENTS; ++i)
     {
@@ -151,7 +151,7 @@ PODVector<VertexElement> VertexBuffer::GetElements(unsigned elementMask)
     return ret;
 }
 
-unsigned VertexBuffer::GetVertexSize(const PODVector<VertexElement>& elements)
+unsigned VertexBuffer::GetVertexSize(const Vector<VertexElement>& elements)
 {
     unsigned size = 0;
 
@@ -174,11 +174,11 @@ unsigned VertexBuffer::GetVertexSize(unsigned elementMask)
     return size;
 }
 
-void VertexBuffer::UpdateOffsets(PODVector<VertexElement>& elements)
+void VertexBuffer::UpdateOffsets(Vector<VertexElement>& elements)
 {
     unsigned elementOffset = 0;
 
-    for (PODVector<VertexElement>::Iterator i = elements.Begin(); i != elements.End(); ++i)
+    for (Vector<VertexElement>::Iterator i = elements.Begin(); i != elements.End(); ++i)
     {
         i->offset_ = elementOffset;
         elementOffset += ELEMENT_TYPESIZES[i->type_];

--- a/Source/Urho3D/GraphicsAPI/VertexBuffer.h
+++ b/Source/Urho3D/GraphicsAPI/VertexBuffer.h
@@ -33,7 +33,7 @@ public:
     /// @property
     void SetShadowed(bool enable);
     /// Set size, vertex elements and dynamic mode. Previous data will be lost.
-    bool SetSize(unsigned vertexCount, const PODVector<VertexElement>& elements, bool dynamic = false);
+    bool SetSize(unsigned vertexCount, const Vector<VertexElement>& elements, bool dynamic = false);
     /// Set size and vertex elements and dynamic mode using legacy element bitmask. Previous data will be lost.
     bool SetSize(unsigned vertexCount, unsigned elementMask, bool dynamic = false);
     /// Set all data in the buffer.
@@ -66,7 +66,7 @@ public:
 
     /// Return vertex elements.
     /// @property
-    const PODVector<VertexElement>& GetElements() const { return elements_; }
+    const Vector<VertexElement>& GetElements() const { return elements_; }
 
     /// Return vertex element, or null if does not exist.
     const VertexElement* GetElement(VertexElementSemantic semantic, unsigned char index = 0) const;
@@ -100,25 +100,25 @@ public:
     unsigned long long GetBufferHash(unsigned streamIndex) { return elementHash_ << (streamIndex * 16); }
 
     /// Return element with specified type and semantic from a vertex element list, or null if does not exist.
-    static const VertexElement* GetElement(const PODVector<VertexElement>& elements, VertexElementType type, VertexElementSemantic semantic, unsigned char index = 0);
+    static const VertexElement* GetElement(const Vector<VertexElement>& elements, VertexElementType type, VertexElementSemantic semantic, unsigned char index = 0);
 
     /// Return whether element list has a specified element type and semantic.
-    static bool HasElement(const PODVector<VertexElement>& elements, VertexElementType type, VertexElementSemantic semantic, unsigned char index = 0);
+    static bool HasElement(const Vector<VertexElement>& elements, VertexElementType type, VertexElementSemantic semantic, unsigned char index = 0);
 
     /// Return element offset for specified type and semantic from a vertex element list, or M_MAX_UNSIGNED if does not exist.
-    static unsigned GetElementOffset(const PODVector<VertexElement>& elements, VertexElementType type, VertexElementSemantic semantic, unsigned char index = 0);
+    static unsigned GetElementOffset(const Vector<VertexElement>& elements, VertexElementType type, VertexElementSemantic semantic, unsigned char index = 0);
 
     /// Return a vertex element list from a legacy element bitmask.
-    static PODVector<VertexElement> GetElements(unsigned elementMask);
+    static Vector<VertexElement> GetElements(unsigned elementMask);
 
     /// Return vertex size from an element list.
-    static unsigned GetVertexSize(const PODVector<VertexElement>& elements);
+    static unsigned GetVertexSize(const Vector<VertexElement>& elements);
 
     /// Return vertex size for a legacy vertex element bitmask.
     static unsigned GetVertexSize(unsigned elementMask);
 
     /// Update offsets of vertex elements.
-    static void UpdateOffsets(PODVector<VertexElement>& elements);
+    static void UpdateOffsets(Vector<VertexElement>& elements);
 
 private:
     /// Update offsets of vertex elements.
@@ -181,7 +181,7 @@ private:
     /// Vertex size.
     unsigned vertexSize_{};
     /// Vertex elements.
-    PODVector<VertexElement> elements_;
+    Vector<VertexElement> elements_;
     /// Vertex element hash.
     unsigned long long elementHash_{};
     /// Vertex element legacy bitmask.

--- a/Source/Urho3D/IK/IKSolver.cpp
+++ b/Source/Urho3D/IK/IKSolver.cpp
@@ -50,7 +50,7 @@ IKSolver::~IKSolver()
 {
     // Destroying the solver tree will destroy the effector objects, so remove
     // any references any of the IKEffector objects could be holding
-    for (PODVector<IKEffector*>::ConstIterator it = effectorList_.Begin(); it != effectorList_.End(); ++it)
+    for (Vector<IKEffector*>::ConstIterator it = effectorList_.Begin(); it != effectorList_.End(); ++it)
         (*it)->SetIKEffectorNode(nullptr);
 
     ik_solver_destroy(solver_);
@@ -265,7 +265,7 @@ void IKSolver::RebuildTree()
      */
     node_->GetComponents<IKEffector>(effectorList_, true);
     node_->GetComponents<IKConstraint>(constraintList_, true);
-    for (PODVector<IKEffector*>::Iterator it = effectorList_.Begin(); it != effectorList_.End();)
+    for (Vector<IKEffector*>::Iterator it = effectorList_.Begin(); it != effectorList_.End();)
     {
         if (ComponentIsInOurSubtree(*it))
         {
@@ -277,7 +277,7 @@ void IKSolver::RebuildTree()
             it = effectorList_.Erase(it);
         }
     }
-    for (PODVector<IKConstraint*>::Iterator it = constraintList_.Begin(); it != constraintList_.End();)
+    for (Vector<IKConstraint*>::Iterator it = constraintList_.Begin(); it != constraintList_.End();)
     {
         if (ComponentIsInOurSubtree(*it))
             ++it;
@@ -307,7 +307,7 @@ bool IKSolver::BuildTreeToEffector(IKEffector* effector)
      */
     const Node* iterNode = effector->GetNode();
     ik_node_t* ikNode;
-    PODVector<const Node*> missingNodes;
+    Vector<const Node*> missingNodes;
     while ((ikNode = ik_node_find_child(solver_->tree, iterNode->GetID())) == nullptr)
     {
         missingNodes.Push(iterNode);
@@ -399,7 +399,7 @@ void IKSolver::Solve()
     if (features_ & USE_ORIGINAL_POSE)
         ApplyOriginalPoseToActivePose();
 
-    for (PODVector<IKEffector*>::ConstIterator it = effectorList_.Begin(); it != effectorList_.End(); ++it)
+    for (Vector<IKEffector*>::ConstIterator it = effectorList_.Begin(); it != effectorList_.End(); ++it)
     {
         (*it)->UpdateTargetNodePosition();
     }
@@ -637,9 +637,9 @@ void IKSolver::HandleNodeAdded(StringHash eventType, VariantMap& eventData)
 
     auto* node = static_cast<Node*>(eventData[P_NODE].GetPtr());
 
-    PODVector<IKEffector*> effectors;
+    Vector<IKEffector*> effectors;
     node->GetComponents<IKEffector>(effectors, true);
-    for (PODVector<IKEffector*>::ConstIterator it = effectors.Begin(); it != effectors.End(); ++it)
+    for (Vector<IKEffector*>::ConstIterator it = effectors.Begin(); it != effectors.End(); ++it)
     {
         if (ComponentIsInOurSubtree(*it) == false)
             continue;
@@ -648,9 +648,9 @@ void IKSolver::HandleNodeAdded(StringHash eventType, VariantMap& eventData)
         effectorList_.Push(*it);
     }
 
-    PODVector<IKConstraint*> constraints;
+    Vector<IKConstraint*> constraints;
     node->GetComponents<IKConstraint>(constraints, true);
-    for (PODVector<IKConstraint*>::ConstIterator it = constraints.Begin(); it != constraints.End(); ++it)
+    for (Vector<IKConstraint*>::ConstIterator it = constraints.Begin(); it != constraints.End(); ++it)
     {
         if (ComponentIsInOurSubtree(*it) == false)
             continue;
@@ -670,17 +670,17 @@ void IKSolver::HandleNodeRemoved(StringHash eventType, VariantMap& eventData)
     auto* node = static_cast<Node*>(eventData[P_NODE].GetPtr());
 
     // Remove cached IKEffectors from our list
-    PODVector<IKEffector*> effectors;
+    Vector<IKEffector*> effectors;
     node->GetComponents<IKEffector>(effectors, true);
-    for (PODVector<IKEffector*>::ConstIterator it = effectors.Begin(); it != effectors.End(); ++it)
+    for (Vector<IKEffector*>::ConstIterator it = effectors.Begin(); it != effectors.End(); ++it)
     {
         (*it)->SetIKEffectorNode(nullptr);
         effectorList_.RemoveSwap(*it);
     }
 
-    PODVector<IKConstraint*> constraints;
+    Vector<IKConstraint*> constraints;
     node->GetComponents<IKConstraint>(constraints, true);
-    for (PODVector<IKConstraint*>::ConstIterator it = constraints.Begin(); it != constraints.End(); ++it)
+    for (Vector<IKConstraint*>::ConstIterator it = constraints.Begin(); it != constraints.End(); ++it)
     {
         constraintList_.RemoveSwap(*it);
     }
@@ -718,7 +718,7 @@ void IKSolver::DrawDebugGeometry(bool depthTest)
 void IKSolver::DrawDebugGeometry(DebugRenderer* debug, bool depthTest)
 {
     // Draws all scene segments
-    for (PODVector<IKEffector*>::ConstIterator it = effectorList_.Begin(); it != effectorList_.End(); ++it)
+    for (Vector<IKEffector*>::ConstIterator it = effectorList_.Begin(); it != effectorList_.End(); ++it)
         (*it)->DrawDebugGeometry(debug, depthTest);
 
     ORDERED_VECTOR_FOR_EACH(&solver_->effector_nodes_list, ik_node_t*, pnode)

--- a/Source/Urho3D/IK/IKSolver.h
+++ b/Source/Urho3D/IK/IKSolver.h
@@ -371,8 +371,8 @@ public:
     void SetAUTO_SOLVE(bool enable);
 
 private:
-    PODVector<IKEffector*> effectorList_;
-    PODVector<IKConstraint*> constraintList_;
+    Vector<IKEffector*> effectorList_;
+    Vector<IKConstraint*> constraintList_;
     ik_solver_t* solver_;
     Algorithm algorithm_;
     unsigned features_;

--- a/Source/Urho3D/IO/Deserializer.cpp
+++ b/Source/Urho3D/IO/Deserializer.cpp
@@ -254,9 +254,9 @@ StringHash Deserializer::ReadStringHash()
     return StringHash(ReadUInt());
 }
 
-PODVector<unsigned char> Deserializer::ReadBuffer()
+Vector<unsigned char> Deserializer::ReadBuffer()
 {
-    PODVector<unsigned char> ret(ReadVLE());
+    Vector<unsigned char> ret(ReadVLE());
     if (ret.Size())
         Read(&ret[0], ret.Size());
     return ret;

--- a/Source/Urho3D/IO/Deserializer.h
+++ b/Source/Urho3D/IO/Deserializer.h
@@ -107,7 +107,7 @@ public:
     /// Read a 32-bit StringHash.
     StringHash ReadStringHash();
     /// Read a buffer with size encoded as VLE.
-    PODVector<unsigned char> ReadBuffer();
+    Vector<unsigned char> ReadBuffer();
     /// Read a resource reference.
     ResourceRef ReadResourceRef();
     /// Read a resource reference list.

--- a/Source/Urho3D/IO/FileSystem.cpp
+++ b/Source/Urho3D/IO/FileSystem.cpp
@@ -160,7 +160,7 @@ int DoSystemRun(const String& fileName, const Vector<String>& arguments)
     pid_t pid = fork();
     if (!pid)
     {
-        PODVector<const char*> argPtrs;
+        Vector<const char*> argPtrs;
         argPtrs.Push(fixedFileName.CString());
         for (unsigned i = 0; i < arguments.Size(); ++i)
             argPtrs.Push(arguments[i].CString());

--- a/Source/Urho3D/IO/MemoryBuffer.cpp
+++ b/Source/Urho3D/IO/MemoryBuffer.cpp
@@ -26,14 +26,14 @@ MemoryBuffer::MemoryBuffer(const void* data, unsigned size) :
         size_ = 0;
 }
 
-MemoryBuffer::MemoryBuffer(PODVector<unsigned char>& data) :
+MemoryBuffer::MemoryBuffer(Vector<unsigned char>& data) :
     AbstractFile(data.Size()),
     buffer_(data.Begin().ptr_),
     readOnly_(false)
 {
 }
 
-MemoryBuffer::MemoryBuffer(const PODVector<unsigned char>& data) :
+MemoryBuffer::MemoryBuffer(const Vector<unsigned char>& data) :
     AbstractFile(data.Size()),
     buffer_(const_cast<unsigned char*>(data.Begin().ptr_)),
     readOnly_(true)

--- a/Source/Urho3D/IO/MemoryBuffer.h
+++ b/Source/Urho3D/IO/MemoryBuffer.h
@@ -18,9 +18,9 @@ public:
     /// Construct as read-only with a pointer and size.
     MemoryBuffer(const void* data, unsigned size);
     /// Construct from a vector, which must not go out of scope before MemoryBuffer.
-    explicit MemoryBuffer(PODVector<unsigned char>& data);
+    explicit MemoryBuffer(Vector<unsigned char>& data);
     /// Construct from a read-only vector, which must not go out of scope before MemoryBuffer.
-    explicit MemoryBuffer(const PODVector<unsigned char>& data);
+    explicit MemoryBuffer(const Vector<unsigned char>& data);
 
     /// Read bytes from the memory area. Return number of bytes actually read.
     unsigned Read(void* dest, unsigned size) override;

--- a/Source/Urho3D/IO/Serializer.cpp
+++ b/Source/Urho3D/IO/Serializer.cpp
@@ -184,7 +184,7 @@ bool Serializer::WriteStringHash(const StringHash& value)
     return WriteUInt(value.Value());
 }
 
-bool Serializer::WriteBuffer(const PODVector<unsigned char>& value)
+bool Serializer::WriteBuffer(const Vector<unsigned char>& value)
 {
     bool success = true;
     unsigned size = value.Size();

--- a/Source/Urho3D/IO/Serializer.h
+++ b/Source/Urho3D/IO/Serializer.h
@@ -91,7 +91,7 @@ public:
     /// Write a 32-bit StringHash.
     bool WriteStringHash(const StringHash& value);
     /// Write a buffer, with size encoded as VLE.
-    bool WriteBuffer(const PODVector<unsigned char>& value);
+    bool WriteBuffer(const Vector<unsigned char>& value);
     /// Write a resource reference.
     bool WriteResourceRef(const ResourceRef& value);
     /// Write a resource reference list.

--- a/Source/Urho3D/IO/VectorBuffer.cpp
+++ b/Source/Urho3D/IO/VectorBuffer.cpp
@@ -10,7 +10,7 @@ namespace Urho3D
 
 VectorBuffer::VectorBuffer() = default;
 
-VectorBuffer::VectorBuffer(const PODVector<unsigned char>& data)
+VectorBuffer::VectorBuffer(const Vector<unsigned char>& data)
 {
     SetData(data);
 }
@@ -70,7 +70,7 @@ unsigned VectorBuffer::Write(const void* data, unsigned size)
     return size;
 }
 
-void VectorBuffer::SetData(const PODVector<unsigned char>& data)
+void VectorBuffer::SetData(const Vector<unsigned char>& data)
 {
     buffer_ = data;
     position_ = 0;

--- a/Source/Urho3D/IO/VectorBuffer.h
+++ b/Source/Urho3D/IO/VectorBuffer.h
@@ -15,7 +15,7 @@ public:
     /// Construct an empty buffer.
     VectorBuffer();
     /// Construct from another buffer.
-    explicit VectorBuffer(const PODVector<unsigned char>& data);
+    explicit VectorBuffer(const Vector<unsigned char>& data);
     /// Construct from a memory area.
     VectorBuffer(const void* data, unsigned size);
     /// Construct from a stream.
@@ -29,7 +29,7 @@ public:
     unsigned Write(const void* data, unsigned size) override;
 
     /// Set data from another buffer.
-    void SetData(const PODVector<unsigned char>& data);
+    void SetData(const Vector<unsigned char>& data);
     /// Set data from a memory area.
     void SetData(const void* data, unsigned size);
     /// Set data from a stream.
@@ -46,11 +46,11 @@ public:
     unsigned char* GetModifiableData() { return size_ ? &buffer_[0] : nullptr; }
 
     /// Return the buffer.
-    const PODVector<unsigned char>& GetBuffer() const { return buffer_; }
+    const Vector<unsigned char>& GetBuffer() const { return buffer_; }
 
 private:
     /// Dynamic data buffer.
-    PODVector<unsigned char> buffer_;
+    Vector<unsigned char> buffer_;
 };
 
 }

--- a/Source/Urho3D/Input/Input.cpp
+++ b/Source/Urho3D/Input/Input.cpp
@@ -1112,9 +1112,9 @@ SDL_JoystickID Input::AddScreenJoystick(XMLFile* layoutFile, XMLFile* styleFile)
     }
 
     // Make sure all the children are non-focusable so they do not mistakenly to be considered as active UI input controls by application
-    PODVector<UIElement*> allChildren;
+    Vector<UIElement*> allChildren;
     state.screenJoystick_->GetChildren(allChildren, true);
-    for (PODVector<UIElement*>::Iterator iter = allChildren.Begin(); iter != allChildren.End(); ++iter)
+    for (Vector<UIElement*>::Iterator iter = allChildren.Begin(); iter != allChildren.End(); ++iter)
         (*iter)->SetFocusMode(FM_NOTFOCUSABLE);
 
     state.Initialize(numButtons, numAxes, numHats);

--- a/Source/Urho3D/Input/Input.h
+++ b/Source/Urho3D/Input/Input.h
@@ -108,13 +108,13 @@ struct JoystickState
     /// Joystick name.
     String name_;
     /// Button up/down state.
-    PODVector<bool> buttons_;
+    Vector<bool> buttons_;
     /// Button pressed on this frame.
-    PODVector<bool> buttonPress_;
+    Vector<bool> buttonPress_;
     /// Axis position from -1 to 1.
-    PODVector<float> axes_;
+    Vector<float> axes_;
     /// POV hat bits.
-    PODVector<int> hats_;
+    Vector<int> hats_;
 };
 
 #ifdef __EMSCRIPTEN__

--- a/Source/Urho3D/LuaScript/LuaScript.cpp
+++ b/Source/Urho3D/LuaScript/LuaScript.cpp
@@ -204,7 +204,7 @@ void LuaScript::RemoveAllEventHandlers()
 
 void LuaScript::RemoveEventHandlersExcept(const Vector<String>& exceptionNames)
 {
-    PODVector<StringHash> exceptionTypes(exceptionNames.Size());
+    Vector<StringHash> exceptionTypes(exceptionNames.Size());
     for (unsigned i = 0; i < exceptionTypes.Size(); ++i)
         exceptionTypes[i] = StringHash(exceptionNames[i]);
 

--- a/Source/Urho3D/LuaScript/LuaScriptInstance.cpp
+++ b/Source/Urho3D/LuaScript/LuaScriptInstance.cpp
@@ -67,9 +67,9 @@ void LuaScriptInstance::RegisterObject(Context* context)
     URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Script File", GetScriptFileAttr, SetScriptFileAttr, ResourceRef,
         ResourceRef(LuaFile::GetTypeStatic()), AM_DEFAULT);
     URHO3D_ACCESSOR_ATTRIBUTE("Script Object Type", GetScriptObjectType, SetScriptObjectType, String, String::EMPTY, AM_DEFAULT);
-    URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Script Data", GetScriptDataAttr, SetScriptDataAttr, PODVector<unsigned char>, Variant::emptyBuffer,
+    URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Script Data", GetScriptDataAttr, SetScriptDataAttr, Vector<unsigned char>, Variant::emptyBuffer,
         AM_FILE | AM_NOEDIT);
-    URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Script Network Data", GetScriptNetworkDataAttr, SetScriptNetworkDataAttr, PODVector<unsigned char>,
+    URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Script Network Data", GetScriptNetworkDataAttr, SetScriptNetworkDataAttr, Vector<unsigned char>,
         Variant::emptyBuffer, AM_NET | AM_NOEDIT);
 }
 
@@ -341,7 +341,7 @@ void LuaScriptInstance::RemoveAllEventHandlers()
 
 void LuaScriptInstance::RemoveEventHandlersExcept(const Vector<String>& exceptionNames)
 {
-    PODVector<StringHash> exceptionTypes(exceptionNames.Size());
+    Vector<StringHash> exceptionTypes(exceptionNames.Size());
     for (unsigned i = 0; i < exceptionTypes.Size(); ++i)
         exceptionTypes[i] = StringHash(exceptionNames[i]);
 
@@ -412,7 +412,7 @@ void LuaScriptInstance::SetScriptObjectType(const String& scriptObjectType)
     FindScriptObjectMethodRefs();
 }
 
-void LuaScriptInstance::SetScriptDataAttr(const PODVector<unsigned char>& data)
+void LuaScriptInstance::SetScriptDataAttr(const Vector<unsigned char>& data)
 {
     if (scriptObjectRef_ == LUA_REFNIL)
         return;
@@ -426,7 +426,7 @@ void LuaScriptInstance::SetScriptDataAttr(const PODVector<unsigned char>& data)
     }
 }
 
-void LuaScriptInstance::SetScriptNetworkDataAttr(const PODVector<unsigned char>& data)
+void LuaScriptInstance::SetScriptNetworkDataAttr(const Vector<unsigned char>& data)
 {
     if (scriptObjectRef_ == LUA_REFNIL)
         return;
@@ -445,10 +445,10 @@ LuaFile* LuaScriptInstance::GetScriptFile() const
     return scriptFile_;
 }
 
-PODVector<unsigned char> LuaScriptInstance::GetScriptDataAttr() const
+Vector<unsigned char> LuaScriptInstance::GetScriptDataAttr() const
 {
     if (scriptObjectRef_ == LUA_REFNIL)
-        return PODVector<unsigned char>();
+        return Vector<unsigned char>();
 
     VectorBuffer buf;
 
@@ -462,10 +462,10 @@ PODVector<unsigned char> LuaScriptInstance::GetScriptDataAttr() const
     return buf.GetBuffer();
 }
 
-PODVector<unsigned char> LuaScriptInstance::GetScriptNetworkDataAttr() const
+Vector<unsigned char> LuaScriptInstance::GetScriptNetworkDataAttr() const
 {
     if (scriptObjectRef_ == LUA_REFNIL)
-        return PODVector<unsigned char>();
+        return Vector<unsigned char>();
 
     VectorBuffer buf;
 

--- a/Source/Urho3D/LuaScript/LuaScriptInstance.h
+++ b/Source/Urho3D/LuaScript/LuaScriptInstance.h
@@ -96,9 +96,9 @@ public:
     /// Set script object type.
     void SetScriptObjectType(const String& scriptObjectType);
     /// Set script file serialization attribute by calling a script function.
-    void SetScriptDataAttr(const PODVector<unsigned char>& data);
+    void SetScriptDataAttr(const Vector<unsigned char>& data);
     /// Set script network serialization attribute by calling a script function.
-    void SetScriptNetworkDataAttr(const PODVector<unsigned char>& data);
+    void SetScriptNetworkDataAttr(const Vector<unsigned char>& data);
 
     /// Return script file.
     LuaFile* GetScriptFile() const;
@@ -110,9 +110,9 @@ public:
     int GetScriptObjectRef() const { return scriptObjectRef_; }
 
     /// Get script file serialization attribute by calling a script function.
-    PODVector<unsigned char> GetScriptDataAttr() const;
+    Vector<unsigned char> GetScriptDataAttr() const;
     /// Get script network serialization attribute by calling a script function.
-    PODVector<unsigned char> GetScriptNetworkDataAttr() const;
+    Vector<unsigned char> GetScriptNetworkDataAttr() const;
     /// Return script object's funcition.
     LuaFunction* GetScriptObjectFunction(const String& functionName) const;
 

--- a/Source/Urho3D/Math/AreaAllocator.cpp
+++ b/Source/Urho3D/Math/AreaAllocator.cpp
@@ -44,14 +44,14 @@ bool AreaAllocator::Allocate(int width, int height, int& x, int& y)
     if (height < 0)
         height = 0;
 
-    PODVector<IntRect>::Iterator best;
+    Vector<IntRect>::Iterator best;
     int bestFreeArea;
 
     for (;;)
     {
         best = freeAreas_.End();
         bestFreeArea = M_MAX_INT;
-        for (PODVector<IntRect>::Iterator i = freeAreas_.Begin(); i != freeAreas_.End(); ++i)
+        for (Vector<IntRect>::Iterator i = freeAreas_.Begin(); i != freeAreas_.End(); ++i)
         {
             int freeWidth = i->Width();
             int freeHeight = i->Height();

--- a/Source/Urho3D/Math/AreaAllocator.h
+++ b/Source/Urho3D/Math/AreaAllocator.h
@@ -40,7 +40,7 @@ private:
     void Cleanup();
 
     /// Free rectangles.
-    PODVector<IntRect> freeAreas_;
+    Vector<IntRect> freeAreas_;
     /// Current size.
     IntVector2 size_;
     /// Maximum size it allows to grow. It is zero when it is not allowed to grow.

--- a/Source/Urho3D/Math/BoundingBox.cpp
+++ b/Source/Urho3D/Math/BoundingBox.cpp
@@ -57,7 +57,7 @@ void BoundingBox::Merge(const Polyhedron& poly)
 {
     for (unsigned i = 0; i < poly.faces_.Size(); ++i)
     {
-        const PODVector<Vector3>& face = poly.faces_[i];
+        const Vector<Vector3>& face = poly.faces_[i];
         if (!face.Empty())
             Merge(&face[0], face.Size());
     }

--- a/Source/Urho3D/Math/Polyhedron.cpp
+++ b/Source/Urho3D/Math/Polyhedron.cpp
@@ -48,7 +48,7 @@ void Polyhedron::Define(const Frustum& frustum)
 void Polyhedron::AddFace(const Vector3& v0, const Vector3& v1, const Vector3& v2)
 {
     faces_.Resize(faces_.Size() + 1);
-    PODVector<Vector3>& face = faces_[faces_.Size() - 1];
+    Vector<Vector3>& face = faces_[faces_.Size() - 1];
     face.Resize(3);
     face[0] = v0;
     face[1] = v1;
@@ -58,7 +58,7 @@ void Polyhedron::AddFace(const Vector3& v0, const Vector3& v1, const Vector3& v2
 void Polyhedron::AddFace(const Vector3& v0, const Vector3& v1, const Vector3& v2, const Vector3& v3)
 {
     faces_.Resize(faces_.Size() + 1);
-    PODVector<Vector3>& face = faces_[faces_.Size() - 1];
+    Vector<Vector3>& face = faces_[faces_.Size() - 1];
     face.Resize(4);
     face[0] = v0;
     face[1] = v1;
@@ -66,7 +66,7 @@ void Polyhedron::AddFace(const Vector3& v0, const Vector3& v1, const Vector3& v2
     face[3] = v3;
 }
 
-void Polyhedron::AddFace(const PODVector<Vector3>& face)
+void Polyhedron::AddFace(const Vector<Vector3>& face)
 {
     faces_.Push(face);
 }
@@ -77,7 +77,7 @@ void Polyhedron::Clip(const Plane& plane)
 
     for (unsigned i = 0; i < faces_.Size(); ++i)
     {
-        PODVector<Vector3>& face = faces_[i];
+        Vector<Vector3>& face = faces_[i];
         Vector3 lastVertex;
         float lastDistance = 0.0f;
 
@@ -215,7 +215,7 @@ void Polyhedron::Transform(const Matrix3& transform)
 {
     for (unsigned i = 0; i < faces_.Size(); ++i)
     {
-        PODVector<Vector3>& face = faces_[i];
+        Vector<Vector3>& face = faces_[i];
         for (unsigned j = 0; j < face.Size(); ++j)
             face[j] = transform * face[j];
     }
@@ -225,7 +225,7 @@ void Polyhedron::Transform(const Matrix3x4& transform)
 {
     for (unsigned i = 0; i < faces_.Size(); ++i)
     {
-        PODVector<Vector3>& face = faces_[i];
+        Vector<Vector3>& face = faces_[i];
         for (unsigned j = 0; j < face.Size(); ++j)
             face[j] = transform * face[j];
     }
@@ -238,8 +238,8 @@ Polyhedron Polyhedron::Transformed(const Matrix3& transform) const
 
     for (unsigned i = 0; i < faces_.Size(); ++i)
     {
-        const PODVector<Vector3>& face = faces_[i];
-        PODVector<Vector3>& newFace = ret.faces_[i];
+        const Vector<Vector3>& face = faces_[i];
+        Vector<Vector3>& newFace = ret.faces_[i];
         newFace.Resize(face.Size());
 
         for (unsigned j = 0; j < face.Size(); ++j)
@@ -256,8 +256,8 @@ Polyhedron Polyhedron::Transformed(const Matrix3x4& transform) const
 
     for (unsigned i = 0; i < faces_.Size(); ++i)
     {
-        const PODVector<Vector3>& face = faces_[i];
-        PODVector<Vector3>& newFace = ret.faces_[i];
+        const Vector<Vector3>& face = faces_[i];
+        Vector<Vector3>& newFace = ret.faces_[i];
         newFace.Resize(face.Size());
 
         for (unsigned j = 0; j < face.Size(); ++j)
@@ -269,7 +269,7 @@ Polyhedron Polyhedron::Transformed(const Matrix3x4& transform) const
 
 void Polyhedron::SetFace(unsigned index, const Vector3& v0, const Vector3& v1, const Vector3& v2)
 {
-    PODVector<Vector3>& face = faces_[index];
+    Vector<Vector3>& face = faces_[index];
     face.Resize(3);
     face[0] = v0;
     face[1] = v1;
@@ -278,7 +278,7 @@ void Polyhedron::SetFace(unsigned index, const Vector3& v0, const Vector3& v1, c
 
 void Polyhedron::SetFace(unsigned index, const Vector3& v0, const Vector3& v1, const Vector3& v2, const Vector3& v3)
 {
-    PODVector<Vector3>& face = faces_[index];
+    Vector<Vector3>& face = faces_[index];
     face.Resize(4);
     face[0] = v0;
     face[1] = v1;

--- a/Source/Urho3D/Math/Polyhedron.h
+++ b/Source/Urho3D/Math/Polyhedron.h
@@ -30,7 +30,7 @@ public:
     }
 
     /// Construct from a list of faces.
-    explicit Polyhedron(const Vector<PODVector<Vector3>>& faces) :
+    explicit Polyhedron(const Vector<Vector<Vector3>>& faces) :
         faces_(faces)
     {
     }
@@ -63,7 +63,7 @@ public:
     /// Add a quadrilateral face.
     void AddFace(const Vector3& v0, const Vector3& v1, const Vector3& v2, const Vector3& v3);
     /// Add an arbitrary face.
-    void AddFace(const PODVector<Vector3>& face);
+    void AddFace(const Vector<Vector3>& face);
     /// Clip with a plane.
     void Clip(const Plane& plane);
     /// Clip with a bounding box.
@@ -86,7 +86,7 @@ public:
     bool Empty() const { return faces_.Empty(); }
 
     /// Polygon faces.
-    Vector<PODVector<Vector3>> faces_;
+    Vector<Vector<Vector3>> faces_;
 
 private:
     /// Set a triangle face by index.
@@ -94,9 +94,9 @@ private:
     /// Set a quadrilateral face by index.
     void SetFace(unsigned index, const Vector3& v0, const Vector3& v1, const Vector3& v2, const Vector3& v3);
     /// Internal vector for clipped vertices.
-    PODVector<Vector3> clippedVertices_;
+    Vector<Vector3> clippedVertices_;
     /// Internal vector for the new face being constructed.
-    PODVector<Vector3> outFace_;
+    Vector<Vector3> outFace_;
 };
 
 }

--- a/Source/Urho3D/Math/Sphere.cpp
+++ b/Source/Urho3D/Math/Sphere.cpp
@@ -78,7 +78,7 @@ void Sphere::Merge(const Polyhedron& poly)
 {
     for (unsigned i = 0; i < poly.faces_.Size(); ++i)
     {
-        const PODVector<Vector3>& face = poly.faces_[i];
+        const Vector<Vector3>& face = poly.faces_[i];
         if (!face.Empty())
             Merge(&face[0], face.Size());
     }

--- a/Source/Urho3D/Navigation/CrowdManager.cpp
+++ b/Source/Urho3D/Navigation/CrowdManager.cpp
@@ -171,7 +171,7 @@ void CrowdManager::SetCrowdTarget(const Vector3& position, Node* node)
     if (!crowd_)
         return;
 
-    PODVector<CrowdAgent*> agents = GetAgents(node, false);     // Get all crowd agent components
+    Vector<CrowdAgent*> agents = GetAgents(node, false);     // Get all crowd agent components
     Vector3 moveTarget(position);
     for (unsigned i = 0; i < agents.Size(); ++i)
     {
@@ -199,7 +199,7 @@ void CrowdManager::SetCrowdVelocity(const Vector3& velocity, Node* node)
     if (!crowd_)
         return;
 
-    PODVector<CrowdAgent*> agents = GetAgents(node, true);      // Get only crowd agent components already in the crowd
+    Vector<CrowdAgent*> agents = GetAgents(node, true);      // Get only crowd agent components already in the crowd
     for (unsigned i = 0; i < agents.Size(); ++i)
         agents[i]->SetTargetVelocity(velocity);
 }
@@ -209,7 +209,7 @@ void CrowdManager::ResetCrowdTarget(Node* node)
     if (!crowd_)
         return;
 
-    PODVector<CrowdAgent*> agents = GetAgents(node, true);
+    Vector<CrowdAgent*> agents = GetAgents(node, true);
     for (unsigned i = 0; i < agents.Size(); ++i)
         agents[i]->ResetTarget();
 }
@@ -383,7 +383,7 @@ Vector3 CrowdManager::MoveAlongSurface(const Vector3& start, const Vector3& end,
         end;
 }
 
-void CrowdManager::FindPath(PODVector<Vector3>& dest, const Vector3& start, const Vector3& end, int queryFilterType)
+void CrowdManager::FindPath(Vector<Vector3>& dest, const Vector3& start, const Vector3& end, int queryFilterType)
 {
     if (crowd_ && navigationMesh_)
         navigationMesh_->FindPath(dest, start, end, Vector3(crowd_->getQueryExtents()), crowd_->getFilter(queryFilterType));
@@ -526,15 +526,15 @@ const CrowdObstacleAvoidanceParams& CrowdManager::GetObstacleAvoidanceParams(uns
     return params ? *reinterpret_cast<const CrowdObstacleAvoidanceParams*>(params) : EMPTY_PARAMS;
 }
 
-PODVector<CrowdAgent*> CrowdManager::GetAgents(Node* node, bool inCrowdFilter) const
+Vector<CrowdAgent*> CrowdManager::GetAgents(Node* node, bool inCrowdFilter) const
 {
     if (!node)
         node = GetScene();
-    PODVector<CrowdAgent*> agents;
+    Vector<CrowdAgent*> agents;
     node->GetComponents<CrowdAgent>(agents, true);
     if (inCrowdFilter)
     {
-        PODVector<CrowdAgent*>::Iterator i = agents.Begin();
+        Vector<CrowdAgent*>::Iterator i = agents.Begin();
         while (i != agents.End())
         {
             if ((*i)->IsInCrowd())
@@ -578,7 +578,7 @@ bool CrowdManager::CreateCrowd()
         SetObstacleAvoidanceTypesAttr(obstacleAvoidanceTypeConfiguration);
 
         // Re-add the existing crowd agents
-        PODVector<CrowdAgent*> agents = GetAgents();
+        Vector<CrowdAgent*> agents = GetAgents();
         for (unsigned i = 0; i < agents.Size(); ++i)
         {
             // Keep adding until the crowd cannot take it anymore

--- a/Source/Urho3D/Navigation/CrowdManager.h
+++ b/Source/Urho3D/Navigation/CrowdManager.h
@@ -89,13 +89,13 @@ public:
     void SetObstacleAvoidanceParams(unsigned obstacleAvoidanceType, const CrowdObstacleAvoidanceParams& params);
 
     /// Get all the crowd agent components in the specified node hierarchy. If the node is not specified then use scene node. When inCrowdFilter is set to true then only get agents that are in the crowd.
-    PODVector<CrowdAgent*> GetAgents(Node* node = nullptr, bool inCrowdFilter = true) const;
+    Vector<CrowdAgent*> GetAgents(Node* node = nullptr, bool inCrowdFilter = true) const;
     /// Find the nearest point on the navigation mesh to a given point using the crowd initialized query extent (based on maxAgentRadius) and the specified query filter type.
     Vector3 FindNearestPoint(const Vector3& point, int queryFilterType, dtPolyRef* nearestRef = nullptr);
     /// Try to move along the surface from one point to another using the crowd initialized query extent (based on maxAgentRadius) and the specified query filter type.
     Vector3 MoveAlongSurface(const Vector3& start, const Vector3& end, int queryFilterType, int maxVisited = 3);
     /// Find a path between world space points using the crowd initialized query extent (based on maxAgentRadius) and the specified query filter type. Return non-empty list of points if successful.
-    void FindPath(PODVector<Vector3>& dest, const Vector3& start, const Vector3& end, int queryFilterType);
+    void FindPath(Vector<Vector3>& dest, const Vector3& start, const Vector3& end, int queryFilterType);
     /// Return a random point on the navigation mesh using the crowd initialized query extent (based on maxAgentRadius) and the specified query filter type.
     Vector3 GetRandomPoint(int queryFilterType, dtPolyRef* randomRef = nullptr);
     /// Return a random point on the navigation mesh within a circle using the crowd initialized query extent (based on maxAgentRadius) and the specified query filter type. The circle radius is only a guideline and in practice the returned point may be further away.
@@ -184,7 +184,7 @@ private:
     /// Number of query filter types configured in the crowd. Limit to DT_CROWD_MAX_QUERY_FILTER_TYPE.
     unsigned numQueryFilterTypes_{};
     /// Number of configured area in each filter type. Limit to DT_MAX_AREAS.
-    PODVector<unsigned> numAreas_;
+    Vector<unsigned> numAreas_;
     /// Number of obstacle avoidance types configured in the crowd. Limit to DT_CROWD_MAX_OBSTAVOIDANCE_PARAMS.
     unsigned numObstacleAvoidanceTypes_{};
 };

--- a/Source/Urho3D/Navigation/DynamicNavigationMesh.cpp
+++ b/Source/Urho3D/Navigation/DynamicNavigationMesh.cpp
@@ -73,11 +73,11 @@ struct TileCompressor : public dtTileCacheCompressor
 struct MeshProcess : public dtTileCacheMeshProcess
 {
     DynamicNavigationMesh* owner_;
-    PODVector<Vector3> offMeshVertices_;
-    PODVector<float> offMeshRadii_;
-    PODVector<unsigned short> offMeshFlags_;
-    PODVector<unsigned char> offMeshAreas_;
-    PODVector<unsigned char> offMeshDir_;
+    Vector<Vector3> offMeshVertices_;
+    Vector<float> offMeshRadii_;
+    Vector<unsigned short> offMeshFlags_;
+    Vector<unsigned char> offMeshAreas_;
+    Vector<unsigned char> offMeshDir_;
 
     inline explicit MeshProcess(DynamicNavigationMesh* owner) :
         owner_(owner)
@@ -99,7 +99,7 @@ struct MeshProcess : public dtTileCacheMeshProcess
         rcVcopy(&bounds.max_.x_, params->bmin);
 
         // collect off-mesh connections
-        PODVector<OffMeshConnection*> offMeshConnections = owner_->CollectOffMeshConnections(bounds);
+        Vector<OffMeshConnection*> offMeshConnections = owner_->CollectOffMeshConnections(bounds);
 
         if (offMeshConnections.Size() > 0)
         {
@@ -297,7 +297,7 @@ bool DynamicNavigationMesh::Allocate(const BoundingBox& boundingBox, unsigned ma
     URHO3D_LOGDEBUG("Allocated empty navigation mesh with max " + String(maxTiles) + " tiles");
 
     // Scan for obstacles to insert into us
-    PODVector<Node*> obstacles;
+    Vector<Node*> obstacles;
     GetScene()->GetChildrenWithComponent<Obstacle>(obstacles, true);
     for (unsigned i = 0; i < obstacles.Size(); ++i)
     {
@@ -449,7 +449,7 @@ bool DynamicNavigationMesh::Build()
         }
 
         // Scan for obstacles to insert into us
-        PODVector<Node*> obstacles;
+        Vector<Node*> obstacles;
         GetScene()->GetChildrenWithComponent<Obstacle>(obstacles, true);
         for (unsigned i = 0; i < obstacles.Size(); ++i)
         {
@@ -521,7 +521,7 @@ bool DynamicNavigationMesh::Build(const IntVector2& from, const IntVector2& to)
     return true;
 }
 
-PODVector<unsigned char> DynamicNavigationMesh::GetTileData(const IntVector2& tile) const
+Vector<unsigned char> DynamicNavigationMesh::GetTileData(const IntVector2& tile) const
 {
     VectorBuffer ret;
     WriteTiles(ret, tile.x_, tile.y_);
@@ -535,7 +535,7 @@ bool DynamicNavigationMesh::IsObstacleInTile(Obstacle* obstacle, const IntVector
     return tileBoundingBox.DistanceToPoint(obstaclePosition) < obstacle->GetRadius();
 }
 
-bool DynamicNavigationMesh::AddTile(const PODVector<unsigned char>& tileData)
+bool DynamicNavigationMesh::AddTile(const Vector<unsigned char>& tileData)
 {
     MemoryBuffer buffer(tileData);
     return ReadTiles(buffer, false);
@@ -606,7 +606,7 @@ void DynamicNavigationMesh::DrawDebugGeometry(DebugRenderer* debug, bool depthTe
         // Draw Obstacle components
         if (drawObstacles_)
         {
-            PODVector<Node*> obstacles;
+            Vector<Node*> obstacles;
             scene->GetChildrenWithComponent<Obstacle>(obstacles, true);
             for (unsigned i = 0; i < obstacles.Size(); ++i)
             {
@@ -619,7 +619,7 @@ void DynamicNavigationMesh::DrawDebugGeometry(DebugRenderer* debug, bool depthTe
         // Draw OffMeshConnection components
         if (drawOffMeshConnections_)
         {
-            PODVector<Node*> connections;
+            Vector<Node*> connections;
             scene->GetChildrenWithComponent<OffMeshConnection>(connections, true);
             for (unsigned i = 0; i < connections.Size(); ++i)
             {
@@ -632,7 +632,7 @@ void DynamicNavigationMesh::DrawDebugGeometry(DebugRenderer* debug, bool depthTe
         // Draw NavArea components
         if (drawNavAreas_)
         {
-            PODVector<Node*> areas;
+            Vector<Node*> areas;
             scene->GetChildrenWithComponent<NavArea>(areas, true);
             for (unsigned i = 0; i < areas.Size(); ++i)
             {
@@ -655,7 +655,7 @@ void DynamicNavigationMesh::DrawDebugGeometry(bool depthTest)
     }
 }
 
-void DynamicNavigationMesh::SetNavigationDataAttr(const PODVector<unsigned char>& value)
+void DynamicNavigationMesh::SetNavigationDataAttr(const Vector<unsigned char>& value)
 {
     ReleaseNavigationMesh();
 
@@ -705,7 +705,7 @@ void DynamicNavigationMesh::SetNavigationDataAttr(const PODVector<unsigned char>
     // \todo Shall we send E_NAVIGATION_MESH_REBUILT here?
 }
 
-PODVector<unsigned char> DynamicNavigationMesh::GetNavigationDataAttr() const
+Vector<unsigned char> DynamicNavigationMesh::GetNavigationDataAttr() const
 {
     VectorBuffer ret;
     if (navMesh_ && tileCache_)
@@ -1019,9 +1019,9 @@ unsigned DynamicNavigationMesh::BuildTiles(Vector<NavigationGeometryInfo>& geome
     return numTiles;
 }
 
-PODVector<OffMeshConnection*> DynamicNavigationMesh::CollectOffMeshConnections(const BoundingBox& bounds)
+Vector<OffMeshConnection*> DynamicNavigationMesh::CollectOffMeshConnections(const BoundingBox& bounds)
 {
-    PODVector<OffMeshConnection*> connections;
+    Vector<OffMeshConnection*> connections;
     node_->GetComponents<OffMeshConnection>(connections, true);
     for (unsigned i = 0; i < connections.Size(); ++i)
     {

--- a/Source/Urho3D/Navigation/DynamicNavigationMesh.h
+++ b/Source/Urho3D/Navigation/DynamicNavigationMesh.h
@@ -47,11 +47,11 @@ public:
     /// Rebuild part of the navigation mesh in the rectangular area. Return true if successful.
     bool Build(const IntVector2& from, const IntVector2& to) override;
     /// Return tile data.
-    PODVector<unsigned char> GetTileData(const IntVector2& tile) const override;
+    Vector<unsigned char> GetTileData(const IntVector2& tile) const override;
     /// Return whether the Obstacle is touching the given tile.
     bool IsObstacleInTile(Obstacle* obstacle, const IntVector2& tile) const;
     /// Add tile to navigation mesh.
-    bool AddTile(const PODVector<unsigned char>& tileData) override;
+    bool AddTile(const Vector<unsigned char>& tileData) override;
     /// Remove tile from navigation mesh.
     void RemoveTile(const IntVector2& tile) override;
     /// Remove all tiles from navigation mesh.
@@ -62,9 +62,9 @@ public:
     void DrawDebugGeometry(bool depthTest);
 
     /// Set navigation data attribute.
-    void SetNavigationDataAttr(const PODVector<unsigned char>& value) override;
+    void SetNavigationDataAttr(const Vector<unsigned char>& value) override;
     /// Return navigation data attribute.
-    PODVector<unsigned char> GetNavigationDataAttr() const override;
+    Vector<unsigned char> GetNavigationDataAttr() const override;
 
     /// Set the maximum number of obstacles allowed.
     /// @property
@@ -108,7 +108,7 @@ protected:
     /// Build tiles in the rectangular area. Return number of built tiles.
     unsigned BuildTiles(Vector<NavigationGeometryInfo>& geometryList, const IntVector2& from, const IntVector2& to);
     /// Off-mesh connections to be rebuilt in the mesh processor.
-    PODVector<OffMeshConnection*> CollectOffMeshConnections(const BoundingBox& bounds);
+    Vector<OffMeshConnection*> CollectOffMeshConnections(const BoundingBox& bounds);
     /// Release the navigation mesh, query, and tile cache.
     void ReleaseNavigationMesh() override;
 
@@ -142,7 +142,7 @@ private:
     bool drawObstacles_{};
 
     /// Queue of tiles to be built.
-    PODVector<IntVector2> tileQueue_;
+    Vector<IntVector2> tileQueue_;
 };
 
 }

--- a/Source/Urho3D/Navigation/NavBuildData.h
+++ b/Source/Urho3D/Navigation/NavBuildData.h
@@ -42,19 +42,19 @@ struct URHO3D_API NavBuildData
     /// World-space bounding box of the navigation mesh tile.
     BoundingBox worldBoundingBox_;
     /// Vertices from geometries.
-    PODVector<Vector3> vertices_;
+    Vector<Vector3> vertices_;
     /// Triangle indices from geometries.
-    PODVector<int> indices_;
+    Vector<int> indices_;
     /// Offmesh connection vertices.
-    PODVector<Vector3> offMeshVertices_;
+    Vector<Vector3> offMeshVertices_;
     /// Offmesh connection radii.
-    PODVector<float> offMeshRadii_;
+    Vector<float> offMeshRadii_;
     /// Offmesh connection flags.
-    PODVector<unsigned short> offMeshFlags_;
+    Vector<unsigned short> offMeshFlags_;
     /// Offmesh connection areas.
-    PODVector<unsigned char> offMeshAreas_;
+    Vector<unsigned char> offMeshAreas_;
     /// Offmesh connection direction.
-    PODVector<unsigned char> offMeshDir_;
+    Vector<unsigned char> offMeshDir_;
     /// Recast context.
     rcContext* ctx_;
     /// Recast heightfield.
@@ -62,7 +62,7 @@ struct URHO3D_API NavBuildData
     /// Recast compact heightfield.
     rcCompactHeightfield* compactHeightField_;
     /// Pretransformed navigation areas, no correlation to the geometry above.
-    PODVector<NavAreaStub> navAreas_;
+    Vector<NavAreaStub> navAreas_;
 };
 
 struct SimpleNavBuildData : public NavBuildData

--- a/Source/Urho3D/Navigation/NavigationMesh.cpp
+++ b/Source/Urho3D/Navigation/NavigationMesh.cpp
@@ -132,7 +132,7 @@ void NavigationMesh::RegisterObject(Context* context)
     URHO3D_ACCESSOR_ATTRIBUTE("Detail Sample Max Error", GetDetailSampleMaxError, SetDetailSampleMaxError, float,
         DEFAULT_DETAIL_SAMPLE_MAX_ERROR, AM_DEFAULT);
     URHO3D_ACCESSOR_ATTRIBUTE("Bounding Box Padding", GetPadding, SetPadding, Vector3, Vector3::ONE, AM_DEFAULT);
-    URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Navigation Data", GetNavigationDataAttr, SetNavigationDataAttr, PODVector<unsigned char>,
+    URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Navigation Data", GetNavigationDataAttr, SetNavigationDataAttr, Vector<unsigned char>,
         Variant::emptyBuffer, AM_FILE | AM_NOEDIT);
     URHO3D_ENUM_ACCESSOR_ATTRIBUTE("Partition Type", GetPartitionType, SetPartitionType, NavmeshPartitionType, navmeshPartitionTypeNames,
         NAVMESH_PARTITION_WATERSHED, AM_DEFAULT);
@@ -177,7 +177,7 @@ void NavigationMesh::DrawDebugGeometry(DebugRenderer* debug, bool depthTest)
         // Draw OffMeshConnection components
         if (drawOffMeshConnections_)
         {
-            PODVector<Node*> connections;
+            Vector<Node*> connections;
             scene->GetChildrenWithComponent<OffMeshConnection>(connections, true);
             for (unsigned i = 0; i < connections.Size(); ++i)
             {
@@ -502,14 +502,14 @@ bool NavigationMesh::Build(const IntVector2& from, const IntVector2& to)
     return true;
 }
 
-PODVector<unsigned char> NavigationMesh::GetTileData(const IntVector2& tile) const
+Vector<unsigned char> NavigationMesh::GetTileData(const IntVector2& tile) const
 {
     VectorBuffer ret;
     WriteTile(ret, tile.x_, tile.y_);
     return ret.GetBuffer();
 }
 
-bool NavigationMesh::AddTile(const PODVector<unsigned char>& tileData)
+bool NavigationMesh::AddTile(const Vector<unsigned char>& tileData)
 {
     MemoryBuffer buffer(tileData);
     return ReadTile(buffer, false);
@@ -625,16 +625,16 @@ Vector3 NavigationMesh::MoveAlongSurface(const Vector3& start, const Vector3& en
     Vector3 resultPos;
     int visitedCount = 0;
     maxVisited = Max(maxVisited, 0);
-    PODVector<dtPolyRef> visited((unsigned)maxVisited);
+    Vector<dtPolyRef> visited((unsigned)maxVisited);
     navMeshQuery_->moveAlongSurface(startRef, &localStart.x_, &localEnd.x_, queryFilter, &resultPos.x_, maxVisited ?
         &visited[0] : nullptr, &visitedCount, maxVisited);
     return transform * resultPos;
 }
 
-void NavigationMesh::FindPath(PODVector<Vector3>& dest, const Vector3& start, const Vector3& end, const Vector3& extents,
+void NavigationMesh::FindPath(Vector<Vector3>& dest, const Vector3& start, const Vector3& end, const Vector3& extents,
     const dtQueryFilter* filter)
 {
-    PODVector<NavigationPathPoint> navPathPoints;
+    Vector<NavigationPathPoint> navPathPoints;
     FindPath(navPathPoints, start, end, extents, filter);
 
     dest.Clear();
@@ -642,7 +642,7 @@ void NavigationMesh::FindPath(PODVector<Vector3>& dest, const Vector3& start, co
         dest.Push(navPathPoints[i].position_);
 }
 
-void NavigationMesh::FindPath(PODVector<NavigationPathPoint>& dest, const Vector3& start, const Vector3& end,
+void NavigationMesh::FindPath(Vector<NavigationPathPoint>& dest, const Vector3& start, const Vector3& end,
     const Vector3& extents, const dtQueryFilter* filter)
 {
     URHO3D_PROFILE(FindPath);
@@ -857,7 +857,7 @@ float NavigationMesh::GetAreaCost(unsigned areaID) const
     return 1.0f;
 }
 
-void NavigationMesh::SetNavigationDataAttr(const PODVector<unsigned char>& value)
+void NavigationMesh::SetNavigationDataAttr(const Vector<unsigned char>& value)
 {
     ReleaseNavigationMesh();
 
@@ -905,7 +905,7 @@ void NavigationMesh::SetNavigationDataAttr(const PODVector<unsigned char>& value
     // \todo Shall we send E_NAVIGATION_MESH_REBUILT here?
 }
 
-PODVector<unsigned char> NavigationMesh::GetNavigationDataAttr() const
+Vector<unsigned char> NavigationMesh::GetNavigationDataAttr() const
 {
     VectorBuffer ret;
 
@@ -937,7 +937,7 @@ void NavigationMesh::CollectGeometries(Vector<NavigationGeometryInfo>& geometryL
 
     // Get Navigable components from child nodes, not from whole scene. This makes it possible to partition
     // the scene into several navigation meshes
-    PODVector<Navigable*> navigables;
+    Vector<Navigable*> navigables;
     node_->GetComponents<Navigable>(navigables, true);
 
     HashSet<Node*> processedNodes;
@@ -949,7 +949,7 @@ void NavigationMesh::CollectGeometries(Vector<NavigationGeometryInfo>& geometryL
 
     // Get offmesh connections
     Matrix3x4 inverse = node_->GetWorldTransform().Inverse();
-    PODVector<OffMeshConnection*> connections;
+    Vector<OffMeshConnection*> connections;
     node_->GetComponents<OffMeshConnection>(connections, true);
 
     for (unsigned i = 0; i < connections.Size(); ++i)
@@ -968,7 +968,7 @@ void NavigationMesh::CollectGeometries(Vector<NavigationGeometryInfo>& geometryL
     }
 
     // Get nav area volumes
-    PODVector<NavArea*> navAreas;
+    Vector<NavArea*> navAreas;
     node_->GetComponents<NavArea>(navAreas, true);
     areas_.Clear();
     for (unsigned i = 0; i < navAreas.Size(); ++i)
@@ -1001,7 +1001,7 @@ void NavigationMesh::CollectGeometries(Vector<NavigationGeometryInfo>& geometryL
 #ifdef URHO3D_PHYSICS
     // Prefer compatible physics collision shapes (triangle mesh, convex hull, box) if found.
     // Then fallback to visible geometry
-    PODVector<CollisionShape*> collisionShapes;
+    Vector<CollisionShape*> collisionShapes;
     node->GetComponents<CollisionShape>(collisionShapes);
     bool collisionShapeFound = false;
 
@@ -1028,7 +1028,7 @@ void NavigationMesh::CollectGeometries(Vector<NavigationGeometryInfo>& geometryL
     if (!collisionShapeFound)
 #endif
     {
-        PODVector<Drawable*> drawables;
+        Vector<Drawable*> drawables;
         node->GetDerivedComponents<Drawable>(drawables);
 
         for (unsigned i = 0; i < drawables.Size(); ++i)
@@ -1184,7 +1184,7 @@ void NavigationMesh::AddTriMeshGeometry(NavBuildData* build, Geometry* geometry,
     const unsigned char* indexData;
     unsigned vertexSize;
     unsigned indexSize;
-    const PODVector<VertexElement>* elements;
+    const Vector<VertexElement>* elements;
 
     geometry->GetRawData(vertexData, vertexSize, indexData, indexSize, elements);
     if (!vertexData || !indexData || !elements || VertexBuffer::GetElementOffset(*elements, TYPE_VECTOR3, SEM_POSITION) != 0)

--- a/Source/Urho3D/Navigation/NavigationMesh.h
+++ b/Source/Urho3D/Navigation/NavigationMesh.h
@@ -143,9 +143,9 @@ public:
     /// Rebuild part of the navigation mesh in the rectangular area. Return true if successful.
     virtual bool Build(const IntVector2& from, const IntVector2& to);
     /// Return tile data.
-    virtual PODVector<unsigned char> GetTileData(const IntVector2& tile) const;
+    virtual Vector<unsigned char> GetTileData(const IntVector2& tile) const;
     /// Add tile to navigation mesh.
-    virtual bool AddTile(const PODVector<unsigned char>& tileData);
+    virtual bool AddTile(const Vector<unsigned char>& tileData);
     /// Remove tile from navigation mesh.
     virtual void RemoveTile(const IntVector2& tile);
     /// Remove all tiles from navigation mesh.
@@ -163,11 +163,11 @@ public:
     Vector3 MoveAlongSurface(const Vector3& start, const Vector3& end, const Vector3& extents = Vector3::ONE, int maxVisited = 3,
         const dtQueryFilter* filter = nullptr);
     /// Find a path between world space points. Return non-empty list of points if successful. Extents specifies how far off the navigation mesh the points can be.
-    void FindPath(PODVector<Vector3>& dest, const Vector3& start, const Vector3& end, const Vector3& extents = Vector3::ONE,
+    void FindPath(Vector<Vector3>& dest, const Vector3& start, const Vector3& end, const Vector3& extents = Vector3::ONE,
         const dtQueryFilter* filter = nullptr);
     /// Find a path between world space points. Return non-empty list of navigation path points if successful. Extents specifies how far off the navigation mesh the points can be.
     void FindPath
-        (PODVector<NavigationPathPoint>& dest, const Vector3& start, const Vector3& end, const Vector3& extents = Vector3::ONE,
+        (Vector<NavigationPathPoint>& dest, const Vector3& start, const Vector3& end, const Vector3& extents = Vector3::ONE,
             const dtQueryFilter* filter = nullptr);
     /// Return a random point on the navigation mesh.
     Vector3 GetRandomPoint(const dtQueryFilter* filter = nullptr, dtPolyRef* randomRef = nullptr);
@@ -276,9 +276,9 @@ public:
     NavmeshPartitionType GetPartitionType() const { return partitionType_; }
 
     /// Set navigation data attribute.
-    virtual void SetNavigationDataAttr(const PODVector<unsigned char>& value);
+    virtual void SetNavigationDataAttr(const Vector<unsigned char>& value);
     /// Return navigation data attribute.
-    virtual PODVector<unsigned char> GetNavigationDataAttr() const;
+    virtual Vector<unsigned char> GetNavigationDataAttr() const;
 
     /// Draw debug geometry for OffMeshConnection components.
     /// @property

--- a/Source/Urho3D/Network/Connection.cpp
+++ b/Source/Urho3D/Network/Connection.cpp
@@ -395,9 +395,9 @@ void Connection::ProcessPendingLatestData()
         return;
 
     // Iterate through pending node data and see if we can find the nodes now
-    for (HashMap<unsigned, PODVector<unsigned char>>::Iterator i = nodeLatestData_.Begin(); i != nodeLatestData_.End();)
+    for (HashMap<unsigned, Vector<unsigned char>>::Iterator i = nodeLatestData_.Begin(); i != nodeLatestData_.End();)
     {
-        HashMap<unsigned, PODVector<unsigned char>>::Iterator current = i++;
+        HashMap<unsigned, Vector<unsigned char>>::Iterator current = i++;
         Node* node = scene_->GetNode(current->first_);
         if (node)
         {
@@ -411,9 +411,9 @@ void Connection::ProcessPendingLatestData()
     }
 
     // Iterate through pending component data and see if we can find the components now
-    for (HashMap<unsigned, PODVector<unsigned char>>::Iterator i = componentLatestData_.Begin(); i != componentLatestData_.End();)
+    for (HashMap<unsigned, Vector<unsigned char>>::Iterator i = componentLatestData_.Begin(); i != componentLatestData_.End();)
     {
-        HashMap<unsigned, PODVector<unsigned char>>::Iterator current = i++;
+        HashMap<unsigned, Vector<unsigned char>>::Iterator current = i++;
         Component* component = scene_->GetComponent(current->first_);
         if (component)
         {
@@ -676,7 +676,7 @@ void Connection::ProcessSceneUpdate(int msgID, MemoryBuffer& msg)
             else
             {
                 // Latest data messages may be received out-of-order relative to node creation, so cache if necessary
-                PODVector<unsigned char>& data = nodeLatestData_[nodeID];
+                Vector<unsigned char>& data = nodeLatestData_[nodeID];
                 data.Resize(msg.GetSize());
                 memcpy(&data[0], msg.GetData(), msg.GetSize());
             }
@@ -753,7 +753,7 @@ void Connection::ProcessSceneUpdate(int msgID, MemoryBuffer& msg)
             else
             {
                 // Latest data messages may be received out-of-order relative to component creation, so cache if necessary
-                PODVector<unsigned char>& data = componentLatestData_[componentID];
+                Vector<unsigned char>& data = componentLatestData_[componentID];
                 data.Resize(msg.GetSize());
                 memcpy(&data[0], msg.GetData(), msg.GetSize());
             }
@@ -1220,8 +1220,8 @@ void Connection::ProcessNode(unsigned nodeID)
 void Connection::ProcessNewNode(Node* node)
 {
     // Process depended upon nodes first, if they are dirty
-    const PODVector<Node*>& dependencyNodes = node->GetDependencyNodes();
-    for (PODVector<Node*>::ConstIterator i = dependencyNodes.Begin(); i != dependencyNodes.End(); ++i)
+    const Vector<Node*>& dependencyNodes = node->GetDependencyNodes();
+    for (Vector<Node*>::ConstIterator i = dependencyNodes.Begin(); i != dependencyNodes.End(); ++i)
     {
         unsigned nodeID = (*i)->GetID();
         if (sceneState_.dirtyNodes_.Contains(nodeID))
@@ -1279,8 +1279,8 @@ void Connection::ProcessNewNode(Node* node)
 void Connection::ProcessExistingNode(Node* node, NodeReplicationState& nodeState)
 {
     // Process depended upon nodes first, if they are dirty
-    const PODVector<Node*>& dependencyNodes = node->GetDependencyNodes();
-    for (PODVector<Node*>::ConstIterator i = dependencyNodes.Begin(); i != dependencyNodes.End(); ++i)
+    const Vector<Node*>& dependencyNodes = node->GetDependencyNodes();
+    for (Vector<Node*>::ConstIterator i = dependencyNodes.Begin(); i != dependencyNodes.End(); ++i)
     {
         unsigned nodeID = (*i)->GetID();
         if (sceneState_.dirtyNodes_.Contains(nodeID))

--- a/Source/Urho3D/Network/Connection.h
+++ b/Source/Urho3D/Network/Connection.h
@@ -308,9 +308,9 @@ private:
     /// Ongoing package send transfers.
     HashMap<StringHash, PackageUpload> uploads_;
     /// Pending latest data for not yet received nodes.
-    HashMap<unsigned, PODVector<unsigned char>> nodeLatestData_;
+    HashMap<unsigned, Vector<unsigned char>> nodeLatestData_;
     /// Pending latest data for not yet received components.
-    HashMap<unsigned, PODVector<unsigned char>> componentLatestData_;
+    HashMap<unsigned, Vector<unsigned char>> componentLatestData_;
     /// Node ID's to process during a replication update.
     HashSet<unsigned> nodesToProcess_;
     /// Reusable message buffer.

--- a/Source/Urho3D/Physics/CollisionShape.cpp
+++ b/Source/Urho3D/Physics/CollisionShape.cpp
@@ -88,7 +88,7 @@ public:
             SharedArrayPtr<unsigned char> indexData;
             unsigned vertexSize;
             unsigned indexSize;
-            const PODVector<VertexElement>* elements;
+            const Vector<VertexElement>* elements;
 
             geometry->GetRawDataShared(vertexData, vertexSize, indexData, indexSize, elements);
             if (!vertexData || !indexData || !elements || VertexBuffer::GetElementOffset(*elements, TYPE_VECTOR3, SEM_POSITION) != 0)
@@ -126,7 +126,7 @@ public:
     explicit TriangleMeshInterface(CustomGeometry* custom) :
         btTriangleIndexVertexArray()
     {
-        const Vector<PODVector<CustomGeometryVertex>>& srcVertices = custom->GetVertices();
+        const Vector<Vector<CustomGeometryVertex>>& srcVertices = custom->GetVertices();
         unsigned totalVertexCount = 0;
         unsigned totalTriangles = 0;
 
@@ -209,7 +209,7 @@ GImpactMeshData::GImpactMeshData(CustomGeometry* custom)
 
 ConvexData::ConvexData(Model* model, unsigned lodLevel)
 {
-    PODVector<Vector3> vertices;
+    Vector<Vector3> vertices;
     unsigned numGeometries = model->GetNumGeometries();
 
     for (unsigned i = 0; i < numGeometries; ++i)
@@ -225,7 +225,7 @@ ConvexData::ConvexData(Model* model, unsigned lodLevel)
         const unsigned char* indexData;
         unsigned vertexSize;
         unsigned indexSize;
-        const PODVector<VertexElement>* elements;
+        const Vector<VertexElement>* elements;
 
         geometry->GetRawData(vertexData, vertexSize, indexData, indexSize, elements);
         if (!vertexData || VertexBuffer::GetElementOffset(*elements, TYPE_VECTOR3, SEM_POSITION) != 0)
@@ -250,8 +250,8 @@ ConvexData::ConvexData(Model* model, unsigned lodLevel)
 
 ConvexData::ConvexData(CustomGeometry* custom)
 {
-    const Vector<PODVector<CustomGeometryVertex>>& srcVertices = custom->GetVertices();
-    PODVector<Vector3> vertices;
+    const Vector<Vector<CustomGeometryVertex>>& srcVertices = custom->GetVertices();
+    Vector<Vector3> vertices;
 
     for (unsigned i = 0; i < srcVertices.Size(); ++i)
     {
@@ -262,7 +262,7 @@ ConvexData::ConvexData(CustomGeometry* custom)
     BuildHull(vertices);
 }
 
-void ConvexData::BuildHull(const PODVector<Vector3>& vertices)
+void ConvexData::BuildHull(const Vector<Vector3>& vertices)
 {
     if (vertices.Size())
     {

--- a/Source/Urho3D/Physics/CollisionShape.h
+++ b/Source/Urho3D/Physics/CollisionShape.h
@@ -94,7 +94,7 @@ struct ConvexData : public CollisionGeometryData
     explicit ConvexData(CustomGeometry* custom);
 
     /// Build the convex hull from vertices.
-    void BuildHull(const PODVector<Vector3>& vertices);
+    void BuildHull(const Vector<Vector3>& vertices);
 
     /// Vertex data.
     SharedArrayPtr<Vector3> vertexData_;

--- a/Source/Urho3D/Physics/Constraint.cpp
+++ b/Source/Urho3D/Physics/Constraint.cpp
@@ -112,7 +112,7 @@ void Constraint::OnSetEnabled()
         constraint_->setEnabled(IsEnabledEffective());
 }
 
-void Constraint::GetDependencyNodes(PODVector<Node*>& dest)
+void Constraint::GetDependencyNodes(Vector<Node*>& dest)
 {
     if (otherBody_ && otherBody_->GetNode())
         dest.Push(otherBody_->GetNode());

--- a/Source/Urho3D/Physics/Constraint.h
+++ b/Source/Urho3D/Physics/Constraint.h
@@ -48,7 +48,7 @@ public:
     /// Handle enabled/disabled state change.
     void OnSetEnabled() override;
     /// Return the depended on nodes to order network updates.
-    void GetDependencyNodes(PODVector<Node*>& dest) override;
+    void GetDependencyNodes(Vector<Node*>& dest) override;
     /// Visualize the component as debug geometry.
     void DrawDebugGeometry(DebugRenderer* debug, bool depthTest) override;
 

--- a/Source/Urho3D/Physics/PhysicsWorld.cpp
+++ b/Source/Urho3D/Physics/PhysicsWorld.cpp
@@ -102,7 +102,7 @@ void CleanupGeometryCacheImpl(CollisionGeometryDataCache& cache)
 struct PhysicsQueryCallback : public btCollisionWorld::ContactResultCallback
 {
     /// Construct.
-    PhysicsQueryCallback(PODVector<RigidBody*>& result, unsigned collisionMask) :
+    PhysicsQueryCallback(Vector<RigidBody*>& result, unsigned collisionMask) :
         result_(result),
         collisionMask_(collisionMask)
     {
@@ -122,7 +122,7 @@ struct PhysicsQueryCallback : public btCollisionWorld::ContactResultCallback
     }
 
     /// Found rigid bodies.
-    PODVector<RigidBody*>& result_;
+    Vector<RigidBody*>& result_;
     /// Collision mask for the query.
     unsigned collisionMask_;
 };
@@ -160,13 +160,13 @@ PhysicsWorld::~PhysicsWorld()
     if (scene_)
     {
         // Force all remaining constraints, rigid bodies and collision shapes to release themselves
-        for (PODVector<Constraint*>::Iterator i = constraints_.Begin(); i != constraints_.End(); ++i)
+        for (Vector<Constraint*>::Iterator i = constraints_.Begin(); i != constraints_.End(); ++i)
             (*i)->ReleaseConstraint();
 
-        for (PODVector<RigidBody*>::Iterator i = rigidBodies_.Begin(); i != rigidBodies_.End(); ++i)
+        for (Vector<RigidBody*>::Iterator i = rigidBodies_.Begin(); i != rigidBodies_.End(); ++i)
             (*i)->ReleaseBody();
 
-        for (PODVector<CollisionShape*>::Iterator i = collisionShapes_.Begin(); i != collisionShapes_.End(); ++i)
+        for (Vector<CollisionShape*>::Iterator i = collisionShapes_.Begin(); i != collisionShapes_.End(); ++i)
             (*i)->ReleaseShape();
     }
 
@@ -352,7 +352,7 @@ void PhysicsWorld::SetMaxNetworkAngularVelocity(float velocity)
     MarkNetworkUpdate();
 }
 
-void PhysicsWorld::Raycast(PODVector<PhysicsRaycastResult>& result, const Ray& ray, float maxDistance, unsigned collisionMask)
+void PhysicsWorld::Raycast(Vector<PhysicsRaycastResult>& result, const Ray& ray, float maxDistance, unsigned collisionMask)
 {
     URHO3D_PROFILE(PhysicsRaycast);
 
@@ -601,7 +601,7 @@ void PhysicsWorld::RemoveCachedGeometry(Model* model)
     RemoveCachedGeometryImpl(gimpactTrimeshCache_, model);
 }
 
-void PhysicsWorld::GetRigidBodies(PODVector<RigidBody*>& result, const Sphere& sphere, unsigned collisionMask)
+void PhysicsWorld::GetRigidBodies(Vector<RigidBody*>& result, const Sphere& sphere, unsigned collisionMask)
 {
     URHO3D_PROFILE(PhysicsSphereQuery);
 
@@ -620,7 +620,7 @@ void PhysicsWorld::GetRigidBodies(PODVector<RigidBody*>& result, const Sphere& s
     world_->removeRigidBody(tempRigidBody.get());
 }
 
-void PhysicsWorld::GetRigidBodies(PODVector<RigidBody*>& result, const BoundingBox& box, unsigned collisionMask)
+void PhysicsWorld::GetRigidBodies(Vector<RigidBody*>& result, const BoundingBox& box, unsigned collisionMask)
 {
     URHO3D_PROFILE(PhysicsBoxQuery);
 
@@ -638,7 +638,7 @@ void PhysicsWorld::GetRigidBodies(PODVector<RigidBody*>& result, const BoundingB
     world_->removeRigidBody(tempRigidBody.get());
 }
 
-void PhysicsWorld::GetRigidBodies(PODVector<RigidBody*>& result, const RigidBody* body)
+void PhysicsWorld::GetRigidBodies(Vector<RigidBody*>& result, const RigidBody* body)
 {
     URHO3D_PROFILE(PhysicsBodyQuery);
 
@@ -661,7 +661,7 @@ void PhysicsWorld::GetRigidBodies(PODVector<RigidBody*>& result, const RigidBody
     }
 }
 
-void PhysicsWorld::GetCollidingBodies(PODVector<RigidBody*>& result, const RigidBody* body)
+void PhysicsWorld::GetCollidingBodies(Vector<RigidBody*>& result, const RigidBody* body)
 {
     URHO3D_PROFILE(GetCollidingBodies);
 

--- a/Source/Urho3D/Physics/PhysicsWorld.h
+++ b/Source/Urho3D/Physics/PhysicsWorld.h
@@ -177,7 +177,7 @@ public:
     void SetMaxNetworkAngularVelocity(float velocity);
     /// Perform a physics world raycast and return all hits.
     void Raycast
-        (PODVector<PhysicsRaycastResult>& result, const Ray& ray, float maxDistance, unsigned collisionMask = M_MAX_UNSIGNED);
+        (Vector<PhysicsRaycastResult>& result, const Ray& ray, float maxDistance, unsigned collisionMask = M_MAX_UNSIGNED);
     /// Perform a physics world raycast and return the closest hit.
     void RaycastSingle(PhysicsRaycastResult& result, const Ray& ray, float maxDistance, unsigned collisionMask = M_MAX_UNSIGNED);
     /// Perform a physics world segmented raycast and return the closest hit. Useful for big scenes with many bodies.
@@ -195,13 +195,13 @@ public:
     /// Invalidate cached collision geometry for a model.
     void RemoveCachedGeometry(Model* model);
     /// Return rigid bodies by a sphere query.
-    void GetRigidBodies(PODVector<RigidBody*>& result, const Sphere& sphere, unsigned collisionMask = M_MAX_UNSIGNED);
+    void GetRigidBodies(Vector<RigidBody*>& result, const Sphere& sphere, unsigned collisionMask = M_MAX_UNSIGNED);
     /// Return rigid bodies by a box query.
-    void GetRigidBodies(PODVector<RigidBody*>& result, const BoundingBox& box, unsigned collisionMask = M_MAX_UNSIGNED);
+    void GetRigidBodies(Vector<RigidBody*>& result, const BoundingBox& box, unsigned collisionMask = M_MAX_UNSIGNED);
     /// Return rigid bodies by contact test with the specified body. It needs to be active to return all contacts reliably.
-    void GetRigidBodies(PODVector<RigidBody*>& result, const RigidBody* body);
+    void GetRigidBodies(Vector<RigidBody*>& result, const RigidBody* body);
     /// Return rigid bodies that have been in collision with the specified body on the last simulation step. Only returns collisions that were sent as events (depends on collision event mode) and excludes e.g. static-static collisions.
-    void GetCollidingBodies(PODVector<RigidBody*>& result, const RigidBody* body);
+    void GetCollidingBodies(Vector<RigidBody*>& result, const RigidBody* body);
 
     /// Return gravity.
     /// @property
@@ -318,11 +318,11 @@ private:
     /// Extra weak pointer to scene to allow for cleanup in case the world is destroyed before other components.
     WeakPtr<Scene> scene_;
     /// Rigid bodies in the world.
-    PODVector<RigidBody*> rigidBodies_;
+    Vector<RigidBody*> rigidBodies_;
     /// Collision shapes in the world.
-    PODVector<CollisionShape*> collisionShapes_;
+    Vector<CollisionShape*> collisionShapes_;
     /// Constraints in the world.
-    PODVector<Constraint*> constraints_;
+    Vector<Constraint*> constraints_;
     /// Collision pairs on this frame.
     HashMap<Pair<WeakPtr<RigidBody>, WeakPtr<RigidBody>>, ManifoldPair> currentCollisions_;
     /// Collision pairs on the previous frame. Used to check if a collision is "new". Manifolds are not guaranteed to exist anymore.

--- a/Source/Urho3D/Physics/RigidBody.cpp
+++ b/Source/Urho3D/Physics/RigidBody.cpp
@@ -102,7 +102,7 @@ void RigidBody::RegisterObject(Context* context)
         AM_DEFAULT);
     URHO3D_ACCESSOR_ATTRIBUTE("CCD Radius", GetCcdRadius, SetCcdRadius, float, 0.0f, AM_DEFAULT);
     URHO3D_ACCESSOR_ATTRIBUTE("CCD Motion Threshold", GetCcdMotionThreshold, SetCcdMotionThreshold, float, 0.0f, AM_DEFAULT);
-    URHO3D_ACCESSOR_ATTRIBUTE("Network Angular Velocity", GetNetAngularVelocityAttr, SetNetAngularVelocityAttr, PODVector<unsigned char>,
+    URHO3D_ACCESSOR_ATTRIBUTE("Network Angular Velocity", GetNetAngularVelocityAttr, SetNetAngularVelocityAttr, Vector<unsigned char>,
         Variant::emptyBuffer, AM_NET | AM_LATESTDATA | AM_NOEDIT);
     URHO3D_ENUM_ATTRIBUTE_EX("Collision Event Mode", collisionEventMode_, MarkBodyDirty, collisionEventModeNames, COLLISION_ACTIVE, AM_DEFAULT);
     URHO3D_ACCESSOR_ATTRIBUTE("Use Gravity", GetUseGravity, SetUseGravity, bool, true, AM_DEFAULT);
@@ -683,7 +683,7 @@ bool RigidBody::IsActive() const
     return body_ ? body_->isActive() : false;
 }
 
-void RigidBody::GetCollidingBodies(PODVector<RigidBody*>& result) const
+void RigidBody::GetCollidingBodies(Vector<RigidBody*>& result) const
 {
     if (physicsWorld_)
         physicsWorld_->GetCollidingBodies(result, this);
@@ -732,7 +732,7 @@ void RigidBody::UpdateMass()
     auto numShapes = (unsigned)compoundShape_->getNumChildShapes();
     if (numShapes)
     {
-        PODVector<float> masses(numShapes);
+        Vector<float> masses(numShapes);
         for (unsigned i = 0; i < numShapes; ++i)
         {
             // The actual mass does not matter, divide evenly between child shapes
@@ -789,7 +789,7 @@ void RigidBody::UpdateMass()
     // Reapply constraint positions for new center of mass shift
     if (node_)
     {
-        for (PODVector<Constraint*>::Iterator i = constraints_.Begin(); i != constraints_.End(); ++i)
+        for (Vector<Constraint*>::Iterator i = constraints_.Begin(); i != constraints_.End(); ++i)
             (*i)->ApplyFrames();
     }
 
@@ -828,14 +828,14 @@ void RigidBody::UpdateGravity()
     }
 }
 
-void RigidBody::SetNetAngularVelocityAttr(const PODVector<unsigned char>& value)
+void RigidBody::SetNetAngularVelocityAttr(const Vector<unsigned char>& value)
 {
     float maxVelocity = physicsWorld_ ? physicsWorld_->GetMaxNetworkAngularVelocity() : DEFAULT_MAX_NETWORK_ANGULAR_VELOCITY;
     MemoryBuffer buf(value);
     SetAngularVelocity(buf.ReadPackedVector3(maxVelocity));
 }
 
-const PODVector<unsigned char>& RigidBody::GetNetAngularVelocityAttr() const
+const Vector<unsigned char>& RigidBody::GetNetAngularVelocityAttr() const
 {
     float maxVelocity = physicsWorld_ ? physicsWorld_->GetMaxNetworkAngularVelocity() : DEFAULT_MAX_NETWORK_ANGULAR_VELOCITY;
     attrBuffer_.Clear();
@@ -861,8 +861,8 @@ void RigidBody::ReleaseBody()
     {
         // Release all constraints which refer to this body
         // Make a copy for iteration
-        PODVector<Constraint*> constraints = constraints_;
-        for (PODVector<Constraint*>::Iterator i = constraints.Begin(); i != constraints.End(); ++i)
+        Vector<Constraint*> constraints = constraints_;
+        for (Vector<Constraint*>::Iterator i = constraints.Begin(); i != constraints.End(); ++i)
             (*i)->ReleaseConstraint();
 
         RemoveBodyFromWorld();
@@ -962,16 +962,16 @@ void RigidBody::AddBodyToWorld()
 
         // Check if CollisionShapes already exist in the node and add them to the compound shape.
         // Do not update mass yet, but do it once all shapes have been added
-        PODVector<CollisionShape*> shapes;
+        Vector<CollisionShape*> shapes;
         node_->GetComponents<CollisionShape>(shapes);
-        for (PODVector<CollisionShape*>::Iterator i = shapes.Begin(); i != shapes.End(); ++i)
+        for (Vector<CollisionShape*>::Iterator i = shapes.Begin(); i != shapes.End(); ++i)
             (*i)->NotifyRigidBody(false);
 
         // Check if this node contains Constraint components that were waiting for the rigid body to be created, and signal them
         // to create themselves now
-        PODVector<Constraint*> constraints;
+        Vector<Constraint*> constraints;
         node_->GetComponents<Constraint>(constraints);
-        for (PODVector<Constraint*>::Iterator i = constraints.Begin(); i != constraints.End(); ++i)
+        for (Vector<Constraint*>::Iterator i = constraints.Begin(); i != constraints.End(); ++i)
             (*i)->CreateConstraint();
     }
 

--- a/Source/Urho3D/Physics/RigidBody.h
+++ b/Source/Urho3D/Physics/RigidBody.h
@@ -264,7 +264,7 @@ public:
     CollisionEventMode GetCollisionEventMode() const { return collisionEventMode_; }
 
     /// Return colliding rigid bodies from the last simulation step. Only returns collisions that were sent as events (depends on collision event mode) and excludes e.g. static-static collisions.
-    void GetCollidingBodies(PODVector<RigidBody*>& result) const;
+    void GetCollidingBodies(Vector<RigidBody*>& result) const;
 
     /// Apply new world transform after a simulation step. Called internally.
     void ApplyWorldTransform(const Vector3& newWorldPosition, const Quaternion& newWorldRotation);
@@ -273,9 +273,9 @@ public:
     /// Update gravity parameters to the Bullet rigid body.
     void UpdateGravity();
     /// Set network angular velocity attribute.
-    void SetNetAngularVelocityAttr(const PODVector<unsigned char>& value);
+    void SetNetAngularVelocityAttr(const Vector<unsigned char>& value);
     /// Return network angular velocity attribute.
-    const PODVector<unsigned char>& GetNetAngularVelocityAttr() const;
+    const Vector<unsigned char>& GetNetAngularVelocityAttr() const;
     /// Add a constraint that refers to this rigid body.
     void AddConstraint(Constraint* constraint);
     /// Remove a constraint that refers to this rigid body.
@@ -317,7 +317,7 @@ private:
     /// Smoothed transform, if has one.
     WeakPtr<SmoothedTransform> smoothedTransform_;
     /// Constraints that refer to this rigid body.
-    PODVector<Constraint*> constraints_;
+    Vector<Constraint*> constraints_;
     /// Gravity override vector.
     Vector3 gravityOverride_;
     /// Center of mass offset.

--- a/Source/Urho3D/Physics2D/CollisionChain2D.cpp
+++ b/Source/Urho3D/Physics2D/CollisionChain2D.cpp
@@ -32,7 +32,7 @@ void CollisionChain2D::RegisterObject(Context* context)
     URHO3D_ACCESSOR_ATTRIBUTE("Is Enabled", IsEnabled, SetEnabled, bool, true, AM_DEFAULT);
     URHO3D_ACCESSOR_ATTRIBUTE("Loop", GetLoop, SetLoop, bool, false, AM_DEFAULT);
     URHO3D_COPY_BASE_ATTRIBUTES(CollisionShape2D);
-    URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Vertices", GetVerticesAttr, SetVerticesAttr, PODVector<unsigned char>, Variant::emptyBuffer, AM_FILE);
+    URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Vertices", GetVerticesAttr, SetVerticesAttr, Vector<unsigned char>, Variant::emptyBuffer, AM_FILE);
 }
 
 void CollisionChain2D::SetLoop(bool loop)
@@ -65,7 +65,7 @@ void CollisionChain2D::SetVertex(unsigned index, const Vector2& vertex)
     }
 }
 
-void CollisionChain2D::SetVertices(const PODVector<Vector2>& vertices)
+void CollisionChain2D::SetVertices(const Vector<Vector2>& vertices)
 {
     vertices_ = vertices;
 
@@ -73,12 +73,12 @@ void CollisionChain2D::SetVertices(const PODVector<Vector2>& vertices)
     RecreateFixture();
 }
 
-void CollisionChain2D::SetVerticesAttr(const PODVector<unsigned char>& value)
+void CollisionChain2D::SetVerticesAttr(const Vector<unsigned char>& value)
 {
     if (value.Empty())
         return;
 
-    PODVector<Vector2> vertices;
+    Vector<Vector2> vertices;
 
     MemoryBuffer buffer(value);
     while (!buffer.IsEof())
@@ -87,7 +87,7 @@ void CollisionChain2D::SetVerticesAttr(const PODVector<unsigned char>& value)
     SetVertices(vertices);
 }
 
-PODVector<unsigned char> CollisionChain2D::GetVerticesAttr() const
+Vector<unsigned char> CollisionChain2D::GetVerticesAttr() const
 {
     VectorBuffer ret;
 
@@ -106,7 +106,7 @@ void CollisionChain2D::RecreateFixture()
 {
     ReleaseFixture();
 
-    PODVector<b2Vec2> b2Vertices;
+    Vector<b2Vec2> b2Vertices;
     unsigned count = vertices_.Size();
     b2Vertices.Resize(count);
 

--- a/Source/Urho3D/Physics2D/CollisionChain2D.h
+++ b/Source/Urho3D/Physics2D/CollisionChain2D.h
@@ -46,16 +46,16 @@ public:
     const Vector2& GetVertex(unsigned index) const { return (index < vertices_.Size()) ? vertices_[index] : Vector2::ZERO; }
 
     /// Set vertices. For non loop first and last must be ghost.
-    void SetVertices(const PODVector<Vector2>& vertices);
+    void SetVertices(const Vector<Vector2>& vertices);
 
     /// Return vertices.
-    const PODVector<Vector2>& GetVertices() const { return vertices_; }
+    const Vector<Vector2>& GetVertices() const { return vertices_; }
 
     /// Set vertices attribute. For non loop first and last must be ghost.
-    void SetVerticesAttr(const PODVector<unsigned char>& value);
+    void SetVerticesAttr(const Vector<unsigned char>& value);
 
     /// Return vertices attribute.
-    PODVector<unsigned char> GetVerticesAttr() const;
+    Vector<unsigned char> GetVerticesAttr() const;
 
 private:
     /// Apply node world scale.
@@ -71,7 +71,7 @@ private:
     bool loop_;
 
     /// Vertices.
-    PODVector<Vector2> vertices_;
+    Vector<Vector2> vertices_;
 };
 
 }

--- a/Source/Urho3D/Physics2D/CollisionPolygon2D.cpp
+++ b/Source/Urho3D/Physics2D/CollisionPolygon2D.cpp
@@ -30,7 +30,7 @@ void CollisionPolygon2D::RegisterObject(Context* context)
 
     URHO3D_ACCESSOR_ATTRIBUTE("Is Enabled", IsEnabled, SetEnabled, bool, true, AM_DEFAULT);
     URHO3D_COPY_BASE_ATTRIBUTES(CollisionShape2D);
-    URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Vertices", GetVerticesAttr, SetVerticesAttr, PODVector<unsigned char>, Variant::emptyBuffer, AM_FILE);
+    URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Vertices", GetVerticesAttr, SetVerticesAttr, Vector<unsigned char>, Variant::emptyBuffer, AM_FILE);
 }
 
 void CollisionPolygon2D::SetVertexCount(unsigned count)
@@ -52,7 +52,7 @@ void CollisionPolygon2D::SetVertex(unsigned index, const Vector2& vertex)
     }
 }
 
-void CollisionPolygon2D::SetVertices(const PODVector<Vector2>& vertices)
+void CollisionPolygon2D::SetVertices(const Vector<Vector2>& vertices)
 {
     vertices_ = vertices;
 
@@ -60,12 +60,12 @@ void CollisionPolygon2D::SetVertices(const PODVector<Vector2>& vertices)
     RecreateFixture();
 }
 
-void CollisionPolygon2D::SetVerticesAttr(const PODVector<unsigned char>& value)
+void CollisionPolygon2D::SetVerticesAttr(const Vector<unsigned char>& value)
 {
     if (value.Empty())
         return;
 
-    PODVector<Vector2> vertices;
+    Vector<Vector2> vertices;
 
     MemoryBuffer buffer(value);
     while (!buffer.IsEof())
@@ -74,7 +74,7 @@ void CollisionPolygon2D::SetVerticesAttr(const PODVector<unsigned char>& value)
     SetVertices(vertices);
 }
 
-PODVector<unsigned char> CollisionPolygon2D::GetVerticesAttr() const
+Vector<unsigned char> CollisionPolygon2D::GetVerticesAttr() const
 {
     VectorBuffer ret;
 
@@ -96,7 +96,7 @@ void CollisionPolygon2D::RecreateFixture()
     if (vertices_.Size() < 3)
         return;
 
-    PODVector<b2Vec2> b2Vertices;
+    Vector<b2Vec2> b2Vertices;
     unsigned count = vertices_.Size();
     b2Vertices.Resize(count);
 

--- a/Source/Urho3D/Physics2D/CollisionPolygon2D.h
+++ b/Source/Urho3D/Physics2D/CollisionPolygon2D.h
@@ -28,7 +28,7 @@ public:
     /// Set vertex.
     void SetVertex(unsigned index, const Vector2& vertex);
     /// Set vertices.
-    void SetVertices(const PODVector<Vector2>& vertices);
+    void SetVertices(const Vector<Vector2>& vertices);
 
     /// Return vertex count.
     /// @property
@@ -38,12 +38,12 @@ public:
     const Vector2& GetVertex(unsigned index) const { return (index < vertices_.Size()) ? vertices_[index] : Vector2::ZERO; }
 
     /// Return vertices.
-    const PODVector<Vector2>& GetVertices() const { return vertices_; }
+    const Vector<Vector2>& GetVertices() const { return vertices_; }
 
     /// Set vertices attribute.
-    void SetVerticesAttr(const PODVector<unsigned char>& value);
+    void SetVerticesAttr(const Vector<unsigned char>& value);
     /// Return vertices attribute.
-    PODVector<unsigned char> GetVerticesAttr() const;
+    Vector<unsigned char> GetVerticesAttr() const;
 
 private:
     /// Apply node world scale.
@@ -54,7 +54,7 @@ private:
     /// Polygon shape.
     b2PolygonShape polygonShape_;
     /// Vertices.
-    PODVector<Vector2> vertices_;
+    Vector<Vector2> vertices_;
 };
 
 }

--- a/Source/Urho3D/Physics2D/PhysicsWorld2D.cpp
+++ b/Source/Urho3D/Physics2D/PhysicsWorld2D.cpp
@@ -441,7 +441,7 @@ class RayCastCallback : public b2RayCastCallback
 {
 public:
     // Construct.
-    RayCastCallback(PODVector<PhysicsRaycastResult2D>& results, const Vector2& startPoint, unsigned collisionMask) :
+    RayCastCallback(Vector<PhysicsRaycastResult2D>& results, const Vector2& startPoint, unsigned collisionMask) :
         results_(results),
         startPoint_(startPoint),
         collisionMask_(collisionMask)
@@ -470,14 +470,14 @@ public:
 
 protected:
     // Physics raycast results.
-    PODVector<PhysicsRaycastResult2D>& results_;
+    Vector<PhysicsRaycastResult2D>& results_;
     // Start point.
     Vector2 startPoint_;
     // Collision mask.
     unsigned collisionMask_;
 };
 
-void PhysicsWorld2D::Raycast(PODVector<PhysicsRaycastResult2D>& results, const Vector2& startPoint, const Vector2& endPoint,
+void PhysicsWorld2D::Raycast(Vector<PhysicsRaycastResult2D>& results, const Vector2& startPoint, const Vector2& endPoint,
     unsigned collisionMask)
 {
     results.Clear();
@@ -621,7 +621,7 @@ class AabbQueryCallback : public b2QueryCallback
 {
 public:
     // Construct.
-    AabbQueryCallback(PODVector<RigidBody2D*>& results, unsigned collisionMask) :
+    AabbQueryCallback(Vector<RigidBody2D*>& results, unsigned collisionMask) :
         results_(results),
         collisionMask_(collisionMask)
     {
@@ -643,12 +643,12 @@ public:
 
 private:
     // Results.
-    PODVector<RigidBody2D*>& results_;
+    Vector<RigidBody2D*>& results_;
     // Collision mask.
     unsigned collisionMask_;
 };
 
-void PhysicsWorld2D::GetRigidBodies(PODVector<RigidBody2D*>& results, const Rect& aabb, unsigned collisionMask)
+void PhysicsWorld2D::GetRigidBodies(Vector<RigidBody2D*>& results, const Rect& aabb, unsigned collisionMask)
 {
     AabbQueryCallback callback(results, collisionMask);
 
@@ -829,7 +829,7 @@ PhysicsWorld2D::ContactInfo::ContactInfo(b2Contact* contact)
     }
 }
 
-const Urho3D::PODVector<unsigned char>& PhysicsWorld2D::ContactInfo::Serialize(VectorBuffer& buffer) const
+const Urho3D::Vector<unsigned char>& PhysicsWorld2D::ContactInfo::Serialize(VectorBuffer& buffer) const
 {
     buffer.Clear();
     for (int i = 0; i < numPoints_; ++i)

--- a/Source/Urho3D/Physics2D/PhysicsWorld2D.h
+++ b/Source/Urho3D/Physics2D/PhysicsWorld2D.h
@@ -144,7 +144,7 @@ public:
     void AddDelayedWorldTransform(const DelayedWorldTransform2D& transform);
 
     /// Perform a physics world raycast and return all hits.
-    void Raycast(PODVector<PhysicsRaycastResult2D>& results, const Vector2& startPoint, const Vector2& endPoint,
+    void Raycast(Vector<PhysicsRaycastResult2D>& results, const Vector2& startPoint, const Vector2& endPoint,
         unsigned collisionMask = M_MAX_UNSIGNED);
     /// Perform a physics world raycast and return the closest hit.
     void RaycastSingle(PhysicsRaycastResult2D& result, const Vector2& startPoint, const Vector2& endPoint,
@@ -154,7 +154,7 @@ public:
     /// Return rigid body at screen point.
     RigidBody2D* GetRigidBody(int screenX, int screenY, unsigned collisionMask = M_MAX_UNSIGNED);
     /// Return rigid bodies by a box query.
-    void GetRigidBodies(PODVector<RigidBody2D*>& results, const Rect& aabb, unsigned collisionMask = M_MAX_UNSIGNED);
+    void GetRigidBodies(Vector<RigidBody2D*>& results, const Rect& aabb, unsigned collisionMask = M_MAX_UNSIGNED);
 
     /// Return whether physics world will automatically simulate during scene update.
     /// @property
@@ -264,7 +264,7 @@ protected:
         /// Construct.
         explicit ContactInfo(b2Contact* contact);
         /// Write contact info to buffer.
-        const PODVector<unsigned char>& Serialize(VectorBuffer& buffer) const;
+        const Vector<unsigned char>& Serialize(VectorBuffer& buffer) const;
 
         /// Rigid body A.
         SharedPtr<RigidBody2D> bodyA_;

--- a/Source/Urho3D/Physics2D/RigidBody2D.cpp
+++ b/Source/Urho3D/Physics2D/RigidBody2D.cpp
@@ -532,10 +532,10 @@ void RigidBody2D::OnNodeSet(Node* node)
     {
         node->AddListener(this);
 
-        PODVector<CollisionShape2D*> shapes;
+        Vector<CollisionShape2D*> shapes;
         node_->GetDerivedComponents<CollisionShape2D>(shapes);
 
-        for (PODVector<CollisionShape2D*>::Iterator i = shapes.Begin(); i != shapes.End(); ++i)
+        for (Vector<CollisionShape2D*>::Iterator i = shapes.Begin(); i != shapes.End(); ++i)
         {
             (*i)->CreateFixture();
             AddCollisionShape2D(*i);

--- a/Source/Urho3D/Resource/Image.cpp
+++ b/Source/Urho3D/Resource/Image.cpp
@@ -1331,7 +1331,7 @@ bool Image::SaveDDS(const String& fileName) const
     }
 
     // Write image
-    PODVector<const Image*> levels;
+    Vector<const Image*> levels;
     GetLevels(levels);
 
     outFile.WriteFileID("DDS ");
@@ -2141,7 +2141,7 @@ Image* Image::GetSubimage(const IntRect& rect) const
         paddedRect.bottom_ = (rect.bottom_ / 4) * 4;
         IntRect currentRect = paddedRect;
 
-        PODVector<unsigned char> subimageData;
+        Vector<unsigned char> subimageData;
         unsigned subimageLevels = 0;
 
         // Save as many mips as possible until the next mip would cross a block boundary
@@ -2293,7 +2293,7 @@ void Image::CleanupLevels()
     nextLevel_.Reset();
 }
 
-void Image::GetLevels(PODVector<Image*>& levels)
+void Image::GetLevels(Vector<Image*>& levels)
 {
     levels.Clear();
 
@@ -2305,7 +2305,7 @@ void Image::GetLevels(PODVector<Image*>& levels)
     }
 }
 
-void Image::GetLevels(PODVector<const Image*>& levels) const
+void Image::GetLevels(Vector<const Image*>& levels) const
 {
     levels.Clear();
 

--- a/Source/Urho3D/Resource/Image.h
+++ b/Source/Urho3D/Resource/Image.h
@@ -195,9 +195,9 @@ public:
     /// Clean up the mip levels.
     void CleanupLevels();
     /// Get all stored mip levels starting from this.
-    void GetLevels(PODVector<Image*>& levels);
+    void GetLevels(Vector<Image*>& levels);
     /// Get all stored mip levels starting from this.
-    void GetLevels(PODVector<const Image*>& levels) const;
+    void GetLevels(Vector<const Image*>& levels) const;
 
 private:
     /// Decode an image using stb_image.

--- a/Source/Urho3D/Resource/ResourceCache.cpp
+++ b/Source/Urho3D/Resource/ResourceCache.cpp
@@ -698,7 +698,7 @@ unsigned ResourceCache::GetNumBackgroundLoadResources() const
 #endif
 }
 
-void ResourceCache::GetResources(PODVector<Resource*>& result, StringHash type) const
+void ResourceCache::GetResources(Vector<Resource*>& result, StringHash type) const
 {
     result.Clear();
     HashMap<StringHash, ResourceGroup>::ConstIterator i = resourceGroups_.Find(type);

--- a/Source/Urho3D/Resource/ResourceCache.h
+++ b/Source/Urho3D/Resource/ResourceCache.h
@@ -134,7 +134,7 @@ public:
     /// @property
     unsigned GetNumBackgroundLoadResources() const;
     /// Return all loaded resources of a specific type.
-    void GetResources(PODVector<Resource*>& result, StringHash type) const;
+    void GetResources(Vector<Resource*>& result, StringHash type) const;
     /// Return an already loaded resource of specific type & name, or null if not found. Will not load if does not exist.
     Resource* GetExistingResource(StringHash type, const String& name);
 
@@ -160,7 +160,7 @@ public:
     /// Template version of queueing a resource background load.
     template <class T> bool BackgroundLoadResource(const String& name, bool sendEventOnFailure = true, Resource* caller = nullptr);
     /// Template version of returning loaded resources of a specific type.
-    template <class T> void GetResources(PODVector<T*>& result) const;
+    template <class T> void GetResources(Vector<T*>& result) const;
     /// Return whether a file exists in the resource directories or package files. Does not check manually added in-memory resources.
     bool Exists(const String& name) const;
     /// Return memory budget for a resource type.
@@ -282,9 +282,9 @@ template <class T> bool ResourceCache::BackgroundLoadResource(const String& name
     return BackgroundLoadResource(type, name, sendEventOnFailure, caller);
 }
 
-template <class T> void ResourceCache::GetResources(PODVector<T*>& result) const
+template <class T> void ResourceCache::GetResources(Vector<T*>& result) const
 {
-    auto& resources = reinterpret_cast<PODVector<Resource*>&>(result);
+    auto& resources = reinterpret_cast<Vector<Resource*>&>(result);
     StringHash type = T::GetTypeStatic();
     GetResources(resources, type);
 

--- a/Source/Urho3D/Resource/XMLElement.cpp
+++ b/Source/Urho3D/Resource/XMLElement.cpp
@@ -319,7 +319,7 @@ bool XMLElement::SetBuffer(const String& name, const void* data, unsigned size)
     return SetAttribute(name, dataStr);
 }
 
-bool XMLElement::SetBuffer(const String& name, const PODVector<unsigned char>& value)
+bool XMLElement::SetBuffer(const String& name, const Vector<unsigned char>& value)
 {
     if (!value.Size())
         return SetAttribute(name, String::EMPTY);
@@ -748,9 +748,9 @@ BoundingBox XMLElement::GetBoundingBox() const
     return ret;
 }
 
-PODVector<unsigned char> XMLElement::GetBuffer(const String& name) const
+Vector<unsigned char> XMLElement::GetBuffer(const String& name) const
 {
-    PODVector<unsigned char> ret;
+    Vector<unsigned char> ret;
     StringToBuffer(ret, GetAttribute(name));
     return ret;
 }

--- a/Source/Urho3D/Resource/XMLElement.h
+++ b/Source/Urho3D/Resource/XMLElement.h
@@ -101,7 +101,7 @@ public:
     /// Set a buffer attribute.
     bool SetBuffer(const String& name, const void* data, unsigned size);
     /// Set a buffer attribute.
-    bool SetBuffer(const String& name, const PODVector<unsigned char>& value);
+    bool SetBuffer(const String& name, const Vector<unsigned char>& value);
     /// Set a color attribute.
     bool SetColor(const String& name, const Color& value);
     /// Set a float attribute.
@@ -212,7 +212,7 @@ public:
     /// Return bool attribute, or false if missing.
     bool GetBool(const String& name) const;
     /// Return buffer attribute, or empty if missing.
-    PODVector<unsigned char> GetBuffer(const String& name) const;
+    Vector<unsigned char> GetBuffer(const String& name) const;
     /// Copy buffer attribute into a supplied buffer. Return true if buffer was large enough.
     bool GetBuffer(const String& name, void* dest, unsigned size) const;
     /// Return bounding box attribute, or empty if missing.

--- a/Source/Urho3D/Scene/Component.cpp
+++ b/Source/Urho3D/Scene/Component.cpp
@@ -86,7 +86,7 @@ void Component::MarkNetworkUpdate()
     }
 }
 
-void Component::GetDependencyNodes(PODVector<Node*>& dest)
+void Component::GetDependencyNodes(Vector<Node*>& dest)
 {
 }
 
@@ -168,7 +168,7 @@ void Component::PrepareNetworkUpdate()
             networkState_->previousValues_[i] = networkState_->currentValues_[i];
 
             // Mark the attribute dirty in all replication states that are tracking this component
-            for (PODVector<ReplicationState*>::Iterator j = networkState_->replicationStates_.Begin();
+            for (Vector<ReplicationState*>::Iterator j = networkState_->replicationStates_.Begin();
                  j != networkState_->replicationStates_.End(); ++j)
             {
                 auto* compState = static_cast<ComponentReplicationState*>(*j);
@@ -249,7 +249,7 @@ bool Component::IsEnabledEffective() const
     return enabled_ && node_ && node_->IsEnabled();
 }
 
-void Component::GetComponents(PODVector<Component*>& dest, StringHash type) const
+void Component::GetComponents(Vector<Component*>& dest, StringHash type) const
 {
     if (node_)
         node_->GetComponents(dest, type);

--- a/Source/Urho3D/Scene/Component.h
+++ b/Source/Urho3D/Scene/Component.h
@@ -51,7 +51,7 @@ public:
     /// Mark for attribute check on the next network update.
     void MarkNetworkUpdate() override;
     /// Return the depended on nodes to order network updates.
-    virtual void GetDependencyNodes(PODVector<Node*>& dest);
+    virtual void GetDependencyNodes(Vector<Node*>& dest);
     /// Visualize the component as debug geometry.
     virtual void DrawDebugGeometry(DebugRenderer* debug, bool depthTest);
 
@@ -85,11 +85,11 @@ public:
     /// Return component in the same scene node by type. If there are several, returns the first.
     Component* GetComponent(StringHash type) const;
     /// Return components in the same scene node by type.
-    void GetComponents(PODVector<Component*>& dest, StringHash type) const;
+    void GetComponents(Vector<Component*>& dest, StringHash type) const;
     /// Template version of returning a component in the same scene node by type.
     template <class T> T* GetComponent() const;
     /// Template version of returning components in the same scene node by type.
-    template <class T> void GetComponents(PODVector<T*>& dest) const;
+    template <class T> void GetComponents(Vector<T*>& dest) const;
 
     /// Add a replication state that is tracking this component.
     void AddReplicationState(ComponentReplicationState* state);
@@ -136,9 +136,9 @@ protected:
 
 template <class T> T* Component::GetComponent() const { return static_cast<T*>(GetComponent(T::GetTypeStatic())); }
 
-template <class T> void Component::GetComponents(PODVector<T*>& dest) const
+template <class T> void Component::GetComponents(Vector<T*>& dest) const
 {
-    GetComponents(reinterpret_cast<PODVector<Component*>&>(dest), T::GetTypeStatic());
+    GetComponents(reinterpret_cast<Vector<Component*>&>(dest), T::GetTypeStatic());
 }
 
 }

--- a/Source/Urho3D/Scene/Node.cpp
+++ b/Source/Urho3D/Scene/Node.cpp
@@ -66,9 +66,9 @@ void Node::RegisterObject(Context* context)
     URHO3D_ATTRIBUTE("Variables", VariantMap, vars_, Variant::emptyVariantMap, AM_FILE); // Network replication of vars uses custom data
     URHO3D_ACCESSOR_ATTRIBUTE("Network Position", GetNetPositionAttr, SetNetPositionAttr, Vector3, Vector3::ZERO,
         AM_NET | AM_LATESTDATA | AM_NOEDIT);
-    URHO3D_ACCESSOR_ATTRIBUTE("Network Rotation", GetNetRotationAttr, SetNetRotationAttr, PODVector<unsigned char>, Variant::emptyBuffer,
+    URHO3D_ACCESSOR_ATTRIBUTE("Network Rotation", GetNetRotationAttr, SetNetRotationAttr, Vector<unsigned char>, Variant::emptyBuffer,
         AM_NET | AM_LATESTDATA | AM_NOEDIT);
-    URHO3D_ACCESSOR_ATTRIBUTE("Network Parent Node", GetNetParentAttr, SetNetParentAttr, PODVector<unsigned char>, Variant::emptyBuffer,
+    URHO3D_ACCESSOR_ATTRIBUTE("Network Parent Node", GetNetParentAttr, SetNetParentAttr, Vector<unsigned char>, Variant::emptyBuffer,
         AM_NET | AM_NOEDIT);
 }
 
@@ -1214,7 +1214,7 @@ unsigned Node::GetNumChildren(bool recursive) const
     }
 }
 
-void Node::GetChildren(PODVector<Node*>& dest, bool recursive) const
+void Node::GetChildren(Vector<Node*>& dest, bool recursive) const
 {
     dest.Clear();
 
@@ -1227,14 +1227,14 @@ void Node::GetChildren(PODVector<Node*>& dest, bool recursive) const
         GetChildrenRecursive(dest);
 }
 
-PODVector<Node*> Node::GetChildren(bool recursive) const
+Vector<Node*> Node::GetChildren(bool recursive) const
 {
-    PODVector<Node*> dest;
+    Vector<Node*> dest;
     GetChildren(dest, recursive);
     return dest;
 }
 
-void Node::GetChildrenWithComponent(PODVector<Node*>& dest, StringHash type, bool recursive) const
+void Node::GetChildrenWithComponent(Vector<Node*>& dest, StringHash type, bool recursive) const
 {
     dest.Clear();
 
@@ -1250,14 +1250,14 @@ void Node::GetChildrenWithComponent(PODVector<Node*>& dest, StringHash type, boo
         GetChildrenWithComponentRecursive(dest, type);
 }
 
-PODVector<Node*> Node::GetChildrenWithComponent(StringHash type, bool recursive) const
+Vector<Node*> Node::GetChildrenWithComponent(StringHash type, bool recursive) const
 {
-    PODVector<Node*> dest;
+    Vector<Node*> dest;
     GetChildrenWithComponent(dest, type, recursive);
     return dest;
 }
 
-void Node::GetChildrenWithTag(PODVector<Node*>& dest, const String& tag, bool recursive /*= true*/) const
+void Node::GetChildrenWithTag(Vector<Node*>& dest, const String& tag, bool recursive /*= true*/) const
 {
     dest.Clear();
 
@@ -1273,9 +1273,9 @@ void Node::GetChildrenWithTag(PODVector<Node*>& dest, const String& tag, bool re
         GetChildrenWithTagRecursive(dest, tag);
 }
 
-PODVector<Node*> Node::GetChildrenWithTag(const String& tag, bool recursive) const
+Vector<Node*> Node::GetChildrenWithTag(const String& tag, bool recursive) const
 {
-    PODVector<Node*> dest;
+    Vector<Node*> dest;
     GetChildrenWithTag(dest, tag, recursive);
     return dest;
 }
@@ -1325,7 +1325,7 @@ unsigned Node::GetNumNetworkComponents() const
     return num;
 }
 
-void Node::GetComponents(PODVector<Component*>& dest, StringHash type, bool recursive) const
+void Node::GetComponents(Vector<Component*>& dest, StringHash type, bool recursive) const
 {
     dest.Clear();
 
@@ -1443,7 +1443,7 @@ void Node::SetNetPositionAttr(const Vector3& value)
         SetPosition(value);
 }
 
-void Node::SetNetRotationAttr(const PODVector<unsigned char>& value)
+void Node::SetNetRotationAttr(const Vector<unsigned char>& value)
 {
     MemoryBuffer buf(value);
     auto* transform = GetComponent<SmoothedTransform>();
@@ -1453,7 +1453,7 @@ void Node::SetNetRotationAttr(const PODVector<unsigned char>& value)
         SetRotation(buf.ReadPackedQuaternion());
 }
 
-void Node::SetNetParentAttr(const PODVector<unsigned char>& value)
+void Node::SetNetParentAttr(const Vector<unsigned char>& value)
 {
     Scene* scene = GetScene();
     if (!scene)
@@ -1495,14 +1495,14 @@ const Vector3& Node::GetNetPositionAttr() const
     return position_;
 }
 
-const PODVector<unsigned char>& Node::GetNetRotationAttr() const
+const Vector<unsigned char>& Node::GetNetRotationAttr() const
 {
     impl_->attrBuffer_.Clear();
     impl_->attrBuffer_.WritePackedQuaternion(rotation_);
     return impl_->attrBuffer_.GetBuffer();
 }
 
-const PODVector<unsigned char>& Node::GetNetParentAttr() const
+const Vector<unsigned char>& Node::GetNetParentAttr() const
 {
     impl_->attrBuffer_.Clear();
     Scene* scene = GetScene();
@@ -1708,7 +1708,7 @@ void Node::PrepareNetworkUpdate()
             networkState_->previousValues_[i] = networkState_->currentValues_[i];
 
             // Mark the attribute dirty in all replication states that are tracking this node
-            for (PODVector<ReplicationState*>::Iterator j = networkState_->replicationStates_.Begin();
+            for (Vector<ReplicationState*>::Iterator j = networkState_->replicationStates_.Begin();
                  j != networkState_->replicationStates_.End(); ++j)
             {
                 auto* nodeState = static_cast<NodeReplicationState*>(*j);
@@ -1733,7 +1733,7 @@ void Node::PrepareNetworkUpdate()
             networkState_->previousVars_[i->first_] = i->second_;
 
             // Mark the var dirty in all replication states that are tracking this node
-            for (PODVector<ReplicationState*>::Iterator j = networkState_->replicationStates_.Begin();
+            for (Vector<ReplicationState*>::Iterator j = networkState_->replicationStates_.Begin();
                  j != networkState_->replicationStates_.End(); ++j)
             {
                 auto* nodeState = static_cast<NodeReplicationState*>(*j);
@@ -1770,7 +1770,7 @@ void Node::MarkReplicationDirty()
 {
     if (networkState_)
     {
-        for (PODVector<ReplicationState*>::Iterator j = networkState_->replicationStates_.Begin();
+        for (Vector<ReplicationState*>::Iterator j = networkState_->replicationStates_.Begin();
              j != networkState_->replicationStates_.End(); ++j)
         {
             auto* nodeState = static_cast<NodeReplicationState*>(*j);
@@ -1958,7 +1958,7 @@ Animatable* Node::FindAttributeAnimationTarget(const String& name, String& outNa
         else
         {
             unsigned index = ToUInt(componentNames[1]);
-            PODVector<Component*> components;
+            Vector<Component*> components;
             node->GetComponents(components, StringHash(componentNames.Front()));
             if (index >= components.Size())
             {
@@ -2113,7 +2113,7 @@ void Node::RemoveChild(Vector<SharedPtr<Node>>::Iterator i)
     children_.Erase(i);
 }
 
-void Node::GetChildrenRecursive(PODVector<Node*>& dest) const
+void Node::GetChildrenRecursive(Vector<Node*>& dest) const
 {
     for (Vector<SharedPtr<Node>>::ConstIterator i = children_.Begin(); i != children_.End(); ++i)
     {
@@ -2124,7 +2124,7 @@ void Node::GetChildrenRecursive(PODVector<Node*>& dest) const
     }
 }
 
-void Node::GetChildrenWithComponentRecursive(PODVector<Node*>& dest, StringHash type) const
+void Node::GetChildrenWithComponentRecursive(Vector<Node*>& dest, StringHash type) const
 {
     for (Vector<SharedPtr<Node>>::ConstIterator i = children_.Begin(); i != children_.End(); ++i)
     {
@@ -2136,7 +2136,7 @@ void Node::GetChildrenWithComponentRecursive(PODVector<Node*>& dest, StringHash 
     }
 }
 
-void Node::GetComponentsRecursive(PODVector<Component*>& dest, StringHash type) const
+void Node::GetComponentsRecursive(Vector<Component*>& dest, StringHash type) const
 {
     for (Vector<SharedPtr<Component>>::ConstIterator i = components_.Begin(); i != components_.End(); ++i)
     {
@@ -2147,7 +2147,7 @@ void Node::GetComponentsRecursive(PODVector<Component*>& dest, StringHash type) 
         (*i)->GetComponentsRecursive(dest, type);
 }
 
-void Node::GetChildrenWithTagRecursive(PODVector<Node*>& dest, const String& tag) const
+void Node::GetChildrenWithTagRecursive(Vector<Node*>& dest, const String& tag) const
 {
     for (Vector<SharedPtr<Node>>::ConstIterator i = children_.Begin(); i != children_.End(); ++i)
     {

--- a/Source/Urho3D/Scene/Node.h
+++ b/Source/Urho3D/Scene/Node.h
@@ -41,7 +41,7 @@ enum TransformSpace
 struct URHO3D_API NodeImpl
 {
     /// Nodes this node depends on for network updates.
-    PODVector<Node*> dependencyNodes_;
+    Vector<Node*> dependencyNodes_;
     /// Network owner connection.
     Connection* owner_;
     /// Name.
@@ -546,17 +546,17 @@ public:
     const Vector<SharedPtr<Node>>& GetChildren() const { return children_; }
 
     /// Return child scene nodes, optionally recursive.
-    void GetChildren(PODVector<Node*>& dest, bool recursive = false) const;
+    void GetChildren(Vector<Node*>& dest, bool recursive = false) const;
     /// Return child scene nodes, optionally recursive.
-    PODVector<Node*> GetChildren(bool recursive) const;
+    Vector<Node*> GetChildren(bool recursive) const;
     /// Return child scene nodes with a specific component.
-    void GetChildrenWithComponent(PODVector<Node*>& dest, StringHash type, bool recursive = false) const;
+    void GetChildrenWithComponent(Vector<Node*>& dest, StringHash type, bool recursive = false) const;
     /// Return child scene nodes with a specific component.
-    PODVector<Node*> GetChildrenWithComponent(StringHash type, bool recursive = false) const;
+    Vector<Node*> GetChildrenWithComponent(StringHash type, bool recursive = false) const;
     /// Return child scene nodes with a specific tag.
-    void GetChildrenWithTag(PODVector<Node*>& dest, const String& tag, bool recursive = false) const;
+    void GetChildrenWithTag(Vector<Node*>& dest, const String& tag, bool recursive = false) const;
     /// Return child scene nodes with a specific tag.
-    PODVector<Node*> GetChildrenWithTag(const String& tag, bool recursive = false) const;
+    Vector<Node*> GetChildrenWithTag(const String& tag, bool recursive = false) const;
 
     /// Return child scene node by index.
     Node* GetChild(unsigned index) const;
@@ -578,7 +578,7 @@ public:
     const Vector<SharedPtr<Component>>& GetComponents() const { return components_; }
 
     /// Return all components of type. Optionally recursive.
-    void GetComponents(PODVector<Component*>& dest, StringHash type, bool recursive = false) const;
+    void GetComponents(Vector<Component*>& dest, StringHash type, bool recursive = false) const;
     /// Return component by type. If there are several, returns the first.
     Component* GetComponent(StringHash type, bool recursive = false) const;
     /// Return component in parent node. If there are several, returns the first. May optional traverse up to the root node.
@@ -599,15 +599,15 @@ public:
     /// Return first component derived from class in the parent node, or if fully traversing then the first node up the tree with one.
     template <class T> T* GetParentDerivedComponent(bool fullTraversal = false) const;
     /// Return components derived from class.
-    template <class T> void GetDerivedComponents(PODVector<T*>& dest, bool recursive = false, bool clearVector = true) const;
+    template <class T> void GetDerivedComponents(Vector<T*>& dest, bool recursive = false, bool clearVector = true) const;
     /// Template version of returning child nodes with a specific component.
-    template <class T> void GetChildrenWithComponent(PODVector<Node*>& dest, bool recursive = false) const;
+    template <class T> void GetChildrenWithComponent(Vector<Node*>& dest, bool recursive = false) const;
     /// Template version of returning a component by type.
     template <class T> T* GetComponent(bool recursive = false) const;
     /// Template version of returning a parent's component by type.
     template <class T> T* GetParentComponent(bool fullTraversal = false) const;
     /// Template version of returning all components of type.
-    template <class T> void GetComponents(PODVector<T*>& dest, bool recursive = false) const;
+    template <class T> void GetComponents(Vector<T*>& dest, bool recursive = false) const;
     /// Template version of checking whether has a specific component.
     template <class T> bool HasComponent() const;
 
@@ -621,15 +621,15 @@ public:
     /// Set network position attribute.
     void SetNetPositionAttr(const Vector3& value);
     /// Set network rotation attribute.
-    void SetNetRotationAttr(const PODVector<unsigned char>& value);
+    void SetNetRotationAttr(const Vector<unsigned char>& value);
     /// Set network parent attribute.
-    void SetNetParentAttr(const PODVector<unsigned char>& value);
+    void SetNetParentAttr(const Vector<unsigned char>& value);
     /// Return network position attribute.
     const Vector3& GetNetPositionAttr() const;
     /// Return network rotation attribute.
-    const PODVector<unsigned char>& GetNetRotationAttr() const;
+    const Vector<unsigned char>& GetNetRotationAttr() const;
     /// Return network parent attribute.
-    const PODVector<unsigned char>& GetNetParentAttr() const;
+    const Vector<unsigned char>& GetNetParentAttr() const;
     /// Load components and optionally load child nodes.
     bool Load(Deserializer& source, SceneResolver& resolver, bool loadChildren = true, bool rewriteIDs = false,
         CreateMode mode = REPLICATED);
@@ -640,7 +640,7 @@ public:
     bool LoadJSON(const JSONValue& source, SceneResolver& resolver, bool loadChildren = true, bool rewriteIDs = false,
         CreateMode mode = REPLICATED);
     /// Return the depended on nodes to order network updates.
-    const PODVector<Node*>& GetDependencyNodes() const { return impl_->dependencyNodes_; }
+    const Vector<Node*>& GetDependencyNodes() const { return impl_->dependencyNodes_; }
 
     /// Prepare network update by comparing attributes and marking replication states dirty as necessary.
     void PrepareNetworkUpdate();
@@ -688,13 +688,13 @@ private:
     /// Remove child node by iterator.
     void RemoveChild(Vector<SharedPtr<Node>>::Iterator i);
     /// Return child nodes recursively.
-    void GetChildrenRecursive(PODVector<Node*>& dest) const;
+    void GetChildrenRecursive(Vector<Node*>& dest) const;
     /// Return child nodes with a specific component recursively.
-    void GetChildrenWithComponentRecursive(PODVector<Node*>& dest, StringHash type) const;
+    void GetChildrenWithComponentRecursive(Vector<Node*>& dest, StringHash type) const;
     /// Return child nodes with a specific tag recursively.
-    void GetChildrenWithTagRecursive(PODVector<Node*>& dest, const String& tag) const;
+    void GetChildrenWithTagRecursive(Vector<Node*>& dest, const String& tag) const;
     /// Return specific components recursively.
-    void GetComponentsRecursive(PODVector<Component*>& dest, StringHash type) const;
+    void GetComponentsRecursive(Vector<Component*>& dest, StringHash type) const;
     /// Clone node recursively.
     Node* CloneRecursive(Node* parent, SceneResolver& resolver, CreateMode mode);
     /// Remove a component from this node with the specified iterator.
@@ -759,7 +759,7 @@ template <class T> void Node::RemoveComponent() { RemoveComponent(T::GetTypeStat
 
 template <class T> void Node::RemoveComponents() { RemoveComponents(T::GetTypeStatic()); }
 
-template <class T> void Node::GetChildrenWithComponent(PODVector<Node*>& dest, bool recursive) const
+template <class T> void Node::GetChildrenWithComponent(Vector<Node*>& dest, bool recursive) const
 {
     GetChildrenWithComponent(dest, T::GetTypeStatic(), recursive);
 }
@@ -768,9 +768,9 @@ template <class T> T* Node::GetComponent(bool recursive) const { return static_c
 
 template <class T> T* Node::GetParentComponent(bool fullTraversal) const { return static_cast<T*>(GetParentComponent(T::GetTypeStatic(), fullTraversal)); }
 
-template <class T> void Node::GetComponents(PODVector<T*>& dest, bool recursive) const
+template <class T> void Node::GetComponents(Vector<T*>& dest, bool recursive) const
 {
-    GetComponents(reinterpret_cast<PODVector<Component*>&>(dest), T::GetTypeStatic(), recursive);
+    GetComponents(reinterpret_cast<Vector<Component*>&>(dest), T::GetTypeStatic(), recursive);
 }
 
 template <class T> bool Node::HasComponent() const { return HasComponent(T::GetTypeStatic()); }
@@ -814,7 +814,7 @@ template <class T> T* Node::GetParentDerivedComponent(bool fullTraversal) const
     return 0;
 }
 
-template <class T> void Node::GetDerivedComponents(PODVector<T*>& dest, bool recursive, bool clearVector) const
+template <class T> void Node::GetDerivedComponents(Vector<T*>& dest, bool recursive, bool clearVector) const
 {
     if (clearVector)
         dest.Clear();

--- a/Source/Urho3D/Scene/ReplicationState.h
+++ b/Source/Urho3D/Scene/ReplicationState.h
@@ -108,7 +108,7 @@ struct URHO3D_API NetworkState
     /// Previous network attribute values.
     Vector<Variant> previousValues_;
     /// Replication states that are tracking this object.
-    PODVector<ReplicationState*> replicationStates_;
+    Vector<ReplicationState*> replicationStates_;
     /// Previous user variables.
     VariantMap previousVars_;
     /// Bitmask for intercepting network messages. Used on the client only.

--- a/Source/Urho3D/Scene/Scene.cpp
+++ b/Source/Urho3D/Scene/Scene.cpp
@@ -698,10 +698,10 @@ Node* Scene::GetNode(unsigned id) const
     }
 }
 
-bool Scene::GetNodesWithTag(PODVector<Node*>& dest, const String& tag) const
+bool Scene::GetNodesWithTag(Vector<Node*>& dest, const String& tag) const
 {
     dest.Clear();
-    HashMap<StringHash, PODVector<Node*>>::ConstIterator it = taggedNodes_.Find(tag);
+    HashMap<StringHash, Vector<Node*>>::ConstIterator it = taggedNodes_.Find(tag);
     if (it != taggedNodes_.End())
     {
         dest = it->second_;
@@ -808,7 +808,7 @@ void Scene::EndThreadedUpdate()
     {
         URHO3D_PROFILE(EndThreadedUpdate);
 
-        for (PODVector<Component*>::ConstIterator i = delayedDirtyComponents_.Begin(); i != delayedDirtyComponents_.End(); ++i)
+        for (Vector<Component*>::ConstIterator i = delayedDirtyComponents_.Begin(); i != delayedDirtyComponents_.End(); ++i)
             (*i)->OnMarkedDirty((*i)->GetNode());
         delayedDirtyComponents_.Clear();
     }
@@ -1133,7 +1133,7 @@ void Scene::MarkReplicationDirty(Node* node)
     if (networkState_ && node->IsReplicated())
     {
         unsigned id = node->GetID();
-        for (PODVector<ReplicationState*>::Iterator i = networkState_->replicationStates_.Begin();
+        for (Vector<ReplicationState*>::Iterator i = networkState_->replicationStates_.Begin();
              i != networkState_->replicationStates_.End(); ++i)
         {
             auto* nodeState = static_cast<NodeReplicationState*>(*i);

--- a/Source/Urho3D/Scene/Scene.h
+++ b/Source/Urho3D/Scene/Scene.h
@@ -163,7 +163,7 @@ public:
     /// Return component from the whole scene by ID, or null if not found.
     Component* GetComponent(unsigned id) const;
     /// Get nodes with specific tag from the whole scene, return false if empty.
-    bool GetNodesWithTag(PODVector<Node*>& dest, const String& tag)  const;
+    bool GetNodesWithTag(Vector<Node*>& dest, const String& tag)  const;
 
     /// Return whether updates are enabled.
     /// @property
@@ -293,7 +293,7 @@ private:
     /// Local components by ID.
     HashMap<unsigned, Component*> localComponents_;
     /// Cached tagged nodes by tag.
-    HashMap<StringHash, PODVector<Node*>> taggedNodes_;
+    HashMap<StringHash, Vector<Node*>> taggedNodes_;
     /// Asynchronous loading progress.
     AsyncProgress asyncProgress_;
     /// Node and component ID resolver for asynchronous loading.
@@ -309,7 +309,7 @@ private:
     /// Components to check for attribute changes on the next network update.
     HashSet<unsigned> networkUpdateComponents_;
     /// Delayed dirty notification queue for components.
-    PODVector<Component*> delayedDirtyComponents_;
+    Vector<Component*> delayedDirtyComponents_;
     /// Mutex for the delayed dirty notification queue.
     Mutex sceneMutex_;
     /// Preallocated event data map for smoothing update events.

--- a/Source/Urho3D/Scene/Serializable.cpp
+++ b/Source/Urho3D/Scene/Serializable.cpp
@@ -109,7 +109,7 @@ void Serializable::OnSetAttribute(const AttributeInfo& attr, const Variant& src)
         break;
 
     case VAR_BUFFER:
-        *(reinterpret_cast<PODVector<unsigned char>*>(dest)) = src.GetBuffer();
+        *(reinterpret_cast<Vector<unsigned char>*>(dest)) = src.GetBuffer();
         break;
 
     case VAR_RESOURCEREF:
@@ -218,7 +218,7 @@ void Serializable::OnGetAttribute(const AttributeInfo& attr, Variant& dest) cons
         break;
 
     case VAR_BUFFER:
-        dest = *(reinterpret_cast<const PODVector<unsigned char>*>(src));
+        dest = *(reinterpret_cast<const Vector<unsigned char>*>(src));
         break;
 
     case VAR_RESOURCEREF:

--- a/Source/Urho3D/Scene/UnknownComponent.h
+++ b/Source/Urho3D/Scene/UnknownComponent.h
@@ -50,7 +50,7 @@ public:
     const Vector<String>& GetXMLAttributes() const { return xmlAttributes_; }
 
     /// Return the binary attributes. Empty when loaded with XML serialization.
-    const PODVector<unsigned char>& GetBinaryAttributes() const { return binaryAttributes_; }
+    const Vector<unsigned char>& GetBinaryAttributes() const { return binaryAttributes_; }
 
     /// Return whether was loaded using XML data.
     bool GetUseXML() const { return useXML_; }
@@ -78,7 +78,7 @@ private:
     /// XML format attribute data (as strings).
     Vector<String> xmlAttributes_;
     /// Binary attributes.
-    PODVector<unsigned char> binaryAttributes_;
+    Vector<unsigned char> binaryAttributes_;
     /// Flag of whether was loaded using XML/JSON data.
     bool useXML_;
 

--- a/Source/Urho3D/Scene/ValueAnimation.cpp
+++ b/Source/Urho3D/Scene/ValueAnimation.cpp
@@ -339,7 +339,7 @@ Variant ValueAnimation::GetAnimationValue(float scaledTime) const
     }
 }
 
-void ValueAnimation::GetEventFrames(float beginTime, float endTime, PODVector<const VAnimEventFrame*>& eventFrames) const
+void ValueAnimation::GetEventFrames(float beginTime, float endTime, Vector<const VAnimEventFrame*>& eventFrames) const
 {
     for (unsigned i = 0; i < eventFrames_.Size(); ++i)
     {

--- a/Source/Urho3D/Scene/ValueAnimation.h
+++ b/Source/Urho3D/Scene/ValueAnimation.h
@@ -123,7 +123,7 @@ public:
     bool HasEventFrames() const { return !eventFrames_.Empty(); }
 
     /// Return all event frames between time.
-    void GetEventFrames(float beginTime, float endTime, PODVector<const VAnimEventFrame*>& eventFrames) const;
+    void GetEventFrames(float beginTime, float endTime, Vector<const VAnimEventFrame*>& eventFrames) const;
 
 protected:
     /// Linear interpolation.

--- a/Source/Urho3D/Scene/ValueAnimationInfo.cpp
+++ b/Source/Urho3D/Scene/ValueAnimationInfo.cpp
@@ -74,7 +74,7 @@ bool ValueAnimationInfo::SetTime(float time)
     // Send keyframe event if necessary
     if (animation_->HasEventFrames())
     {
-        PODVector<const VAnimEventFrame*> eventFrames;
+        Vector<const VAnimEventFrame*> eventFrames;
         GetEventFrames(lastScaledTime_, scaledTime, eventFrames);
 
         if (eventFrames.Size())
@@ -135,7 +135,7 @@ float ValueAnimationInfo::CalculateScaledTime(float currentTime, bool& finished)
     }
 }
 
-void ValueAnimationInfo::GetEventFrames(float beginTime, float endTime, PODVector<const VAnimEventFrame*>& eventFrames)
+void ValueAnimationInfo::GetEventFrames(float beginTime, float endTime, Vector<const VAnimEventFrame*>& eventFrames)
 {
     switch (wrapMode_)
     {

--- a/Source/Urho3D/Scene/ValueAnimationInfo.h
+++ b/Source/Urho3D/Scene/ValueAnimationInfo.h
@@ -61,7 +61,7 @@ protected:
     /// Calculate scaled time.
     float CalculateScaledTime(float currentTime, bool& finished) const;
     /// Return event frames.
-    void GetEventFrames(float beginTime, float endTime, PODVector<const VAnimEventFrame*>& eventFrames);
+    void GetEventFrames(float beginTime, float endTime, Vector<const VAnimEventFrame*>& eventFrames);
 
     /// Target object.
     WeakPtr<Object> target_;

--- a/Source/Urho3D/UI/BorderImage.cpp
+++ b/Source/Urho3D/UI/BorderImage.cpp
@@ -48,7 +48,7 @@ void BorderImage::RegisterObject(Context* context)
         AM_FILE);
 }
 
-void BorderImage::GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect& currentScissor)
+void BorderImage::GetBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor)
 {
     if (enabled_)
         GetBatches(batches, vertexData, currentScissor, (hovering_ || selected_ || HasFocus()) ? hoverOffset_ : IntVector2::ZERO);
@@ -121,7 +121,7 @@ void BorderImage::SetTiled(bool enable)
     tiled_ = enable;
 }
 
-void BorderImage::GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect& currentScissor,
+void BorderImage::GetBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor,
     const IntVector2& offset)
 {
     bool allOpaque = true;

--- a/Source/Urho3D/UI/BorderImage.h
+++ b/Source/Urho3D/UI/BorderImage.h
@@ -27,7 +27,7 @@ public:
     static void RegisterObject(Context* context);
 
     /// Return UI rendering batches.
-    void GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect& currentScissor) override;
+    void GetBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor) override;
 
     /// Set texture.
     /// @property
@@ -111,7 +111,7 @@ public:
 protected:
     /// Return UI rendering batches with offset to image rectangle.
     void GetBatches
-        (PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect& currentScissor, const IntVector2& offset);
+        (Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor, const IntVector2& offset);
 
     /// Texture.
     SharedPtr<Texture> texture_;

--- a/Source/Urho3D/UI/Button.cpp
+++ b/Source/Urho3D/UI/Button.cpp
@@ -66,7 +66,7 @@ void Button::Update(float timeStep)
     }
 }
 
-void Button::GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect& currentScissor)
+void Button::GetBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor)
 {
     IntVector2 offset(IntVector2::ZERO);
     if (enabled_)

--- a/Source/Urho3D/UI/Button.h
+++ b/Source/Urho3D/UI/Button.h
@@ -25,7 +25,7 @@ public:
     /// Perform UI element update.
     void Update(float timeStep) override;
     /// Return UI rendering batches.
-    void GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect& currentScissor) override;
+    void GetBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor) override;
     /// React to mouse click begin.
     void OnClickBegin
         (const IntVector2& position, const IntVector2& screenPosition, MouseButton button, MouseButtonFlags buttons, QualifierFlags qualifiers, Cursor* cursor) override;

--- a/Source/Urho3D/UI/CheckBox.cpp
+++ b/Source/Urho3D/UI/CheckBox.cpp
@@ -37,7 +37,7 @@ void CheckBox::RegisterObject(Context* context)
     URHO3D_ACCESSOR_ATTRIBUTE("Checked Image Offset", GetCheckedOffset, SetCheckedOffset, IntVector2, IntVector2::ZERO, AM_FILE);
 }
 
-void CheckBox::GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect& currentScissor)
+void CheckBox::GetBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor)
 {
     IntVector2 offset(IntVector2::ZERO);
     if (enabled_)

--- a/Source/Urho3D/UI/CheckBox.h
+++ b/Source/Urho3D/UI/CheckBox.h
@@ -23,7 +23,7 @@ public:
     static void RegisterObject(Context* context);
 
     /// Return UI rendering batches.
-    void GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect& currentScissor) override;
+    void GetBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor) override;
     /// React to mouse click begin.
     void OnClickBegin
         (const IntVector2& position, const IntVector2& screenPosition, MouseButton button, MouseButtonFlags buttons, QualifierFlags qualifiers, Cursor* cursor) override;

--- a/Source/Urho3D/UI/Cursor.cpp
+++ b/Source/Urho3D/UI/Cursor.cpp
@@ -90,7 +90,7 @@ void Cursor::RegisterObject(Context* context)
     URHO3D_MIXED_ACCESSOR_ATTRIBUTE("Shapes", GetShapesAttr, SetShapesAttr, VariantVector, Variant::emptyVariantVector, AM_FILE);
 }
 
-void Cursor::GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect& currentScissor)
+void Cursor::GetBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor)
 {
     unsigned initialSize = vertexData.Size();
     const IntVector2& offset = shapeInfos_[shape_].hotSpot_;

--- a/Source/Urho3D/UI/Cursor.h
+++ b/Source/Urho3D/UI/Cursor.h
@@ -86,7 +86,7 @@ public:
     static void RegisterObject(Context* context);
 
     /// Return UI rendering batches.
-    void GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect& currentScissor) override;
+    void GetBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor) override;
 
     /// Define a shape.
     void DefineShape(const String& shape, Image* image, const IntRect& imageRect, const IntVector2& hotSpot);

--- a/Source/Urho3D/UI/DropDownList.cpp
+++ b/Source/Urho3D/UI/DropDownList.cpp
@@ -65,7 +65,7 @@ void DropDownList::ApplyAttributes()
     SetSelection(selectionAttr_);
 }
 
-void DropDownList::GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect& currentScissor)
+void DropDownList::GetBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor)
 {
     Menu::GetBatches(batches, vertexData, currentScissor);
 
@@ -186,7 +186,7 @@ UIElement* DropDownList::GetItem(unsigned index) const
     return listView_->GetItem(index);
 }
 
-PODVector<UIElement*> DropDownList::GetItems() const
+Vector<UIElement*> DropDownList::GetItems() const
 {
     return listView_->GetItems();
 }

--- a/Source/Urho3D/UI/DropDownList.h
+++ b/Source/Urho3D/UI/DropDownList.h
@@ -27,7 +27,7 @@ public:
     /// Apply attribute changes that can not be applied immediately.
     void ApplyAttributes() override;
     /// Return UI rendering batches.
-    void GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect& currentScissor) override;
+    void GetBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor) override;
     /// React to the popup being shown.
     void OnShowPopup() override;
     /// React to the popup being hidden.
@@ -62,7 +62,7 @@ public:
     /// @property{get_items}
     UIElement* GetItem(unsigned index) const;
     /// Return all items.
-    PODVector<UIElement*> GetItems() const;
+    Vector<UIElement*> GetItems() const;
     /// Return selection index, or M_MAX_UNSIGNED if none selected.
     /// @property
     unsigned GetSelection() const;

--- a/Source/Urho3D/UI/ListView.cpp
+++ b/Source/Urho3D/UI/ListView.cpp
@@ -490,13 +490,13 @@ void ListView::RemoveAllItems()
 
 void ListView::SetSelection(unsigned index)
 {
-    PODVector<unsigned> indices;
+    Vector<unsigned> indices;
     indices.Push(index);
     SetSelections(indices);
     EnsureItemVisibility(index);
 }
 
-void ListView::SetSelections(const PODVector<unsigned>& indices)
+void ListView::SetSelections(const Vector<unsigned>& indices)
 {
     // Make a weak pointer to self to check for destruction as a response to events
     WeakPtr<ListView> self(this);
@@ -504,7 +504,7 @@ void ListView::SetSelections(const PODVector<unsigned>& indices)
     unsigned numItems = GetNumItems();
 
     // Remove first items that should no longer be selected
-    for (PODVector<unsigned>::Iterator i = selections_.Begin(); i != selections_.End();)
+    for (Vector<unsigned>::Iterator i = selections_.Begin(); i != selections_.End();)
     {
         unsigned index = *i;
         if (!indices.Contains(index))
@@ -528,7 +528,7 @@ void ListView::SetSelections(const PODVector<unsigned>& indices)
     bool added = false;
 
     // Then add missing items
-    for (PODVector<unsigned>::ConstIterator i = indices.Begin(); i != indices.End(); ++i)
+    for (Vector<unsigned>::ConstIterator i = indices.Begin(); i != indices.End(); ++i)
     {
         unsigned index = *i;
         if (index < numItems)
@@ -653,7 +653,7 @@ void ListView::ChangeSelection(int delta, bool additive)
     int direction = delta > 0 ? 1 : -1;
     unsigned newSelection = selection;
     unsigned okSelection = selection;
-    PODVector<unsigned> indices = selections_;
+    Vector<unsigned> indices = selections_;
 
     while (delta != 0)
     {
@@ -677,7 +677,7 @@ void ListView::ChangeSelection(int delta, bool additive)
 
 void ListView::ClearSelection()
 {
-    SetSelections(PODVector<unsigned>());
+    SetSelections(Vector<unsigned>());
 }
 
 void ListView::SetHighlightMode(HighlightMode mode)
@@ -765,7 +765,7 @@ void ListView::Expand(unsigned index, bool enable, bool recursive)
     SetItemExpanded(item, enable);
     int baseIndent = item->GetIndent();
 
-    PODVector<bool> expanded((unsigned)(baseIndent + 1));
+    Vector<bool> expanded((unsigned)(baseIndent + 1));
     expanded[baseIndent] = enable;
 
     contentElement_->DisableLayoutUpdate();
@@ -817,9 +817,9 @@ UIElement* ListView::GetItem(unsigned index) const
     return contentElement_->GetChild(index);
 }
 
-PODVector<UIElement*> ListView::GetItems() const
+Vector<UIElement*> ListView::GetItems() const
 {
-    PODVector<UIElement*> items;
+    Vector<UIElement*> items;
     contentElement_->GetChildren(items);
     return items;
 }
@@ -876,11 +876,11 @@ UIElement* ListView::GetSelectedItem() const
     return contentElement_->GetChild(GetSelection());
 }
 
-PODVector<UIElement*> ListView::GetSelectedItems() const
+Vector<UIElement*> ListView::GetSelectedItems() const
 {
-    PODVector<UIElement*> ret;
+    Vector<UIElement*> ret;
 
-    for (PODVector<unsigned>::ConstIterator i = selections_.Begin(); i != selections_.End(); ++i)
+    for (Vector<unsigned>::ConstIterator i = selections_.Begin(); i != selections_.End(); ++i)
     {
         UIElement* item = GetItem(*i);
         if (item)
@@ -894,7 +894,7 @@ void ListView::CopySelectedItemsToClipboard() const
 {
     String selectedText;
 
-    for (PODVector<unsigned>::ConstIterator i = selections_.Begin(); i != selections_.End(); ++i)
+    for (Vector<unsigned>::ConstIterator i = selections_.Begin(); i != selections_.End(); ++i)
     {
         // Only handle Text UI element
         auto* text = dynamic_cast<Text*>(GetItem(*i));
@@ -1038,7 +1038,7 @@ void ListView::HandleUIMouseClick(StringHash eventType, VariantMap& eventData)
                 {
                     unsigned first = selections_.Front();
                     unsigned last = selections_.Back();
-                    PODVector<unsigned> newSelections = selections_;
+                    Vector<unsigned> newSelections = selections_;
                     if (i == first || i == last)
                     {
                         for (unsigned j = first; j <= last; ++j)

--- a/Source/Urho3D/UI/ListView.h
+++ b/Source/Urho3D/UI/ListView.h
@@ -65,7 +65,7 @@ public:
     /// @property
     void SetSelection(unsigned index);
     /// Set multiple selected items. If multiselect disabled, sets only the first.
-    void SetSelections(const PODVector<unsigned>& indices);
+    void SetSelections(const Vector<unsigned>& indices);
     /// Add item to the selection, multiselect mode only.
     void AddSelection(unsigned index);
     /// Remove item from the selection.
@@ -108,7 +108,7 @@ public:
     /// @property{get_items}
     UIElement* GetItem(unsigned index) const;
     /// Return all items.
-    PODVector<UIElement*> GetItems() const;
+    Vector<UIElement*> GetItems() const;
     /// Return index of item, or M_MAX_UNSIGNED If not found.
     unsigned FindItem(UIElement* item) const;
     /// Return first selected index, or M_MAX_UNSIGNED if none selected.
@@ -117,7 +117,7 @@ public:
 
     /// Return all selected indices.
     /// @property
-    const PODVector<unsigned>& GetSelections() const { return selections_; }
+    const Vector<unsigned>& GetSelections() const { return selections_; }
 
     /// Copy selected items to system clipboard. Currently only applicable to Text items.
     void CopySelectedItemsToClipboard() const;
@@ -126,7 +126,7 @@ public:
     UIElement* GetSelectedItem() const;
     /// Return all selected items.
     /// @property
-    PODVector<UIElement*> GetSelectedItems() const;
+    Vector<UIElement*> GetSelectedItems() const;
     /// Return whether an item at index is selected.
     bool IsSelected(unsigned index) const;
     /// Return whether an item at index has its children expanded (in hierarchy mode only).
@@ -168,7 +168,7 @@ protected:
     void UpdateSelectionEffect();
 
     /// Current selection.
-    PODVector<unsigned> selections_;
+    Vector<unsigned> selections_;
     /// Highlight mode.
     HighlightMode highlightMode_;
     /// Multiselect flag.

--- a/Source/Urho3D/UI/Menu.cpp
+++ b/Source/Urho3D/UI/Menu.cpp
@@ -292,9 +292,9 @@ void Menu::ShowPopup(bool enable)
         OnHidePopup();
 
         // If the popup has child menus, hide their popups as well
-        PODVector<UIElement*> children;
+        Vector<UIElement*> children;
         popup_->GetChildren(children, true);
-        for (PODVector<UIElement*>::ConstIterator i = children.Begin(); i != children.End(); ++i)
+        for (Vector<UIElement*>::ConstIterator i = children.Begin(); i != children.End(); ++i)
         {
             auto* menu = dynamic_cast<Menu*>(*i);
             if (menu)

--- a/Source/Urho3D/UI/Sprite.cpp
+++ b/Source/Urho3D/UI/Sprite.cpp
@@ -88,7 +88,7 @@ IntVector2 Sprite::ElementToScreen(const IntVector2& position)
     return IntVector2((int)transformedPos.x_, (int)transformedPos.y_);
 }
 
-void Sprite::GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect& currentScissor)
+void Sprite::GetBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor)
 {
     bool allOpaque = true;
     if (GetDerivedOpacity() < 1.0f || colors_[C_TOPLEFT].a_ < 1.0f || colors_[C_TOPRIGHT].a_ < 1.0f ||

--- a/Source/Urho3D/UI/Sprite.h
+++ b/Source/Urho3D/UI/Sprite.h
@@ -28,7 +28,7 @@ public:
     /// Update and return screen position.
     const IntVector2& GetScreenPosition() const override;
     /// Return UI rendering batches.
-    void GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect& currentScissor) override;
+    void GetBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor) override;
     /// React to position change.
     void OnPositionSet(const IntVector2& newPosition) override;
     /// Convert screen coordinates to element coordinates.

--- a/Source/Urho3D/UI/Text.cpp
+++ b/Source/Urho3D/UI/Text.cpp
@@ -98,7 +98,7 @@ void Text::ApplyAttributes()
     UpdateText();
 }
 
-void Text::GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect& currentScissor)
+void Text::GetBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor)
 {
     FontFace* face = font_ ? font_->GetFace(fontSize_) : nullptr;
     if (!face)
@@ -163,7 +163,7 @@ void Text::GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData,
         // One batch per texture/page
         UIBatch pageBatch(this, BLEND_ALPHA, currentScissor, textures[n], &vertexData);
 
-        const PODVector<GlyphLocation>& pageGlyphLocation = pageGlyphLocations_[n];
+        const Vector<GlyphLocation>& pageGlyphLocation = pageGlyphLocations_[n];
 
         switch (textEffect)
         {
@@ -773,7 +773,7 @@ int Text::GetRowStartPosition(i32 rowIndex) const
     return ret;
 }
 
-void Text::ConstructBatch(UIBatch& pageBatch, const PODVector<GlyphLocation>& pageGlyphLocation, float dx, float dy, Color* color,
+void Text::ConstructBatch(UIBatch& pageBatch, const Vector<GlyphLocation>& pageGlyphLocation, float dx, float dy, Color* color,
     float depthBias)
 {
     i32 startDataSize = pageBatch.vertexData_->Size();

--- a/Source/Urho3D/UI/Text.h
+++ b/Source/Urho3D/UI/Text.h
@@ -75,7 +75,7 @@ public:
     /// Apply attribute changes that can not be applied immediately.
     void ApplyAttributes() override;
     /// Return UI rendering batches.
-    void GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect& currentScissor) override;
+    void GetBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor) override;
     /// React to resize.
     void OnResize(const IntVector2& newSize, const IntVector2& delta) override;
     /// React to indent change.
@@ -229,7 +229,7 @@ protected:
     int GetRowStartPosition(i32 rowIndex) const;
     /// Construct batch.
     void ConstructBatch
-        (UIBatch& pageBatch, const PODVector<GlyphLocation>& pageGlyphLocation, float dx = 0, float dy = 0, Color* color = nullptr,
+        (UIBatch& pageBatch, const Vector<GlyphLocation>& pageGlyphLocation, float dx = 0, float dy = 0, Color* color = nullptr,
             float depthBias = 0.0f);
 
     /// Font.
@@ -267,17 +267,17 @@ protected:
     /// Row height.
     float rowHeight_;
     /// Text as Unicode characters.
-    PODVector<c32> unicodeText_;
+    Vector<c32> unicodeText_;
     /// Text modified into printed form.
-    PODVector<c32> printText_;
+    Vector<c32> printText_;
     /// Mapping of printed form back to original char indices.
-    PODVector<i32> printToText_;
+    Vector<i32> printToText_;
     /// Row widths.
-    PODVector<float> rowWidths_;
+    Vector<float> rowWidths_;
     /// Glyph locations per each texture in the font.
-    Vector<PODVector<GlyphLocation>> pageGlyphLocations_;
+    Vector<Vector<GlyphLocation>> pageGlyphLocations_;
     /// Cached locations of each character in the text.
-    PODVector<CharLocation> charLocations_;
+    Vector<CharLocation> charLocations_;
     /// The text will be automatically translated.
     bool autoLocalizable_;
     /// Localization string id storage. Used when autoLocalizable flag is set.

--- a/Source/Urho3D/UI/Text3D.h
+++ b/Source/Urho3D/UI/Text3D.h
@@ -224,9 +224,9 @@ protected:
     /// Material to use as a base for the text material(s).
     SharedPtr<Material> material_;
     /// Text UI batches.
-    PODVector<UIBatch> uiBatches_;
+    Vector<UIBatch> uiBatches_;
     /// Text vertex data.
-    PODVector<float> uiVertexData_;
+    Vector<float> uiVertexData_;
     /// Custom world transform for facing the camera automatically.
     Matrix3x4 customWorldTransform_;
     /// Text rotation mode in relation to the camera.

--- a/Source/Urho3D/UI/UI.cpp
+++ b/Source/Urho3D/UI/UI.cpp
@@ -957,7 +957,7 @@ void UI::Update(float timeStep, UIElement* element)
         Update(timeStep, children[i]);
 }
 
-void UI::SetVertexData(VertexBuffer* dest, const PODVector<float>& vertexData)
+void UI::SetVertexData(VertexBuffer* dest, const Vector<float>& vertexData)
 {
     if (vertexData.Empty())
         return;
@@ -971,7 +971,7 @@ void UI::SetVertexData(VertexBuffer* dest, const PODVector<float>& vertexData)
     dest->SetData(&vertexData[0]);
 }
 
-void UI::Render(VertexBuffer* buffer, const PODVector<UIBatch>& batches, unsigned batchStart, unsigned batchEnd)
+void UI::Render(VertexBuffer* buffer, const Vector<UIBatch>& batches, unsigned batchStart, unsigned batchEnd)
 {
     // Engine does not render when window is closed or device is lost
     assert(graphics_ && graphics_->IsInitialized() && !graphics_->IsDeviceLost());
@@ -1141,7 +1141,7 @@ void UI::Render(VertexBuffer* buffer, const PODVector<UIBatch>& batches, unsigne
     }
 }
 
-void UI::GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, UIElement* element, IntRect currentScissor)
+void UI::GetBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, UIElement* element, IntRect currentScissor)
 {
     // Set clipping scissor for child elements. No need to draw if zero size
     element->AdjustScissor(currentScissor);
@@ -1315,7 +1315,7 @@ void UI::ReleaseFontFaces()
 {
     URHO3D_LOGDEBUG("Reloading font faces");
 
-    PODVector<Font*> fonts;
+    Vector<Font*> fonts;
     GetSubsystem<ResourceCache>()->GetResources<Font>(fonts);
 
     for (unsigned i = 0; i < fonts.Size(); ++i)
@@ -1973,7 +1973,7 @@ void UI::HandleKeyDown(StringHash eventType, VariantMap& eventData)
             if (topLevel)
             {
                 topLevel->GetChildren(tempElements_, true);
-                for (PODVector<UIElement*>::Iterator i = tempElements_.Begin(); i != tempElements_.End();)
+                for (Vector<UIElement*>::Iterator i = tempElements_.Begin(); i != tempElements_.End();)
                 {
                     if ((*i)->GetFocusMode() < FM_FOCUSABLE)
                         i = tempElements_.Erase(i);

--- a/Source/Urho3D/UI/UI.h
+++ b/Source/Urho3D/UI/UI.h
@@ -164,6 +164,7 @@ public:
     /// @property
     UIElement* GetFrontElement() const;
     /// Return currently dragged elements.
+    /// @nobindtemp
     const Vector<UIElement*> GetDragElements();
 
     /// Return the number of currently dragged elements.
@@ -274,15 +275,15 @@ private:
         /// Texture that UIElement will be rendered into.
         SharedPtr<Texture2D> texture_;
         /// UI rendering batches.
-        PODVector<UIBatch> batches_;
+        Vector<UIBatch> batches_;
         /// UI rendering vertex data.
-        PODVector<float> vertexData_;
+        Vector<float> vertexData_;
         /// UI vertex buffer.
         SharedPtr<VertexBuffer> vertexBuffer_;
         /// UI rendering batches for debug draw.
-        PODVector<UIBatch> debugDrawBatches_;
+        Vector<UIBatch> debugDrawBatches_;
         /// UI rendering vertex data for debug draw.
-        PODVector<float> debugVertexData_;
+        Vector<float> debugVertexData_;
         /// UI debug geometry vertex buffer.
         SharedPtr<VertexBuffer> debugVertexBuffer_;
     };
@@ -292,11 +293,11 @@ private:
     /// Update UI element logic recursively.
     void Update(float timeStep, UIElement* element);
     /// Upload UI geometry into a vertex buffer.
-    void SetVertexData(VertexBuffer* dest, const PODVector<float>& vertexData);
+    void SetVertexData(VertexBuffer* dest, const Vector<float>& vertexData);
     /// Render UI batches to the current rendertarget. Geometry must have been uploaded first.
-    void Render(VertexBuffer* buffer, const PODVector<UIBatch>& batches, unsigned batchStart, unsigned batchEnd);
+    void Render(VertexBuffer* buffer, const Vector<UIBatch>& batches, unsigned batchStart, unsigned batchEnd);
     /// Generate batches from an UI element recursively. Skip the cursor element.
-    void GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, UIElement* element, IntRect currentScissor);
+    void GetBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, UIElement* element, IntRect currentScissor);
     /// Return UI element at global screen coordinates. Return position converted to element's screen coordinates.
     UIElement* GetElementAt(const IntVector2& position, bool enabledOnly, IntVector2* elementScreenPosition);
     /// Return UI element at screen position recursively.
@@ -380,19 +381,19 @@ private:
     /// Currently focused element.
     WeakPtr<UIElement> focusElement_;
     /// UI rendering batches.
-    PODVector<UIBatch> batches_;
+    Vector<UIBatch> batches_;
     /// UI rendering vertex data.
-    PODVector<float> vertexData_;
+    Vector<float> vertexData_;
     /// UI rendering batches for debug draw.
-    PODVector<UIBatch> debugDrawBatches_;
+    Vector<UIBatch> debugDrawBatches_;
     /// UI rendering vertex data for debug draw.
-    PODVector<float> debugVertexData_;
+    Vector<float> debugVertexData_;
     /// UI vertex buffer.
     SharedPtr<VertexBuffer> vertexBuffer_;
     /// UI debug geometry vertex buffer.
     SharedPtr<VertexBuffer> debugVertexBuffer_;
     /// UI element query vector.
-    PODVector<UIElement*> tempElements_;
+    Vector<UIElement*> tempElements_;
     /// Clipboard text.
     mutable String clipBoard_;
     /// Seconds between clicks to register a double click.

--- a/Source/Urho3D/UI/UIBatch.cpp
+++ b/Source/Urho3D/UI/UIBatch.cpp
@@ -19,7 +19,7 @@ UIBatch::UIBatch()
     SetDefaultColor();
 }
 
-UIBatch::UIBatch(UIElement* element, BlendMode blendMode, const IntRect& scissor, Texture* texture, PODVector<float>* vertexData) :     // NOLINT(modernize-pass-by-value)
+UIBatch::UIBatch(UIElement* element, BlendMode blendMode, const IntRect& scissor, Texture* texture, Vector<float>* vertexData) :     // NOLINT(modernize-pass-by-value)
     element_(element),
     blendMode_(blendMode),
     scissor_(scissor),
@@ -419,7 +419,7 @@ unsigned UIBatch::GetInterpolatedColor(float x, float y)
     }
 }
 
-void UIBatch::AddOrMerge(const UIBatch& batch, PODVector<UIBatch>& batches)
+void UIBatch::AddOrMerge(const UIBatch& batch, Vector<UIBatch>& batches)
 {
     if (batch.vertexEnd_ == batch.vertexStart_)
         return;

--- a/Source/Urho3D/UI/UIBatch.h
+++ b/Source/Urho3D/UI/UIBatch.h
@@ -26,7 +26,7 @@ public:
     /// Construct with defaults.
     UIBatch();
     /// Construct.
-    UIBatch(UIElement* element, BlendMode blendMode, const IntRect& scissor, Texture* texture, PODVector<float>* vertexData);
+    UIBatch(UIElement* element, BlendMode blendMode, const IntRect& scissor, Texture* texture, Vector<float>* vertexData);
 
     /// Set new color for the batch. Overrides gradient.
     void SetColor(const Color& color, bool overrideAlpha = false);
@@ -52,7 +52,7 @@ public:
     unsigned GetInterpolatedColor(float x, float y);
 
     /// Add or merge a batch.
-    static void AddOrMerge(const UIBatch& batch, PODVector<UIBatch>& batches);
+    static void AddOrMerge(const UIBatch& batch, Vector<UIBatch>& batches);
 
     /// Element this batch represents.
     UIElement* element_{};
@@ -65,7 +65,7 @@ public:
     /// Inverse texture size.
     Vector2 invTextureSize_{Vector2::ONE};
     /// Vertex data.
-    PODVector<float>* vertexData_{};
+    Vector<float>* vertexData_{};
     /// Vertex data start index.
     unsigned vertexStart_{};
     /// Vertex data end index.

--- a/Source/Urho3D/UI/UIComponent.cpp
+++ b/Source/Urho3D/UI/UIComponent.cpp
@@ -100,7 +100,7 @@ public:
         pos = ui->ConvertUIToSystem(screenPos);
 
         Ray ray(camera->GetScreenRay((float)pos.x_ / rect.Width(), (float)pos.y_ / rect.Height()));
-        PODVector<RayQueryResult> queryResultVector;
+        Vector<RayQueryResult> queryResultVector;
         RayOctreeQuery query(queryResultVector, ray, RAY_TRIANGLE_UV, M_INFINITY, DRAWABLE_GEOMETRY, DEFAULT_VIEWMASK);
 
         octree->Raycast(query);

--- a/Source/Urho3D/UI/UIElement.cpp
+++ b/Source/Urho3D/UI/UIElement.cpp
@@ -321,13 +321,13 @@ void UIElement::Update(float timeStep)
 {
 }
 
-void UIElement::GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect& currentScissor)
+void UIElement::GetBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor)
 {
     // Reset hovering for next frame
     hovering_ = false;
 }
 
-void UIElement::GetDebugDrawBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect& currentScissor)
+void UIElement::GetDebugDrawBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor)
 {
     UIBatch batch(this, BLEND_ALPHA, currentScissor, nullptr, &vertexData);
 
@@ -1081,11 +1081,11 @@ void UIElement::UpdateLayout()
     // Prevent further updates while this update happens
     DisableLayoutUpdate();
 
-    PODVector<int> positions;
-    PODVector<int> sizes;
-    PODVector<int> minSizes;
-    PODVector<int> maxSizes;
-    PODVector<float> flexScales;
+    Vector<int> positions;
+    Vector<int> sizes;
+    Vector<int> minSizes;
+    Vector<int> maxSizes;
+    Vector<float> flexScales;
 
     int baseIndentWidth = GetIndentWidth();
 
@@ -1574,7 +1574,7 @@ XMLFile* UIElement::GetDefaultStyle(bool recursiveUp) const
         return defaultStyle_;
 }
 
-void UIElement::GetChildren(PODVector<UIElement*>& dest, bool recursive) const
+void UIElement::GetChildren(Vector<UIElement*>& dest, bool recursive) const
 {
     dest.Clear();
 
@@ -1588,9 +1588,9 @@ void UIElement::GetChildren(PODVector<UIElement*>& dest, bool recursive) const
         GetChildrenRecursive(dest);
 }
 
-PODVector<UIElement*> UIElement::GetChildren(bool recursive) const
+Vector<UIElement*> UIElement::GetChildren(bool recursive) const
 {
-    PODVector<UIElement*> dest;
+    Vector<UIElement*> dest;
     GetChildren(dest, recursive);
     return dest;
 }
@@ -1684,7 +1684,7 @@ bool UIElement::HasTag(const String& tag) const
     return tags_.Contains(tag);
 }
 
-void UIElement::GetChildrenWithTag(PODVector<UIElement*>& dest, const String& tag, bool recursive) const
+void UIElement::GetChildrenWithTag(Vector<UIElement*>& dest, const String& tag, bool recursive) const
 {
     dest.Clear();
 
@@ -1701,14 +1701,14 @@ void UIElement::GetChildrenWithTag(PODVector<UIElement*>& dest, const String& ta
         GetChildrenWithTagRecursive(dest, tag);
 }
 
-PODVector<UIElement*> UIElement::GetChildrenWithTag(const String& tag, bool recursive) const
+Vector<UIElement*> UIElement::GetChildrenWithTag(const String& tag, bool recursive) const
 {
-    PODVector<UIElement*> dest;
+    Vector<UIElement*> dest;
     GetChildrenWithTag(dest, tag, recursive);
     return dest;
 }
 
-void UIElement::GetChildrenWithTagRecursive(PODVector<UIElement*>& dest, const String& tag) const
+void UIElement::GetChildrenWithTagRecursive(Vector<UIElement*>& dest, const String& tag) const
 {
     for (Vector<SharedPtr<UIElement>>::ConstIterator i = children_.Begin(); i != children_.End(); ++i)
     {
@@ -1809,7 +1809,7 @@ void UIElement::AdjustScissor(IntRect& currentScissor)
     }
 }
 
-void UIElement::GetBatchesWithOffset(IntVector2& offset, PODVector<UIBatch>& batches, PODVector<float>& vertexData,
+void UIElement::GetBatchesWithOffset(IntVector2& offset, Vector<UIBatch>& batches, Vector<float>& vertexData,
     IntRect currentScissor)
 {
     Vector2 floatOffset((float)offset.x_, (float)offset.y_);
@@ -2032,7 +2032,7 @@ void UIElement::UpdateAnchoring()
     }
 }
 
-void UIElement::GetChildrenRecursive(PODVector<UIElement*>& dest) const
+void UIElement::GetChildrenRecursive(Vector<UIElement*>& dest) const
 {
     for (Vector<SharedPtr<UIElement>>::ConstIterator i = children_.Begin(); i != children_.End(); ++i)
     {
@@ -2054,7 +2054,7 @@ void UIElement::ApplyStyleRecursive(UIElement* element)
     }
 }
 
-int UIElement::CalculateLayoutParentSize(const PODVector<int>& sizes, int begin, int end, int spacing)
+int UIElement::CalculateLayoutParentSize(const Vector<int>& sizes, int begin, int end, int spacing)
 {
     int width = begin + end;
     if (sizes.Empty())
@@ -2071,8 +2071,8 @@ int UIElement::CalculateLayoutParentSize(const PODVector<int>& sizes, int begin,
     return width - spacing;
 }
 
-void UIElement::CalculateLayout(PODVector<int>& positions, PODVector<int>& sizes, const PODVector<int>& minSizes,
-    const PODVector<int>& maxSizes, const PODVector<float>& flexScales, int targetSize, int begin, int end, int spacing)
+void UIElement::CalculateLayout(Vector<int>& positions, Vector<int>& sizes, const Vector<int>& minSizes,
+    const Vector<int>& maxSizes, const Vector<float>& flexScales, int targetSize, int begin, int end, int spacing)
 {
     unsigned numChildren = sizes.Size();
     if (!numChildren)
@@ -2114,7 +2114,7 @@ void UIElement::CalculateLayout(PODVector<int>& positions, PODVector<int>& sizes
             break;
 
         // Check which of the children can be resized to correct the error. If none, must break
-        PODVector<unsigned> resizable;
+        Vector<unsigned> resizable;
         for (unsigned i = 0; i < numChildren; ++i)
         {
             if (error < 0 && sizes[i] > minSizes[i])

--- a/Source/Urho3D/UI/UIElement.h
+++ b/Source/Urho3D/UI/UIElement.h
@@ -132,9 +132,9 @@ public:
     /// @property
     virtual const IntVector2& GetScreenPosition() const;
     /// Return UI rendering batches.
-    virtual void GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect& currentScissor);
+    virtual void GetBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor);
     /// Return UI rendering batches for debug draw.
-    virtual void GetDebugDrawBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect& currentScissor);
+    virtual void GetDebugDrawBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor);
     /// React to mouse hover.
     virtual void OnHover(const IntVector2& position, const IntVector2& screenPosition, MouseButtonFlags buttons, QualifierFlags qualifiers, Cursor* cursor);
     /// React to mouse click begin.
@@ -650,10 +650,10 @@ public:
     const Vector<SharedPtr<UIElement>>& GetChildren() const { return children_; }
 
     /// Return child elements either recursively or non-recursively.
-    void GetChildren(PODVector<UIElement*>& dest, bool recursive = false) const;
+    void GetChildren(Vector<UIElement*>& dest, bool recursive = false) const;
 
     /// Return child elements, optionally recursive.
-    PODVector<UIElement*> GetChildren(bool recursive) const;
+    Vector<UIElement*> GetChildren(bool recursive) const;
 
     /// Return parent element.
     /// @property
@@ -678,10 +678,10 @@ public:
     const StringVector& GetTags() const { return tags_; }
 
     /// Return child elements with a specific tag either recursively or non-recursively.
-    void GetChildrenWithTag(PODVector<UIElement*>& dest, const String& tag, bool recursive = false) const;
+    void GetChildrenWithTag(Vector<UIElement*>& dest, const String& tag, bool recursive = false) const;
 
     /// Return child elements with a specific tag either recursively or non-recursively.
-    PODVector<UIElement*> GetChildrenWithTag(const String& tag, bool recursive = false) const;
+    Vector<UIElement*> GetChildrenWithTag(const String& tag, bool recursive = false) const;
 
     /// Return the drag button combo if this element is being dragged.
     /// @property
@@ -723,7 +723,7 @@ public:
     /// Adjust scissor for rendering.
     void AdjustScissor(IntRect& currentScissor);
     /// Get UI rendering batches with a specified offset. Also recurse to child elements.
-    void GetBatchesWithOffset(IntVector2& offset, PODVector<UIBatch>& batches, PODVector<float>& vertexData, IntRect currentScissor);
+    void GetBatchesWithOffset(IntVector2& offset, Vector<UIBatch>& batches, Vector<float>& vertexData, IntRect currentScissor);
 
     /// Return color attribute. Uses just the top-left color.
     const Color& GetColorAttr() const { return colors_[0]; }
@@ -840,17 +840,17 @@ protected:
 
 private:
     /// Return child elements recursively.
-    void GetChildrenRecursive(PODVector<UIElement*>& dest) const;
+    void GetChildrenRecursive(Vector<UIElement*>& dest) const;
     /// Return child elements with a specific tag recursively.
-    void GetChildrenWithTagRecursive(PODVector<UIElement*>& dest, const String& tag) const;
+    void GetChildrenWithTagRecursive(Vector<UIElement*>& dest, const String& tag) const;
     /// Recursively apply style to a child element hierarchy when adding to an element.
     void ApplyStyleRecursive(UIElement* element);
     /// Calculate layout width for resizing the parent element.
-    int CalculateLayoutParentSize(const PODVector<int>& sizes, int begin, int end, int spacing);
+    int CalculateLayoutParentSize(const Vector<int>& sizes, int begin, int end, int spacing);
     /// Calculate child widths/positions in the layout.
     void CalculateLayout
-        (PODVector<int>& positions, PODVector<int>& sizes, const PODVector<int>& minSizes, const PODVector<int>& maxSizes,
-            const PODVector<float>& flexScales, int targetSize, int begin, int end, int spacing);
+        (Vector<int>& positions, Vector<int>& sizes, const Vector<int>& minSizes, const Vector<int>& maxSizes,
+            const Vector<float>& flexScales, int targetSize, int begin, int end, int spacing);
     /// Get child element constant position in a layout.
     IntVector2 GetLayoutChildPosition(UIElement* child);
     /// Detach from parent.

--- a/Source/Urho3D/UI/UISelectable.cpp
+++ b/Source/Urho3D/UI/UISelectable.cpp
@@ -20,7 +20,7 @@ void UISelectable::RegisterObject(Context* context)
     URHO3D_ATTRIBUTE("Hover Color", Color, hoverColor_, Color::TRANSPARENT_BLACK, AM_FILE);
 }
 
-void UISelectable::GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect & currentScissor)
+void UISelectable::GetBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect & currentScissor)
 {
     // Hovering and/or whole selection batch
     if ((hovering_ && hoverColor_.a_ > 0.0) || (selected_ && selectionColor_.a_ > 0.0f))

--- a/Source/Urho3D/UI/UISelectable.h
+++ b/Source/Urho3D/UI/UISelectable.h
@@ -24,7 +24,7 @@ public:
     static void RegisterObject(Context* context);
 
     /// Return UI rendering batches.
-    void GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect& currentScissor) override;
+    void GetBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor) override;
 
     /// Set selection background color. Color with 0 alpha (default) disables.
     /// @property

--- a/Source/Urho3D/UI/Window.cpp
+++ b/Source/Urho3D/UI/Window.cpp
@@ -62,7 +62,7 @@ void Window::RegisterObject(Context* context)
     // Instead it should be set false in code when needed
 }
 
-void Window::GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect& currentScissor)
+void Window::GetBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor)
 {
     if (modal_)
     {

--- a/Source/Urho3D/UI/Window.h
+++ b/Source/Urho3D/UI/Window.h
@@ -40,7 +40,7 @@ public:
     static void RegisterObject(Context* context);
 
     /// Return UI rendering batches.
-    void GetBatches(PODVector<UIBatch>& batches, PODVector<float>& vertexData, const IntRect& currentScissor) override;
+    void GetBatches(Vector<UIBatch>& batches, Vector<float>& vertexData, const IntRect& currentScissor) override;
 
     /// React to mouse hover.
     void OnHover(const IntVector2& position, const IntVector2& screenPosition, MouseButtonFlags buttons, QualifierFlags qualifiers, Cursor* cursor) override;

--- a/Source/Urho3D/Urho2D/AnimatedSprite2D.cpp
+++ b/Source/Urho3D/Urho2D/AnimatedSprite2D.cpp
@@ -417,7 +417,7 @@ void AnimatedSprite2D::UpdateSourceBatchesSpriter()
     Vertex2D vertex2;
     Vertex2D vertex3;
 
-    const PODVector<Spriter::SpatialTimelineKey*>& timelineKeys = spriterInstance_->GetTimelineKeys();
+    const Vector<Spriter::SpatialTimelineKey*>& timelineKeys = spriterInstance_->GetTimelineKeys();
     for (unsigned i = 0; i < timelineKeys.Size(); ++i)
     {
         if (timelineKeys[i]->GetObjectType() != Spriter::SPRITE)

--- a/Source/Urho3D/Urho2D/AnimationSet2D.cpp
+++ b/Source/Urho3D/Urho2D/AnimationSet2D.cpp
@@ -176,7 +176,7 @@ bool AnimationSet2D::HasAnimation(const String& animationName) const
 #endif
     if (spriterData_ && !spriterData_->entities_.Empty())
     {
-        const PODVector<Spriter::Animation*>& animations = spriterData_->entities_[0]->animations_;
+        const Vector<Spriter::Animation*>& animations = spriterData_->entities_[0]->animations_;
         for (unsigned i = 0; i < animations.Size(); ++i)
         {
             if (animationName == animations[i]->name_)

--- a/Source/Urho3D/Urho2D/Renderer2D.cpp
+++ b/Source/Urho3D/Urho2D/Renderer2D.cpp
@@ -82,7 +82,7 @@ static inline bool CompareRayQueryResults(RayQueryResult& lr, RayQueryResult& rr
     return lhs->GetID() > rhs->GetID();
 }
 
-void Renderer2D::ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQueryResult>& results)
+void Renderer2D::ProcessRayQuery(const RayOctreeQuery& query, Vector<RayQueryResult>& results)
 {
     unsigned resultSize = results.Size();
     for (unsigned i = 0; i < drawables_.Size(); ++i)
@@ -181,7 +181,7 @@ void Renderer2D::UpdateGeometry(const FrameInfo& frame)
             auto* dest = reinterpret_cast<Vertex2D*>(vertexBuffer->Lock(0, vertexCount, true));
             if (dest)
             {
-                const PODVector<const SourceBatch2D*>& sourceBatches = viewBatchInfo.sourceBatches_;
+                const Vector<const SourceBatch2D*>& sourceBatches = viewBatchInfo.sourceBatches_;
                 for (unsigned b = 0; b < sourceBatches.Size(); ++b)
                 {
                     const Vector<Vertex2D>& vertices = sourceBatches[b]->vertices_;
@@ -322,7 +322,7 @@ void Renderer2D::HandleBeginViewUpdate(StringHash eventType, VariantMap& eventDa
         int numWorkItems = queue->GetNumThreads() + 1; // Worker threads + main thread
         int drawablesPerItem = drawables_.Size() / numWorkItems;
 
-        PODVector<Drawable2D*>::Iterator start = drawables_.Begin();
+        Vector<Drawable2D*>::Iterator start = drawables_.Begin();
         for (int i = 0; i < numWorkItems; ++i)
         {
             SharedPtr<WorkItem> item = queue->GetFreeItem();
@@ -330,7 +330,7 @@ void Renderer2D::HandleBeginViewUpdate(StringHash eventType, VariantMap& eventDa
             item->workFunction_ = CheckDrawableVisibilityWork;
             item->aux_ = this;
 
-            PODVector<Drawable2D*>::Iterator end = drawables_.End();
+            Vector<Drawable2D*>::Iterator end = drawables_.End();
             if (i < numWorkItems - 1 && end - start > drawablesPerItem)
                 end = start + drawablesPerItem;
 
@@ -365,7 +365,7 @@ void Renderer2D::HandleBeginViewUpdate(StringHash eventType, VariantMap& eventDa
     }
 }
 
-void Renderer2D::GetDrawables(PODVector<Drawable2D*>& drawables, Node* node)
+void Renderer2D::GetDrawables(Vector<Drawable2D*>& drawables, Node* node)
 {
     if (!node || !node->IsEnabled())
         return;
@@ -403,7 +403,7 @@ void Renderer2D::UpdateViewBatchInfo(ViewBatchInfo2D& viewBatchInfo, Camera* cam
     if (viewBatchInfo.batchUpdatedFrameNumber_ == frame_.frameNumber_)
         return;
 
-    PODVector<const SourceBatch2D*>& sourceBatches = viewBatchInfo.sourceBatches_;
+    Vector<const SourceBatch2D*>& sourceBatches = viewBatchInfo.sourceBatches_;
     sourceBatches.Clear();
     for (unsigned d = 0; d < drawables_.Size(); ++d)
     {

--- a/Source/Urho3D/Urho2D/Renderer2D.h
+++ b/Source/Urho3D/Urho2D/Renderer2D.h
@@ -35,11 +35,11 @@ struct ViewBatchInfo2D
     /// Batch updated frame number.
     unsigned batchUpdatedFrameNumber_;
     /// Source batches.
-    PODVector<const SourceBatch2D*> sourceBatches_;
+    Vector<const SourceBatch2D*> sourceBatches_;
     /// Batch count.
     unsigned batchCount_;
     /// Distances.
-    PODVector<float> distances_;
+    Vector<float> distances_;
     /// Materials.
     Vector<SharedPtr<Material>> materials_;
     /// Geometries.
@@ -63,7 +63,7 @@ public:
     static void RegisterObject(Context* context);
 
     /// Process octree raycast. May be called from a worker thread.
-    void ProcessRayQuery(const RayOctreeQuery& query, PODVector<RayQueryResult>& results) override;
+    void ProcessRayQuery(const RayOctreeQuery& query, Vector<RayQueryResult>& results) override;
     /// Calculate distance and prepare batches for rendering. May be called from worker thread(s), possibly re-entrantly.
     void UpdateBatches(const FrameInfo& frame) override;
     /// Prepare geometry for rendering. Called from a worker thread if possible (no GPU update).
@@ -89,7 +89,7 @@ private:
     /// Handle view update begin event. Determine Drawable2D's and their batches here.
     void HandleBeginViewUpdate(StringHash eventType, VariantMap& eventData);
     /// Get all drawables in node.
-    void GetDrawables(PODVector<Drawable2D*>& drawables, Node* node);
+    void GetDrawables(Vector<Drawable2D*>& drawables, Node* node);
     /// Update view batch info.
     void UpdateViewBatchInfo(ViewBatchInfo2D& viewBatchInfo, Camera* camera);
     /// Add view batch.
@@ -101,7 +101,7 @@ private:
     /// Material.
     SharedPtr<Material> material_;
     /// Drawables.
-    PODVector<Drawable2D*> drawables_;
+    Vector<Drawable2D*> drawables_;
     /// View frame info for current frame.
     FrameInfo frame_;
     /// View batch info.

--- a/Source/Urho3D/Urho2D/SpriterData2D.h
+++ b/Source/Urho3D/Urho2D/SpriterData2D.h
@@ -45,8 +45,8 @@ struct SpriterData
     int scmlVersion_{};
     String generator_;
     String generatorVersion_;
-    PODVector<Folder*> folders_;
-    PODVector<Entity*> entities_;
+    Vector<Folder*> folders_;
+    Vector<Entity*> entities_;
 };
 
 /// Folder.
@@ -60,7 +60,7 @@ struct Folder
 
     int id_{};
     String name_;
-    PODVector<File*> files_;
+    Vector<File*> files_;
 };
 
 /// File.
@@ -91,8 +91,8 @@ struct Entity
 
     int id_{};
     String name_;
-    PODVector<CharacterMap*> characterMaps_;
-    PODVector<Animation*> animations_;
+    Vector<CharacterMap*> characterMaps_;
+    Vector<Animation*> animations_;
 };
 
 /// Character map.
@@ -106,7 +106,7 @@ struct CharacterMap
 
     int id_{};
     String name_;
-    PODVector<MapInstruction*> maps_;
+    Vector<MapInstruction*> maps_;
 };
 
 /// Map instruction.
@@ -136,8 +136,8 @@ struct Animation
     String name_;
     float length_{};
     bool looping_{};
-    PODVector<MainlineKey*> mainlineKeys_;
-    PODVector<Timeline*> timelines_;
+    Vector<MainlineKey*> mainlineKeys_;
+    Vector<Timeline*> timelines_;
 };
 
 /// Mainline key.
@@ -151,8 +151,8 @@ struct MainlineKey
 
     int id_{};
     float time_{};
-    PODVector<Ref*> boneRefs_;
-    PODVector<Ref*> objectRefs_;
+    Vector<Ref*> boneRefs_;
+    Vector<Ref*> objectRefs_;
 };
 
 /// Ref.
@@ -189,7 +189,7 @@ struct Timeline
     int id_{};
     String name_;
     ObjectType objectType_;
-    PODVector<SpatialTimelineKey*> keys_;
+    Vector<SpatialTimelineKey*> keys_;
 };
 
 /// Curve type.

--- a/Source/Urho3D/Urho2D/SpriterInstance2D.cpp
+++ b/Source/Urho3D/Urho2D/SpriterInstance2D.cpp
@@ -218,7 +218,7 @@ void SpriterInstance::UpdateTimelineKeys()
 
 void SpriterInstance::UpdateMainlineKey()
 {
-    const PODVector<MainlineKey*>& mainlineKeys = animation_->mainlineKeys_;
+    const Vector<MainlineKey*>& mainlineKeys = animation_->mainlineKeys_;
     for (unsigned i = 0; i < mainlineKeys.Size(); ++i)
     {
         if (mainlineKeys[i]->time_ <= currentTime_)

--- a/Source/Urho3D/Urho2D/SpriterInstance2D.h
+++ b/Source/Urho3D/Urho2D/SpriterInstance2D.h
@@ -54,7 +54,7 @@ public:
     /// Return root spatial info.
     const SpatialInfo& GetSpatialInfo() const { return spatialInfo_; }
     /// Return animation result timeline keys.
-    const PODVector<SpatialTimelineKey*>& GetTimelineKeys() const { return timelineKeys_; }
+    const Vector<SpatialTimelineKey*>& GetTimelineKeys() const { return timelineKeys_; }
 
 private:
     /// Handle set entity.
@@ -87,7 +87,7 @@ private:
     /// Current mainline key.
     MainlineKey* mainlineKey_{};
     /// Current timeline keys.
-    PODVector<SpatialTimelineKey*> timelineKeys_;
+    Vector<SpatialTimelineKey*> timelineKeys_;
 };
 
 }

--- a/Source/Urho3D/Urho2D/TmxFile2D.cpp
+++ b/Source/Urho3D/Urho2D/TmxFile2D.cpp
@@ -165,7 +165,7 @@ bool TmxTileLayer2D::Load(const XMLElement& element, const TileMapInfo2D& info)
         while (!IsAlpha(dataValue[startPosition]) && !IsDigit(dataValue[startPosition])
               && dataValue[startPosition] != '+' && dataValue[startPosition] != '/') ++startPosition;
         dataValue = dataValue.Substring(startPosition);
-        PODVector<unsigned char> buffer = DecodeBase64(dataValue);
+        Vector<unsigned char> buffer = DecodeBase64(dataValue);
         int currentIndex = 0;
         for (int y = 0; y < height_; ++y)
         {


### PR DESCRIPTION
After https://github.com/urho3d/Urho3D/pull/2872 PODVector is just alias for Vector.

```
template <typename T> using PODVector = Vector<T>;
```

This alias has been retained for backwards compatibility. Since backwards compatibility is already broken, it's time to get rid of it.