### PR TITLE
Log::WriteFormat fails for LOG_RAW

### DIFF
--- a/Source/Urho3D/IO/Log.cpp
+++ b/Source/Urho3D/IO/Log.cpp
@@ -119,9 +119,15 @@ void Log::SetQuiet(bool quiet)
 
 void Log::WriteFormat(int level, const char* format, ...)
 {
-    // No-op if illegal level
-    if (!logInstance || (logInstance->level_ > level && level != LOG_RAW) || level >= LOG_NONE)
+    if (!logInstance)
         return;
+
+    if (level != LOG_RAW)
+    {
+        // No-op if illegal level
+        if (level < LOG_TRACE || level >= LOG_NONE || logInstance->level_ > level)
+            return;
+    }
 
     // Forward to normal Write() after formatting the input
     String message;
@@ -129,7 +135,7 @@ void Log::WriteFormat(int level, const char* format, ...)
     va_start(args, format);
     message.AppendWithFormatArgs(format, args);
     va_end(args);
-    
+
     Write(level, message);
 }
 

--- a/Source/Urho3D/IO/Log.cpp
+++ b/Source/Urho3D/IO/Log.cpp
@@ -119,7 +119,8 @@ void Log::SetQuiet(bool quiet)
 
 void Log::WriteFormat(int level, const char* format, ...)
 {
-    if (!logInstance || logInstance->level_ > level)
+    // No-op if illegal level
+    if (!logInstance || (logInstance->level_ > level && level != LOG_RAW) || level >= LOG_NONE)
         return;
 
     // Forward to normal Write() after formatting the input
@@ -128,7 +129,7 @@ void Log::WriteFormat(int level, const char* format, ...)
     va_start(args, format);
     message.AppendWithFormatArgs(format, args);
     va_end(args);
-
+    
     Write(level, message);
 }
 


### PR DESCRIPTION
Adds special case in Log::WriteFormat for LOG_RAW to match the behavior of Log::Write.

The introduction of WriteFormat in #2685 left LOG_RAW messages unprinted (messages like those produced by LuaScript::Print). Another alternate fix, though it would leave WriteFormat and Write with inconsistent behaviors, would be to return the URHO3D_LOGRAWF and URHO3D_LOGRAW macros to their old definitions from before #2685.