### PR TITLE
Include GraphicsDefs.h in Shader.h

### DIFF
--- a/Source/Urho3D/GraphicsAPI/Shader.h
+++ b/Source/Urho3D/GraphicsAPI/Shader.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../Container/ArrayPtr.h"
+#include "../GraphicsAPI/GraphicsDefs.h"
 #include "../Resource/Resource.h"
 
 namespace Urho3D


### PR DESCRIPTION
Needed for the definition of the ShaderType enum.