### PR TITLE
Forward Declare Node

### DIFF
--- a/Source/Urho3D/Graphics/AnimationState.h
+++ b/Source/Urho3D/Graphics/AnimationState.h
@@ -14,6 +14,7 @@ namespace Urho3D
 class Animation;
 class AnimatedModel;
 class Deserializer;
+class Node;
 class Serializer;
 class Skeleton;
 struct AnimationTrack;


### PR DESCRIPTION
Node is used in line 45 but has no forward declaration.
```
    /// Scene node pointer.
    WeakPtr<Node> node_;
```