### PR TITLE
Include Variant.h from RenderPath.h

### DIFF
--- a/Source/Urho3D/Graphics/RenderPath.h
+++ b/Source/Urho3D/Graphics/RenderPath.h
@@ -7,6 +7,7 @@
 
 #include "../Container/Ptr.h"
 #include "../Container/RefCounted.h"
+#include "../Core/Variant.h"
 #include "../GraphicsAPI/GraphicsDefs.h"
 #include "../Math/Color.h"
 #include "../Math/Vector4.h"


### PR DESCRIPTION
The full definition seems to be needed for `HashMap<StringHash, Variant> shaderParameters_;` and not just a (not present) forward declaration.