### PR TITLE
Remove half-pixel offsets | Remove unused D3D9 code from shaders

### DIFF
--- a/Source/Urho3D/AngelScript/Generated_Members.h
+++ b/Source/Urho3D/AngelScript/Generated_Members.h
@@ -5495,9 +5495,6 @@ template <class T> void RegisterMembers_UIBatch(asIScriptEngine* engine, const c
     // bool UIBatch::useGradient_
     engine->RegisterObjectProperty(className, "bool useGradient", offsetof(T, useGradient_));
 
-    // static Vector3 UIBatch::posAdjust
-    engine->SetDefaultNamespace(className);engine->RegisterGlobalProperty("Vector3 posAdjust", (void*)&T::posAdjust);engine->SetDefaultNamespace("");
-
     #ifdef REGISTER_MEMBERS_MANUAL_PART_UIBatch
         REGISTER_MEMBERS_MANUAL_PART_UIBatch();
     #endif
@@ -10604,9 +10601,6 @@ template <class T> void RegisterMembers_Graphics(asIScriptEngine* engine, const 
 
     // static unsigned Graphics::GetFormat(const String& formatName)
     engine->SetDefaultNamespace(className);engine->RegisterGlobalFunction("uint GetFormat(const String&in)", AS_FUNCTIONPR(T::GetFormat, (const String&), unsigned), AS_CALL_CDECL);engine->SetDefaultNamespace("");
-
-    // static const Vector2& Graphics::GetPixelUVOffset()
-    engine->SetDefaultNamespace(className);engine->RegisterGlobalFunction("const Vector2& GetPixelUVOffset()", AS_FUNCTIONPR(T::GetPixelUVOffset, (), const Vector2&), AS_CALL_CDECL);engine->SetDefaultNamespace("");
 
     // static unsigned Graphics::GetMaxBones()
     engine->SetDefaultNamespace(className);engine->RegisterGlobalFunction("uint GetMaxBones()", AS_FUNCTIONPR(T::GetMaxBones, (), unsigned), AS_CALL_CDECL);engine->SetDefaultNamespace("");

--- a/Source/Urho3D/Graphics/Batch.cpp
+++ b/Source/Urho3D/Graphics/Batch.cpp
@@ -89,10 +89,8 @@ void CalculateShadowMatrix(Matrix4& dest, LightBatchQueue* queue, unsigned split
         1.0f
     );
 
-    // Add pixel-perfect offset if needed by the graphics API
-    const Vector2& pixelUVOffset = Graphics::GetPixelUVOffset();
-    offset.x_ += scale.x_ + pixelUVOffset.x_ / width;
-    offset.y_ += scale.y_ + pixelUVOffset.y_ / height;
+    offset.x_ += scale.x_;
+    offset.y_ += scale.y_;
 
     if (Graphics::GetGAPI() == GAPI_OPENGL)
     {

--- a/Source/Urho3D/Graphics/Graphics.h
+++ b/Source/Urho3D/Graphics/Graphics.h
@@ -719,9 +719,6 @@ public:
     /// Return the API-specific texture format from a textual description, for example "rgb".
     static unsigned GetFormat(const String& formatName);
 
-    /// Return UV offset required for pixel perfect rendering.
-    static const Vector2& GetPixelUVOffset() { return pixelUVOffset; }
-
     /// Return maximum number of supported bones for skinning.
     static unsigned GetMaxBones();
     /// Return whether is using an OpenGL 3 context. Return always false on Direct3D9 & Direct3D11.
@@ -1184,8 +1181,6 @@ private:
     /// Graphics API name.
     String apiName_;
 
-    /// Pixel perfect UV offset.
-    inline static Vector2 pixelUVOffset;
     /// OpenGL3 support flag.
     inline static bool gl3Support;
     /// Used graphics API.

--- a/Source/Urho3D/Graphics/View.cpp
+++ b/Source/Urho3D/Graphics/View.cpp
@@ -758,14 +758,13 @@ void View::SetGBufferShaderParameters(const IntVector2& texSize, const IntRect& 
 
     if (Graphics::GetGAPI() == GAPI_OPENGL)
     {
-        bufferUVOffset = Vector4(((float)viewRect.left_) / texWidth + widthRange,
-            1.0f - (((float)viewRect.top_) / texHeight + heightRange), widthRange, heightRange);
+        bufferUVOffset = Vector4((float)viewRect.left_ / texWidth + widthRange,
+            1.0f - ((float)viewRect.top_ / texHeight + heightRange), widthRange, heightRange);
     }
     else
     {
-        const Vector2& pixelUVOffset = Graphics::GetPixelUVOffset();
-        bufferUVOffset = Vector4((pixelUVOffset.x_ + (float)viewRect.left_) / texWidth + widthRange,
-            (pixelUVOffset.y_ + (float)viewRect.top_) / texHeight + heightRange, widthRange, heightRange);
+        bufferUVOffset = Vector4((float)viewRect.left_ / texWidth + widthRange,
+            (float)viewRect.top_ / texHeight + heightRange, widthRange, heightRange);
     }
 
     graphics_->SetShaderParameter(VSP_GBUFFEROFFSETS, bufferUVOffset);
@@ -1850,9 +1849,7 @@ void View::RenderQuad(RenderPathCommand& command)
         auto width = (float)renderTargets_[nameHash]->GetWidth();
         auto height = (float)renderTargets_[nameHash]->GetHeight();
 
-        const Vector2& pixelUVOffset = Graphics::GetPixelUVOffset();
         graphics_->SetShaderParameter(invSizeName, Vector2(1.0f / width, 1.0f / height));
-        graphics_->SetShaderParameter(offsetsName, Vector2(pixelUVOffset.x_ / width, pixelUVOffset.y_ / height));
     }
 
     // Set command's shader parameters last to allow them to override any of the above

--- a/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11Graphics.cpp
+++ b/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11Graphics.cpp
@@ -177,7 +177,6 @@ void Graphics::Constructor_D3D11()
     orientations_ = "LandscapeLeft LandscapeRight";
     apiName_ = "D3D11";
 
-    Graphics::pixelUVOffset = Vector2(0.0f, 0.0f);
     Graphics::gl3Support = false;
 
     SetTextureUnitMappings_D3D11();

--- a/Source/Urho3D/GraphicsAPI/OpenGL/OGLGraphics.cpp
+++ b/Source/Urho3D/GraphicsAPI/OpenGL/OGLGraphics.cpp
@@ -278,7 +278,6 @@ void Graphics::Constructor_OGL()
     apiName_ = "GLES2";
 #endif
 
-    Graphics::pixelUVOffset = Vector2(0.0f, 0.0f);
     Graphics::gl3Support = false;
 
     SetTextureUnitMappings_OGL();

--- a/Source/Urho3D/UI/UI.cpp
+++ b/Source/Urho3D/UI/UI.cpp
@@ -925,7 +925,6 @@ void UI::Initialize()
     URHO3D_PROFILE(InitUI);
 
     graphics_ = graphics;
-    UIBatch::posAdjust = Vector3(Graphics::GetPixelUVOffset(), 0.0f);
 
     // Set initial root element size
     ResizeRootElement();

--- a/Source/Urho3D/UI/UIBatch.cpp
+++ b/Source/Urho3D/UI/UIBatch.cpp
@@ -12,8 +12,6 @@
 namespace Urho3D
 {
 
-Vector3 UIBatch::posAdjust(0.0f, 0.0f, 0.0f);
-
 UIBatch::UIBatch()
 {
     SetDefaultColor();
@@ -81,9 +79,9 @@ void UIBatch::AddQuad(float x, float y, float width, float height, int texOffset
 
     const IntVector2& screenPos = element_->GetScreenPosition();
 
-    float left = x + screenPos.x_ - posAdjust.x_;
+    float left = x + screenPos.x_;
     float right = left + width;
-    float top = y + screenPos.y_ - posAdjust.x_;
+    float top = y + screenPos.y_;
     float bottom = top + height;
 
     float leftUV = texOffsetX * invTextureSize_.x_;
@@ -163,10 +161,10 @@ void UIBatch::AddQuad(const Matrix3x4& transform, int x, int y, int width, int h
         bottomRightColor = GetInterpolatedColor(x + width, y + height);
     }
 
-    Vector3 v1 = (transform * Vector3((float)x, (float)y, 0.0f)) - posAdjust;
-    Vector3 v2 = (transform * Vector3((float)x + (float)width, (float)y, 0.0f)) - posAdjust;
-    Vector3 v3 = (transform * Vector3((float)x, (float)y + (float)height, 0.0f)) - posAdjust;
-    Vector3 v4 = (transform * Vector3((float)x + (float)width, (float)y + (float)height, 0.0f)) - posAdjust;
+    Vector3 v1 = (transform * Vector3((float)x, (float)y, 0.0f));
+    Vector3 v2 = (transform * Vector3((float)x + (float)width, (float)y, 0.0f));
+    Vector3 v3 = (transform * Vector3((float)x, (float)y + (float)height, 0.0f));
+    Vector3 v4 = (transform * Vector3((float)x + (float)width, (float)y + (float)height, 0.0f));
 
     float leftUV = ((float)texOffsetX) * invTextureSize_.x_;
     float topUV = ((float)texOffsetY) * invTextureSize_.y_;
@@ -258,10 +256,10 @@ void UIBatch::AddQuad(int x, int y, int width, int height, int texOffsetX, int t
 void UIBatch::AddQuad(const Matrix3x4& transform, const IntVector2& a, const IntVector2& b, const IntVector2& c, const IntVector2& d,
     const IntVector2& texA, const IntVector2& texB, const IntVector2& texC, const IntVector2& texD)
 {
-    Vector3 v1 = (transform * Vector3((float)a.x_, (float)a.y_, 0.0f)) - posAdjust;
-    Vector3 v2 = (transform * Vector3((float)b.x_, (float)b.y_, 0.0f)) - posAdjust;
-    Vector3 v3 = (transform * Vector3((float)c.x_, (float)c.y_, 0.0f)) - posAdjust;
-    Vector3 v4 = (transform * Vector3((float)d.x_, (float)d.y_, 0.0f)) - posAdjust;
+    Vector3 v1 = (transform * Vector3((float)a.x_, (float)a.y_, 0.0f));
+    Vector3 v2 = (transform * Vector3((float)b.x_, (float)b.y_, 0.0f));
+    Vector3 v3 = (transform * Vector3((float)c.x_, (float)c.y_, 0.0f));
+    Vector3 v4 = (transform * Vector3((float)d.x_, (float)d.y_, 0.0f));
 
     Vector2 uv1((float)texA.x_ * invTextureSize_.x_, (float)texA.y_ * invTextureSize_.y_);
     Vector2 uv2((float)texB.x_ * invTextureSize_.x_, (float)texB.y_ * invTextureSize_.y_);
@@ -320,10 +318,10 @@ void UIBatch::AddQuad(const Matrix3x4& transform, const IntVector2& a, const Int
     const IntVector2& texA, const IntVector2& texB, const IntVector2& texC, const IntVector2& texD, const Color& colA,
     const Color& colB, const Color& colC, const Color& colD)
 {
-    Vector3 v1 = (transform * Vector3((float)a.x_, (float)a.y_, 0.0f)) - posAdjust;
-    Vector3 v2 = (transform * Vector3((float)b.x_, (float)b.y_, 0.0f)) - posAdjust;
-    Vector3 v3 = (transform * Vector3((float)c.x_, (float)c.y_, 0.0f)) - posAdjust;
-    Vector3 v4 = (transform * Vector3((float)d.x_, (float)d.y_, 0.0f)) - posAdjust;
+    Vector3 v1 = (transform * Vector3((float)a.x_, (float)a.y_, 0.0f));
+    Vector3 v2 = (transform * Vector3((float)b.x_, (float)b.y_, 0.0f));
+    Vector3 v3 = (transform * Vector3((float)c.x_, (float)c.y_, 0.0f));
+    Vector3 v4 = (transform * Vector3((float)d.x_, (float)d.y_, 0.0f));
 
     Vector2 uv1((float)texA.x_ * invTextureSize_.x_, (float)texA.y_ * invTextureSize_.y_);
     Vector2 uv2((float)texB.x_ * invTextureSize_.x_, (float)texB.y_ * invTextureSize_.y_);

--- a/Source/Urho3D/UI/UIBatch.h
+++ b/Source/Urho3D/UI/UIBatch.h
@@ -92,9 +92,6 @@ public:
     bool useGradient_{};
     /// Custom material.
     Material* customMaterial_{};
-
-    /// Position adjustment vector for pixel-perfect rendering. Initialized by UI.
-    static Vector3 posAdjust;
 };
 
 }

--- a/bin/CoreData/Shaders/HLSL/AutoExposure.hlsl
+++ b/bin/CoreData/Shaders/HLSL/AutoExposure.hlsl
@@ -7,33 +7,18 @@
 uniform float cAutoExposureAdaptRate;
 uniform float2 cAutoExposureLumRange;
 uniform float cAutoExposureMiddleGrey;
-uniform float2 cHDR128Offsets;
-uniform float2 cLum64Offsets;
-uniform float2 cLum16Offsets;
-uniform float2 cLum4Offsets;
 uniform float2 cHDR128InvSize;
 uniform float2 cLum64InvSize;
 uniform float2 cLum16InvSize;
 uniform float2 cLum4InvSize;
 
-#ifndef D3D11
-float GatherAvgLum(sampler2D texSampler, float2 texCoord, float2 texelSize)
-#else
 float GatherAvgLum(Texture2D tex, SamplerState texSampler, float2 texCoord, float2 texelSize)
-#endif
 {
     float lumAvg = 0.0;
-    #ifndef D3D11
-    lumAvg += tex2D(texSampler, texCoord + float2(0.0, 0.0) * texelSize).r;
-    lumAvg += tex2D(texSampler, texCoord + float2(0.0, 2.0) * texelSize).r;
-    lumAvg += tex2D(texSampler, texCoord + float2(2.0, 2.0) * texelSize).r;
-    lumAvg += tex2D(texSampler, texCoord + float2(2.0, 0.0) * texelSize).r;
-    #else
     lumAvg += tex.Sample(texSampler, texCoord + float2(0.0, 0.0) * texelSize).r;
     lumAvg += tex.Sample(texSampler, texCoord + float2(0.0, 2.0) * texelSize).r;
     lumAvg += tex.Sample(texSampler, texCoord + float2(2.0, 2.0) * texelSize).r;
     lumAvg += tex.Sample(texSampler, texCoord + float2(2.0, 0.0) * texelSize).r;
-    #endif
     return lumAvg / 4.0;
 }
 
@@ -45,25 +30,7 @@ void VS(float4 iPos : POSITION,
     float4x3 modelMatrix = iModelMatrix;
     float3 worldPos = GetWorldPos(modelMatrix);
     oPos = GetClipPos(worldPos);
-
     oTexCoord = GetQuadTexCoord(oPos);
-
-    #ifdef LUMINANCE64
-    oTexCoord = GetQuadTexCoord(oPos) + cHDR128Offsets;
-    #endif
-
-    #ifdef LUMINANCE16
-    oTexCoord = GetQuadTexCoord(oPos) + cLum64Offsets;
-    #endif
-
-    #ifdef LUMINANCE4
-    oTexCoord = GetQuadTexCoord(oPos) + cLum16Offsets;
-    #endif
-
-    #ifdef LUMINANCE1
-    oTexCoord = GetQuadTexCoord(oPos) + cLum4Offsets;
-    #endif
-
     oScreenPos = GetScreenPosPreDiv(oPos);
 }
 
@@ -81,27 +48,15 @@ void PS(float2 iTexCoord : TEXCOORD0,
     #endif
 
     #ifdef LUMINANCE16
-    #ifndef D3D11
-    oColor = GatherAvgLum(sDiffMap, iTexCoord, cLum64InvSize);
-    #else
     oColor = GatherAvgLum(tDiffMap, sDiffMap, iTexCoord, cLum64InvSize);
-    #endif
     #endif
 
     #ifdef LUMINANCE4
-    #ifndef D3D11
-    oColor = GatherAvgLum(sDiffMap, iTexCoord, cLum16InvSize);
-    #else
     oColor = GatherAvgLum(tDiffMap, sDiffMap, iTexCoord, cLum16InvSize);
-    #endif
     #endif
 
     #ifdef LUMINANCE1
-    #ifndef D3D11
-    oColor = exp(GatherAvgLum(sDiffMap, iTexCoord, cLum4InvSize) / 16.0);
-    #else
     oColor = exp(GatherAvgLum(tDiffMap, sDiffMap, iTexCoord, cLum4InvSize) / 16.0);
-    #endif
     #endif
 
     #ifdef ADAPTLUMINANCE

--- a/bin/CoreData/Shaders/HLSL/Basic.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Basic.hlsl
@@ -31,7 +31,7 @@ void VS(float4 iPos : POSITION,
     #ifdef VERTEXCOLOR
         out float4 oColor : COLOR0,
     #endif
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         out float oClip : SV_CLIPDISTANCE0,
     #endif
     out float4 oPos : OUTPOSITION)
@@ -40,7 +40,7 @@ void VS(float4 iPos : POSITION,
     float3 worldPos = GetWorldPos(modelMatrix);
     oPos = GetClipPos(worldPos);
 
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         oClip = dot(oPos, cClipPlane);
     #endif
 
@@ -59,7 +59,7 @@ void PS(
     #ifdef VERTEXCOLOR
         float4 iColor : COLOR0,
     #endif
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         float iClip : SV_CLIPDISTANCE0,
     #endif
     out float4 oColor : OUTCOLOR0)

--- a/bin/CoreData/Shaders/HLSL/Bloom.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Bloom.hlsl
@@ -3,31 +3,14 @@
 #include "Samplers.hlsl"
 #include "ScreenPos.hlsl"
 
-#ifndef D3D11
-
-// D3D9 uniforms
-uniform float cBloomThreshold;
-uniform float2 cBloomMix;
-uniform float2 cBlurHOffsets;
-uniform float2 cBlurHInvSize;
-
-#else
-
 // D3D11 constant buffers
-#ifdef COMPILEVS
-cbuffer CustomVS : register(b6)
-{
-    float2 cBlurHOffsets;
-}
-#else
+#ifdef COMPILEPS
 cbuffer CustomPS : register(b6)
 {
     float cBloomThreshold;
     float2 cBloomMix;
     float2 cBlurHInvSize;
 }
-#endif
-
 #endif
 
 static const float offsets[5] = {
@@ -54,7 +37,7 @@ void VS(float4 iPos : POSITION,
     float4x3 modelMatrix = iModelMatrix;
     float3 worldPos = GetWorldPos(modelMatrix);
     oPos = GetClipPos(worldPos);
-    oTexCoord = GetQuadTexCoord(oPos) + cBlurHOffsets;
+    oTexCoord = GetQuadTexCoord(oPos);
     oScreenPos = GetScreenPosPreDiv(oPos);
 }
 

--- a/bin/CoreData/Shaders/HLSL/BloomHDR.hlsl
+++ b/bin/CoreData/Shaders/HLSL/BloomHDR.hlsl
@@ -4,35 +4,8 @@
 #include "ScreenPos.hlsl"
 #include "PostProcess.hlsl"
 
-#ifndef D3D11
-
-// D3D9 uniforms
-uniform float cBloomHDRThreshold;
-uniform float2 cBloomHDRBlurDir;
-uniform float cBloomHDRBlurRadius;
-uniform float cBloomHDRBlurSigma;
-uniform float2 cBloomHDRMix;
-uniform float2 cBright2Offsets;
-uniform float2 cBright4Offsets;
-uniform float2 cBright8Offsets;
-uniform float2 cBright16Offsets;
-uniform float2 cBright2InvSize;
-uniform float2 cBright4InvSize;
-uniform float2 cBright8InvSize;
-uniform float2 cBright16InvSize;
-
-#else
-
 // D3D11 constant buffers
-#ifdef COMPILEVS
-cbuffer CustomVS : register(b6)
-{
-    float2 cBright2Offsets;
-    float2 cBright4Offsets;
-    float2 cBright8Offsets;
-    float2 cBright16Offsets;
-}
-#else
+#ifdef COMPILEPS
 cbuffer CustomPS : register(b6)
 {
     float cBloomHDRThreshold;
@@ -47,8 +20,6 @@ cbuffer CustomPS : register(b6)
 }
 #endif
 
-#endif
-
 static const int BlurKernelSize = 5;
 
 void VS(float4 iPos : POSITION,
@@ -59,41 +30,7 @@ void VS(float4 iPos : POSITION,
     float4x3 modelMatrix = iModelMatrix;
     float3 worldPos = GetWorldPos(modelMatrix);
     oPos = GetClipPos(worldPos);
-
     oTexCoord = GetQuadTexCoord(oPos);
-
-    #ifdef BLUR2
-    oTexCoord = GetQuadTexCoord(oPos) + cBright2Offsets;
-    #endif
-
-    #ifdef BLUR4
-    oTexCoord = GetQuadTexCoord(oPos) + cBright4Offsets;
-    #endif
-
-    #ifdef BLUR8
-    oTexCoord = GetQuadTexCoord(oPos) + cBright8Offsets;
-    #endif
-
-    #ifdef BLUR16
-    oTexCoord = GetQuadTexCoord(oPos) + cBright16Offsets;
-    #endif
-
-    #ifdef COMBINE2
-    oTexCoord = GetQuadTexCoord(oPos) + cBright2Offsets;
-    #endif
-
-    #ifdef COMBINE4
-    oTexCoord = GetQuadTexCoord(oPos) + cBright4Offsets;
-    #endif
-
-    #ifdef COMBINE8
-    oTexCoord = GetQuadTexCoord(oPos) + cBright8Offsets;
-    #endif
-
-    #ifdef COMBINE16
-    oTexCoord = GetQuadTexCoord(oPos) + cBright16Offsets;
-    #endif
-
     oScreenPos = GetScreenPosPreDiv(oPos);
 }
 
@@ -105,26 +42,6 @@ void PS(float2 iTexCoord : TEXCOORD0,
     float3 color = Sample2D(DiffMap, iScreenPos).rgb;
     oColor = float4(max(color - cBloomHDRThreshold, 0.0), 1.0);
     #endif
-
-    #ifndef D3D11
-
-    #ifdef BLUR16
-    oColor = GaussianBlur(BlurKernelSize, cBloomHDRBlurDir, cBright16InvSize * cBloomHDRBlurRadius, cBloomHDRBlurSigma, sDiffMap, iTexCoord);
-    #endif
-
-    #ifdef BLUR8
-    oColor = GaussianBlur(BlurKernelSize, cBloomHDRBlurDir, cBright8InvSize * cBloomHDRBlurRadius, cBloomHDRBlurSigma, sDiffMap, iTexCoord);
-    #endif
-
-    #ifdef BLUR4
-    oColor = GaussianBlur(BlurKernelSize, cBloomHDRBlurDir, cBright4InvSize * cBloomHDRBlurRadius, cBloomHDRBlurSigma, sDiffMap, iTexCoord);
-    #endif
-
-    #ifdef BLUR2
-    oColor = GaussianBlur(BlurKernelSize, cBloomHDRBlurDir, cBright2InvSize * cBloomHDRBlurRadius, cBloomHDRBlurSigma, sDiffMap, iTexCoord);
-    #endif
-
-    #else
 
     #ifdef BLUR16
     oColor = GaussianBlur(BlurKernelSize, cBloomHDRBlurDir, cBright16InvSize * cBloomHDRBlurRadius, cBloomHDRBlurSigma, tDiffMap, sDiffMap, iTexCoord);
@@ -140,8 +57,6 @@ void PS(float2 iTexCoord : TEXCOORD0,
 
     #ifdef BLUR2
     oColor = GaussianBlur(BlurKernelSize, cBloomHDRBlurDir, cBright2InvSize * cBloomHDRBlurRadius, cBloomHDRBlurSigma, tDiffMap, sDiffMap, iTexCoord);
-    #endif
-
     #endif
 
     #ifdef COMBINE16

--- a/bin/CoreData/Shaders/HLSL/Blur.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Blur.hlsl
@@ -7,7 +7,6 @@
 uniform float2 cBlurDir;
 uniform float cBlurRadius;
 uniform float cBlurSigma;
-uniform float2 cBlurHOffsets;
 uniform float2 cBlurHInvSize;
 
 void VS(float4 iPos : POSITION,
@@ -18,7 +17,7 @@ void VS(float4 iPos : POSITION,
     float4x3 modelMatrix = iModelMatrix;
     float3 worldPos = GetWorldPos(modelMatrix);
     oPos = GetClipPos(worldPos);
-    oTexCoord = GetQuadTexCoord(oPos) + cBlurHOffsets;
+    oTexCoord = GetQuadTexCoord(oPos);
     oScreenPos = GetScreenPosPreDiv(oPos);
 }
 
@@ -27,34 +26,18 @@ void PS(float2 iTexCoord : TEXCOORD0,
     out float4 oColor : OUTCOLOR0)
 {
     #ifdef BLUR3
-        #ifndef D3D11
-            oColor = GaussianBlur(3, cBlurDir, cBlurHInvSize * cBlurRadius, cBlurSigma, sDiffMap, iTexCoord);
-        #else
-            oColor = GaussianBlur(3, cBlurDir, cBlurHInvSize * cBlurRadius, cBlurSigma, tDiffMap, sDiffMap, iTexCoord);
-        #endif
+        oColor = GaussianBlur(3, cBlurDir, cBlurHInvSize * cBlurRadius, cBlurSigma, tDiffMap, sDiffMap, iTexCoord);
     #endif
 
     #ifdef BLUR5
-        #ifndef D3D11
-            oColor = GaussianBlur(5, cBlurDir, cBlurHInvSize * cBlurRadius, cBlurSigma, sDiffMap, iTexCoord);
-        #else
-            oColor = GaussianBlur(5, cBlurDir, cBlurHInvSize * cBlurRadius, cBlurSigma, tDiffMap, sDiffMap, iTexCoord);
-        #endif
+        oColor = GaussianBlur(5, cBlurDir, cBlurHInvSize * cBlurRadius, cBlurSigma, tDiffMap, sDiffMap, iTexCoord);
     #endif
 
     #ifdef BLUR7
-        #ifndef D3D11
-            oColor = GaussianBlur(7, cBlurDir, cBlurHInvSize * cBlurRadius, cBlurSigma, sDiffMap, iTexCoord);
-        #else
-            oColor = GaussianBlur(7, cBlurDir, cBlurHInvSize * cBlurRadius, cBlurSigma, tDiffMap, sDiffMap, iTexCoord);
-        #endif
+        oColor = GaussianBlur(7, cBlurDir, cBlurHInvSize * cBlurRadius, cBlurSigma, tDiffMap, sDiffMap, iTexCoord);
     #endif
 
     #ifdef BLUR9
-        #ifndef D3D11
-            oColor = GaussianBlur(9, cBlurDir, cBlurHInvSize * cBlurRadius, cBlurSigma, sDiffMap, iTexCoord);
-        #else
-            oColor = GaussianBlur(9, cBlurDir, cBlurHInvSize * cBlurRadius, cBlurSigma, tDiffMap, sDiffMap, iTexCoord);
-        #endif
+        oColor = GaussianBlur(9, cBlurDir, cBlurHInvSize * cBlurRadius, cBlurSigma, tDiffMap, sDiffMap, iTexCoord);
     #endif
 }

--- a/bin/CoreData/Shaders/HLSL/ColorCorrection.hlsl
+++ b/bin/CoreData/Shaders/HLSL/ColorCorrection.hlsl
@@ -18,9 +18,5 @@ void PS(float2 iScreenPos : TEXCOORD0,
     out float4 oColor : OUTCOLOR0)
 {
     float3 color = Sample2D(DiffMap, iScreenPos).rgb;
-    #ifndef D3D11
-        oColor = float4(ColorCorrection(color, sVolumeMap), 1.0);
-    #else
-        oColor = float4(ColorCorrection(color, tVolumeMap, sVolumeMap), 1.0);
-    #endif
+    oColor = float4(ColorCorrection(color, tVolumeMap, sVolumeMap), 1.0);
 }

--- a/bin/CoreData/Shaders/HLSL/FXAA2.hlsl
+++ b/bin/CoreData/Shaders/HLSL/FXAA2.hlsl
@@ -11,21 +11,12 @@
 #include "Transform.hlsl"
 #include "ScreenPos.hlsl"
 
-#ifndef D3D11
-
-// D3D9 uniforms
-uniform float4 cFXAAParams;
-
-#else
-
 // D3D11 constant buffers
 #ifdef COMPILEPS
 cbuffer CustomPS : register(b6)
 {
     float4 cFXAAParams;
 }
-#endif
-
 #endif
 
 void VS(float4 iPos : POSITION,

--- a/bin/CoreData/Shaders/HLSL/FXAA3.hlsl
+++ b/bin/CoreData/Shaders/HLSL/FXAA3.hlsl
@@ -297,15 +297,9 @@ float CalcLuma(float3 rgb)
 
 /*--------------------------------------------------------------------------*/
 
-#ifndef D3D11
-#define FxaaTexTop(tex, p) float4(tex2Dlod(s##tex, float4(p, 0.0, 0.0)).rgb, 1.0)
-#define LumaTop(tex, p) CalcLuma(tex2Dlod(s##tex, float4(p, 0.0, 0.0)).rgb)
-#define LumaOff(tex, p, o, r) CalcLuma(tex2Dlod(s##tex, float4(p + (o * r), 0, 0)).rgb)
-#else
 #define FxaaTexTop(tex, p) float4(t##tex.SampleLevel(s##tex, p, 0.0).rgb, 1.0)
 #define LumaTop(tex, p) CalcLuma(t##tex.SampleLevel(s##tex, p, 0.0).rgb)
 #define LumaOff(tex, p, o, r) CalcLuma(t##tex.SampleLevel(s##tex, p + (o * r), 0.0).rgb)
-#endif
 
 /*============================================================================
 

--- a/bin/CoreData/Shaders/HLSL/Lighting.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Lighting.hlsl
@@ -225,9 +225,7 @@ float GetShadow(float4 shadowPos)
 {
     #if defined(SIMPLE_SHADOW)
         // Take one sample
-        #ifdef D3D11
-            shadowPos.xyz /= shadowPos.w;
-        #endif
+        shadowPos.xyz /= shadowPos.w;
         float inLight = SampleShadow(ShadowMap, shadowPos).r;
         #ifndef SHADOWCMP
             return cShadowIntensity.y + cShadowIntensity.x * inLight;
@@ -242,14 +240,8 @@ float GetShadow(float4 shadowPos)
     #elif defined(PCF_SHADOW)
         // Take four samples and average them
         // Note: in case of sampling a point light cube shadow, we optimize out the w divide as it has already been performed
-        #ifdef D3D11
-            shadowPos.xyz /= shadowPos.w;
-        #endif
-        #if !defined(POINTLIGHT) && !defined(D3D11)
-            float2 offsets = cShadowMapInvSize * shadowPos.w;
-        #else
-            float2 offsets = cShadowMapInvSize;
-        #endif
+        shadowPos.xyz /= shadowPos.w;
+        float2 offsets = cShadowMapInvSize;
         float4 shadowPos2 = float4(shadowPos.x + offsets.x, shadowPos.yzw);
         float4 shadowPos3 = float4(shadowPos.x, shadowPos.y + offsets.y, shadowPos.zw);
         float4 shadowPos4 = float4(shadowPos.xy + offsets.xy, shadowPos.zw);

--- a/bin/CoreData/Shaders/HLSL/LitParticle.hlsl
+++ b/bin/CoreData/Shaders/HLSL/LitParticle.hlsl
@@ -6,16 +6,11 @@
 #include "Fog.hlsl"
 
 #if defined(COMPILEPS) && defined(SOFTPARTICLES)
-#ifndef D3D11
-// D3D9 uniform
-uniform float cSoftParticleFadeScale;
-#else
 // D3D11 constant buffer
 cbuffer CustomPS : register(b6)
 {
     float cSoftParticleFadeScale;
 }
-#endif
 #endif
 
 void VS(float4 iPos : POSITION,
@@ -62,7 +57,7 @@ void VS(float4 iPos : POSITION,
     #ifdef VERTEXCOLOR
         out float4 oColor : COLOR0,
     #endif
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         out float oClip : SV_CLIPDISTANCE0,
     #endif
     out float4 oPos : OUTPOSITION)
@@ -78,7 +73,7 @@ void VS(float4 iPos : POSITION,
     oTexCoord = GetTexCoord(iTexCoord);
     oWorldPos = float4(worldPos, GetDepth(oPos));
 
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         oClip = dot(oPos, cClipPlane);
     #endif
 
@@ -139,7 +134,7 @@ void PS(float2 iTexCoord : TEXCOORD0,
     #ifdef VERTEXCOLOR
         float4 iColor : COLOR0,
     #endif
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         float iClip : SV_CLIPDISTANCE0,
     #endif
     out float4 oColor : OUTCOLOR0)

--- a/bin/CoreData/Shaders/HLSL/LitSolid.hlsl
+++ b/bin/CoreData/Shaders/HLSL/LitSolid.hlsl
@@ -62,7 +62,7 @@ void VS(float4 iPos : POSITION,
     #ifdef VERTEXCOLOR
         out float4 oColor : COLOR0,
     #endif
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         out float oClip : SV_CLIPDISTANCE0,
     #endif
     out float4 oPos : OUTPOSITION)
@@ -78,7 +78,7 @@ void VS(float4 iPos : POSITION,
     oNormal = GetWorldNormal(modelMatrix);
     oWorldPos = float4(worldPos, GetDepth(oPos));
 
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         oClip = dot(oPos, cClipPlane);
     #endif
 
@@ -168,7 +168,7 @@ void PS(
     #ifdef VERTEXCOLOR
         float4 iColor : COLOR0,
     #endif
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         float iClip : SV_CLIPDISTANCE0,
     #endif
     #ifdef PREPASS

--- a/bin/CoreData/Shaders/HLSL/PBRLitSolid.hlsl
+++ b/bin/CoreData/Shaders/HLSL/PBRLitSolid.hlsl
@@ -65,7 +65,7 @@ void VS(float4 iPos : POSITION,
     #ifdef VERTEXCOLOR
         out float4 oColor : COLOR0,
     #endif
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         out float oClip : SV_CLIPDISTANCE0,
     #endif
     out float4 oPos : OUTPOSITION)
@@ -81,7 +81,7 @@ void VS(float4 iPos : POSITION,
     oNormal = GetWorldNormal(modelMatrix);
     oWorldPos = float4(worldPos, GetDepth(oPos));
 
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         oClip = dot(oPos, cClipPlane);
     #endif
 
@@ -173,7 +173,7 @@ void PS(
     #ifdef VERTEXCOLOR
         float4 iColor : COLOR0,
     #endif
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         float iClip : SV_CLIPDISTANCE0,
     #endif
     #ifdef PREPASS
@@ -183,11 +183,7 @@ void PS(
         out float4 oAlbedo : OUTCOLOR1,
         out float4 oNormal : OUTCOLOR2,
         out float4 oDepth : OUTCOLOR3,
-        #ifndef D3D11
-            float2 iFragPos : VPOS,
-        #else
-            float4 iFragPos : SV_Position,
-        #endif
+        float4 iFragPos : SV_Position,
     #endif
     out float4 oColor : OUTCOLOR0)
 {

--- a/bin/CoreData/Shaders/HLSL/PBRTerrainBlend.hlsl
+++ b/bin/CoreData/Shaders/HLSL/PBRTerrainBlend.hlsl
@@ -8,20 +8,6 @@
 #include "PBR.hlsl"
 #include "IBL.hlsl"
 
-#ifndef D3D11
-
-// D3D9 uniforms and samplers
-#ifdef COMPILEVS
-uniform float2 cDetailTiling;
-#else
-sampler2D sWeightMap0 : register(s0);
-sampler2D sDetailMap1 : register(s1);
-sampler2D sDetailMap2 : register(s2);
-sampler2D sDetailMap3 : register(s3);
-#endif
-
-#else
-
 // D3D11 constant buffers and samplers
 #ifdef COMPILEVS
 cbuffer CustomVS : register(b6)
@@ -39,7 +25,6 @@ SamplerState sDetailMap2 : register(s2);
 SamplerState sDetailMap3 : register(s3);
 #endif
 
-#endif
 void VS(float4 iPos : POSITION,
         float3 iNormal : NORMAL,
         float2 iTexCoord : TEXCOORD0,
@@ -74,7 +59,7 @@ void VS(float4 iPos : POSITION,
     #ifdef VERTEXCOLOR
         out float4 oColor : COLOR0,
     #endif
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         out float oClip : SV_CLIPDISTANCE0,
     #endif
     out float4 oPos : OUTPOSITION)
@@ -87,7 +72,7 @@ void VS(float4 iPos : POSITION,
     oTexCoord = GetTexCoord(iTexCoord);
     oDetailTexCoord = cDetailTiling * oTexCoord;
 
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         oClip = dot(oPos, cClipPlane);
     #endif
 
@@ -142,7 +127,7 @@ void PS(
     #ifdef VERTEXCOLOR
         float4 iColor : COLOR0,
     #endif
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         float iClip : SV_CLIPDISTANCE0,
     #endif
     #ifdef PREPASS
@@ -152,11 +137,7 @@ void PS(
         out float4 oAlbedo : OUTCOLOR1,
         out float4 oNormal : OUTCOLOR2,
         out float4 oDepth : OUTCOLOR3,
-        #ifndef D3D11
-            float2 iFragPos : VPOS,
-        #else
-            float4 iFragPos : SV_Position,
-        #endif
+        float4 iFragPos : SV_Position,
     #endif
     out float4 oColor : OUTCOLOR0)
 {

--- a/bin/CoreData/Shaders/HLSL/PBRVegetation.hlsl
+++ b/bin/CoreData/Shaders/HLSL/PBRVegetation.hlsl
@@ -8,19 +8,6 @@
 #include "PBR.hlsl"
 #include "IBL.hlsl"
 
-#ifndef D3D11
-
-// D3D9 uniforms
-uniform float cWindHeightFactor;
-uniform float cWindHeightPivot;
-uniform float cWindPeriod;
-uniform float2 cWindWorldSpacing;
-#ifdef WINDSTEMAXIS
-    uniform float3 cWindStemAxis;
-#endif
-
-#else
-
 // D3D11 constant buffer
 cbuffer CustomVS : register(b6)
 {
@@ -32,8 +19,6 @@ cbuffer CustomVS : register(b6)
         float3 cWindStemAxis;
     #endif
 }
-
-#endif
 
 void VS(float4 iPos : POSITION,
     #if !defined(BILLBOARD) && !defined(TRAILFACECAM)
@@ -92,7 +77,7 @@ void VS(float4 iPos : POSITION,
     #ifdef VERTEXCOLOR
         out float4 oColor : COLOR0,
     #endif
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         out float oClip : SV_CLIPDISTANCE0,
     #endif
     out float4 oPos : OUTPOSITION)
@@ -119,7 +104,7 @@ void VS(float4 iPos : POSITION,
     oNormal = GetWorldNormal(modelMatrix);
     oWorldPos = float4(worldPos, GetDepth(oPos));
 
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         oClip = dot(oPos, cClipPlane);
     #endif
 

--- a/bin/CoreData/Shaders/HLSL/PostProcess.hlsl
+++ b/bin/CoreData/Shaders/HLSL/PostProcess.hlsl
@@ -9,11 +9,7 @@ float2 Noise(float2 coord)
 }
 
 // Adapted: http://callumhay.blogspot.com/2010/09/gaussian-blur-shader-glsl.html
-#ifndef D3D11
-float4 GaussianBlur(int blurKernelSize, float2 blurDir, float2 blurRadius, float sigma, sampler2D texSampler, float2 texCoord)
-#else
 float4 GaussianBlur(int blurKernelSize, float2 blurDir, float2 blurRadius, float sigma, Texture2D tex, SamplerState texSampler, float2 texCoord)
-#endif
 {
     const int blurKernelHalfSize = blurKernelSize / 2;
 
@@ -27,25 +23,14 @@ float4 GaussianBlur(int blurKernelSize, float2 blurDir, float2 blurRadius, float
     float4 avgValue = float4(0.0, 0.0, 0.0, 0.0);
     float gaussCoeffSum = 0.0;
 
-    #ifndef D3D11
-    avgValue += tex2D(texSampler, texCoord) * gaussCoeff.x;
-    #else
     avgValue += tex.Sample(texSampler, texCoord) * gaussCoeff.x;
-    #endif
-
     gaussCoeffSum += gaussCoeff.x;
     gaussCoeff.xy *= gaussCoeff.yz;
 
     for (int i = 1; i <= blurKernelHalfSize; i++)
     {
-        #ifndef D3D11
-        avgValue += tex2D(texSampler, texCoord - i * blurVec) * gaussCoeff.x;
-        avgValue += tex2D(texSampler, texCoord + i * blurVec) * gaussCoeff.x;
-        #else
         avgValue += tex.Sample(texSampler, texCoord - i * blurVec) * gaussCoeff.x;
         avgValue += tex.Sample(texSampler, texCoord + i * blurVec) * gaussCoeff.x;
-        #endif
-
         gaussCoeffSum += 2.0 * gaussCoeff.x;
         gaussCoeff.xy *= gaussCoeff.yz;
     }
@@ -78,20 +63,12 @@ float3 Uncharted2Tonemap(float3 x)
    return ((x*(A*x+C*B)+D*E)/(x*(A*x+B)+D*F))-E/F;
 }
 
-#ifndef D3D11
-float3 ColorCorrection(float3 color, sampler3D lut)
-#else
 float3 ColorCorrection(float3 color, Texture3D lut, SamplerState lutSampler)
-#endif
 {
     float lutSize = 16.0;
     float scale = (lutSize - 1.0) / lutSize;
     float offset = 1.0 / (2.0 * lutSize);
-    #ifndef D3D11
-        return tex3D(lut, clamp(color, 0.0, 1.0) * scale + offset).rgb;
-    #else
-        return lut.Sample(lutSampler, clamp(color, 0.0, 1.0) * scale + offset).rgb;
-    #endif
+    return lut.Sample(lutSampler, clamp(color, 0.0, 1.0) * scale + offset).rgb;
 }
 
 static const float Gamma = 2.2;

--- a/bin/CoreData/Shaders/HLSL/Samplers.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Samplers.hlsl
@@ -1,4 +1,3 @@
-#ifdef D3D11
 // Make sampling macros also available for VS on D3D11
 #define Sample2D(tex, uv) t##tex.Sample(s##tex, uv)
 #define Sample2DProj(tex, uv) t##tex.Sample(s##tex, uv.xy / uv.w)
@@ -6,43 +5,8 @@
 #define SampleCube(tex, uv) t##tex.Sample(s##tex, uv)
 #define SampleCubeLOD(tex, uv) t##tex.SampleLevel(s##tex, uv.xyz, uv.w)
 #define SampleShadow(tex, uv) t##tex.SampleCmpLevelZero(s##tex, uv.xy, uv.z)
-#endif
 
 #ifdef COMPILEPS
-
-#ifndef D3D11
-
-// D3D9 samplers
-sampler2D sDiffMap : register(s0);
-samplerCUBE sDiffCubeMap : register(s0);
-sampler2D sAlbedoBuffer : register(s0);
-sampler2D sNormalMap : register(s1);
-sampler2D sNormalBuffer : register(s1);
-sampler2D sSpecMap : register(s2);
-sampler2D sRoughMetalFresnel : register(s2); //R: Roughness, G: Metal
-sampler2D sEmissiveMap : register(s3);
-sampler2D sEnvMap : register(s4);
-sampler3D sVolumeMap : register(s5);
-samplerCUBE sEnvCubeMap : register(s4);
-sampler2D sLightRampMap : register(s8);
-sampler2D sLightSpotMap : register(s9);
-samplerCUBE sLightCubeMap : register(s9);
-sampler2D sShadowMap : register(s10);
-samplerCUBE sFaceSelectCubeMap : register(s11);
-samplerCUBE sIndirectionCubeMap : register(s12);
-sampler2D sDepthBuffer : register(s13);
-sampler2D sLightBuffer : register(s14);
-samplerCUBE sZoneCubeMap : register(s15);
-sampler3D sZoneVolumeMap : register(s15);
-
-#define Sample2D(tex, uv) tex2D(s##tex, uv)
-#define Sample2DProj(tex, uv) tex2Dproj(s##tex, uv)
-#define Sample2DLod0(tex, uv) tex2Dlod(s##tex, float4(uv, 0.0, 0.0))
-#define SampleCube(tex, uv) texCUBE(s##tex, uv)
-#define SampleCubeLOD(tex, uv) texCUBElod(s##tex, uv)
-#define SampleShadow(tex, uv) tex2Dproj(s##tex, uv)
-
-#else
 
 // D3D11 textures and samplers
 
@@ -93,8 +57,6 @@ SamplerState sDepthBuffer : register(s13);
 SamplerState sLightBuffer : register(s14);
 SamplerState sZoneCubeMap : register(s15);
 SamplerState sZoneVolumeMap : register(s15);
-
-#endif
 
 float3 DecodeNormal(float4 normalInput)
 {

--- a/bin/CoreData/Shaders/HLSL/ShadowBlur.hlsl
+++ b/bin/CoreData/Shaders/HLSL/ShadowBlur.hlsl
@@ -3,21 +3,12 @@
 #include "Transform.hlsl"
 #include "ScreenPos.hlsl"
 
-#ifndef D3D11
-
-// D3D9 uniforms
-uniform float2 cBlurOffsets;
-
-#else
-
 #ifdef COMPILEPS
 // D3D11 constant buffers
 cbuffer CustomPS : register(b6)
 {
     float2 cBlurOffsets;
 }
-#endif
-
 #endif
 
 void VS(float4 iPos : POSITION,

--- a/bin/CoreData/Shaders/HLSL/TerrainBlend.hlsl
+++ b/bin/CoreData/Shaders/HLSL/TerrainBlend.hlsl
@@ -5,20 +5,6 @@
 #include "Lighting.hlsl"
 #include "Fog.hlsl"
 
-#ifndef D3D11
-
-// D3D9 uniforms and samplers
-#ifdef COMPILEVS
-uniform float2 cDetailTiling;
-#else
-sampler2D sWeightMap0 : register(s0);
-sampler2D sDetailMap1 : register(s1);
-sampler2D sDetailMap2 : register(s2);
-sampler2D sDetailMap3 : register(s3);
-#endif
-
-#else
-
 // D3D11 constant buffers and samplers
 #ifdef COMPILEVS
 cbuffer CustomVS : register(b6)
@@ -34,8 +20,6 @@ SamplerState sWeightMap0 : register(s0);
 SamplerState sDetailMap1 : register(s1);
 SamplerState sDetailMap2 : register(s2);
 SamplerState sDetailMap3 : register(s3);
-#endif
-
 #endif
 
 void VS(float4 iPos : POSITION,
@@ -72,7 +56,7 @@ void VS(float4 iPos : POSITION,
         out float3 oVertexLight : TEXCOORD4,
         out float4 oScreenPos : TEXCOORD5,
     #endif
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         out float oClip : SV_CLIPDISTANCE0,
     #endif
     out float4 oPos : OUTPOSITION)
@@ -85,7 +69,7 @@ void VS(float4 iPos : POSITION,
     oTexCoord = GetTexCoord(iTexCoord);
     oDetailTexCoord = cDetailTiling * oTexCoord;
 
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         oClip = dot(oPos, cClipPlane);
     #endif
 
@@ -137,7 +121,7 @@ void PS(float2 iTexCoord : TEXCOORD0,
         float3 iVertexLight : TEXCOORD4,
         float4 iScreenPos : TEXCOORD5,
     #endif
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         float iClip : SV_CLIPDISTANCE0,
     #endif
     #ifdef PREPASS

--- a/bin/CoreData/Shaders/HLSL/Text.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Text.hlsl
@@ -2,15 +2,6 @@
 #include "Samplers.hlsl"
 #include "Transform.hlsl"
 
-#ifndef D3D11
-
-// D3D9 uniforms
-uniform float2 cShadowOffset;
-uniform float4 cShadowColor;
-uniform float4 cStrokeColor;
-
-#else
-
 #ifdef COMPILEPS
 // D3D11 constant buffers
 cbuffer CustomPS : register(b6)
@@ -19,8 +10,6 @@ cbuffer CustomPS : register(b6)
     float4 cShadowColor;
     float4 cStrokeColor;
 }
-#endif
-
 #endif
 
 void VS(float4 iPos : POSITION,

--- a/bin/CoreData/Shaders/HLSL/Tonemap.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Tonemap.hlsl
@@ -4,14 +4,6 @@
 #include "ScreenPos.hlsl"
 #include "PostProcess.hlsl"
 
-#ifndef D3D11
-
-// D3D9 uniforms
-uniform float cTonemapExposureBias;
-uniform float cTonemapMaxWhite;
-
-#else
-
 #ifdef COMPILEPS
 // D3D11 constant buffers
 cbuffer CustomPS : register(b6)
@@ -19,8 +11,6 @@ cbuffer CustomPS : register(b6)
     float cTonemapExposureBias;
     float cTonemapMaxWhite;
 }
-#endif
-
 #endif
 
 void VS(float4 iPos : POSITION,

--- a/bin/CoreData/Shaders/HLSL/Transform.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Transform.hlsl
@@ -1,10 +1,6 @@
 #ifdef COMPILEVS
 
-#ifdef D3D11
 #define OUTPOSITION SV_POSITION
-#else
-#define OUTPOSITION POSITION
-#endif
 
 #ifdef SKINNED
 float4x3 GetSkinMatrix(float4 blendWeights, int4 blendIndices)
@@ -149,17 +145,10 @@ float3 GetTrailNormal(float4 iPos, float3 iParentPos, float3 iForward)
 
 #ifdef COMPILEPS
 
-#ifdef D3D11
 #define OUTCOLOR0 SV_TARGET
 #define OUTCOLOR1 SV_TARGET1
 #define OUTCOLOR2 SV_TARGET2
 #define OUTCOLOR3 SV_TARGET3
-#else
-#define OUTCOLOR0 COLOR0
-#define OUTCOLOR1 COLOR1
-#define OUTCOLOR2 COLOR2
-#define OUTCOLOR3 COLOR3
-#endif
 
 #endif
 

--- a/bin/CoreData/Shaders/HLSL/Uniforms.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Uniforms.hlsl
@@ -1,85 +1,3 @@
-#ifndef D3D11
-
-// D3D9 uniforms (no constant buffers)
-
-#ifdef COMPILEVS
-
-// Vertex shader uniforms
-uniform float3 cAmbientStartColor;
-uniform float3 cAmbientEndColor;
-#ifdef BILLBOARD
-uniform float3x3 cBillboardRot;
-#endif
-uniform float3 cCameraPos;
-uniform float cNearClip;
-uniform float cFarClip;
-uniform float4 cDepthMode;
-uniform float cDeltaTime;
-uniform float cElapsedTime;
-uniform float3 cFrustumSize;
-uniform float4 cGBufferOffsets;
-uniform float4 cLightPos;
-uniform float3 cLightDir;
-uniform float4 cNormalOffsetScale;
-uniform float4x3 cModel;
-uniform float4x3 cView;
-uniform float4x3 cViewInv;
-uniform float4x4 cViewProj;
-uniform float4 cUOffset;
-uniform float4 cVOffset;
-uniform float4x3 cZone;
-#ifdef SKINNED
-    uniform float4x3 cSkinMatrices[MAXBONES];
-#endif
-#ifdef NUMVERTEXLIGHTS
-    uniform float4 cVertexLights[4*3];
-#else
-    uniform float4x4 cLightMatrices[4];
-#endif
-#endif
-
-#ifdef COMPILEPS
-
-// Pixel shader uniforms
-uniform float4 cAmbientColor;
-uniform float3 cCameraPosPS;
-uniform float cDeltaTimePS;
-uniform float4 cDepthReconstruct;
-uniform float cElapsedTimePS;
-uniform float4 cFogParams;
-uniform float3 cFogColor;
-uniform float2 cGBufferInvSize;
-uniform float4 cLightColor;
-uniform float4 cLightPosPS;
-uniform float3 cLightDirPS;
-uniform float4 cNormalOffsetScalePS;
-uniform float4 cMatDiffColor;
-uniform float3 cMatEmissiveColor;
-uniform float3 cMatEnvMapColor;
-uniform float4 cMatSpecColor;
-#ifdef PBR
-    uniform float cRoughness;
-    uniform float cMetallic;
-    uniform float cLightRad;
-    uniform float cLightLength;
-#endif
-uniform float3 cZoneMin;
-uniform float3 cZoneMax;
-uniform float cNearClipPS;
-uniform float cFarClipPS;
-uniform float4 cShadowCubeAdjust;
-uniform float4 cShadowDepthFade;
-uniform float2 cShadowIntensity;
-uniform float2 cShadowMapInvSize;
-uniform float4 cShadowSplits;
-uniform float4x4 cLightMatricesPS[4];
-#ifdef VSM_SHADOW
-uniform float2 cVSMShadowParams;
-#endif
-#endif
-
-#else
-
 // D3D11 uniforms (using constant buffers)
 
 #ifdef COMPILEVS
@@ -202,8 +120,6 @@ cbuffer MaterialPS : register(b4)
         float cMetallic;
     #endif
 }
-#endif
-
 #endif
 
 #endif

--- a/bin/CoreData/Shaders/HLSL/Unlit.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Unlit.hlsl
@@ -31,7 +31,7 @@ void VS(float4 iPos : POSITION,
     #ifdef VERTEXCOLOR
         out float4 oColor : COLOR0,
     #endif
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         out float oClip : SV_CLIPDISTANCE0,
     #endif
     out float4 oPos : OUTPOSITION)
@@ -47,7 +47,7 @@ void VS(float4 iPos : POSITION,
     oTexCoord = GetTexCoord(iTexCoord);
     oWorldPos = float4(worldPos, GetDepth(oPos));
 
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         oClip = dot(oPos, cClipPlane);
     #endif
 
@@ -61,7 +61,7 @@ void PS(float2 iTexCoord : TEXCOORD0,
     #ifdef VERTEXCOLOR
         float4 iColor : COLOR0,
     #endif
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         float iClip : SV_CLIPDISTANCE0,
     #endif
     #ifdef PREPASS

--- a/bin/CoreData/Shaders/HLSL/UnlitParticle.hlsl
+++ b/bin/CoreData/Shaders/HLSL/UnlitParticle.hlsl
@@ -5,16 +5,11 @@
 #include "Fog.hlsl"
 
 #if defined(COMPILEPS) && defined(SOFTPARTICLES)
-#ifndef D3D11
-// D3D9 uniform
-uniform float cSoftParticleFadeScale;
-#else
 // D3D11 constant buffer
 cbuffer CustomPS : register(b6)
 {
     float cSoftParticleFadeScale;
 }
-#endif
 #endif
 
 void VS(float4 iPos : POSITION,
@@ -48,7 +43,7 @@ void VS(float4 iPos : POSITION,
     #ifdef VERTEXCOLOR
         out float4 oColor : COLOR0,
     #endif
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         out float oClip : SV_CLIPDISTANCE0,
     #endif
     out float4 oPos : OUTPOSITION)
@@ -64,7 +59,7 @@ void VS(float4 iPos : POSITION,
     oTexCoord = GetTexCoord(iTexCoord);
     oWorldPos = float4(worldPos, GetDepth(oPos));
 
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         oClip = dot(oPos, cClipPlane);
     #endif
 
@@ -85,7 +80,7 @@ void PS(float2 iTexCoord : TEXCOORD0,
     #ifdef VERTEXCOLOR
         float4 iColor : COLOR0,
     #endif
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         float iClip : SV_CLIPDISTANCE0,
     #endif
     out float4 oColor : OUTCOLOR0)

--- a/bin/CoreData/Shaders/HLSL/Vegetation.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Vegetation.hlsl
@@ -5,19 +5,6 @@
 #include "Lighting.hlsl"
 #include "Fog.hlsl"
 
-#ifndef D3D11
-
-// D3D9 uniforms
-uniform float cWindHeightFactor;
-uniform float cWindHeightPivot;
-uniform float cWindPeriod;
-uniform float2 cWindWorldSpacing;
-#ifdef WINDSTEMAXIS
-    uniform float3 cWindStemAxis;
-#endif
-
-#else
-
 // D3D11 constant buffer
 cbuffer CustomVS : register(b6)
 {
@@ -29,8 +16,6 @@ cbuffer CustomVS : register(b6)
         float3 cWindStemAxis;
     #endif
 }
-
-#endif
 
 void VS(float4 iPos : POSITION,
     #if !defined(BILLBOARD) && !defined(TRAILFACECAM)
@@ -89,7 +74,7 @@ void VS(float4 iPos : POSITION,
     #ifdef VERTEXCOLOR
         out float4 oColor : COLOR0,
     #endif
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         out float oClip : SV_CLIPDISTANCE0,
     #endif
     out float4 oPos : OUTPOSITION)
@@ -116,7 +101,7 @@ void VS(float4 iPos : POSITION,
     oNormal = GetWorldNormal(modelMatrix);
     oWorldPos = float4(worldPos, GetDepth(oPos));
 
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         oClip = dot(oPos, cClipPlane);
     #endif
 

--- a/bin/CoreData/Shaders/HLSL/VegetationDepth.hlsl
+++ b/bin/CoreData/Shaders/HLSL/VegetationDepth.hlsl
@@ -2,19 +2,6 @@
 #include "Samplers.hlsl"
 #include "Transform.hlsl"
 
-#ifndef D3D11
-
-// D3D9 uniforms
-uniform float cWindHeightFactor;
-uniform float cWindHeightPivot;
-uniform float cWindPeriod;
-uniform float2 cWindWorldSpacing;
-#ifdef WINDSTEMAXIS
-    uniform float3 cWindStemAxis;
-#endif
-
-#else
-
 // D3D11 constant buffer
 cbuffer CustomVS : register(b6)
 {
@@ -26,8 +13,6 @@ cbuffer CustomVS : register(b6)
         float3 cWindStemAxis;
     #endif
 }
-
-#endif
 
 void VS(float4 iPos : POSITION,
     #ifdef SKINNED

--- a/bin/CoreData/Shaders/HLSL/VegetationShadow.hlsl
+++ b/bin/CoreData/Shaders/HLSL/VegetationShadow.hlsl
@@ -2,19 +2,6 @@
 #include "Samplers.hlsl"
 #include "Transform.hlsl"
 
-#ifndef D3D11
-
-// D3D9 uniforms
-uniform float cWindHeightFactor;
-uniform float cWindHeightPivot;
-uniform float cWindPeriod;
-uniform float2 cWindWorldSpacing;
-#ifdef WINDSTEMAXIS
-    uniform float3 cWindStemAxis;
-#endif
-
-#else
-
 // D3D11 constant buffer
 cbuffer CustomVS : register(b6)
 {
@@ -26,8 +13,6 @@ cbuffer CustomVS : register(b6)
         float3 cWindStemAxis;
     #endif
 }
-
-#endif
 
 void VS(float4 iPos : POSITION,
     #ifdef SKINNED

--- a/bin/CoreData/Shaders/HLSL/Water.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Water.hlsl
@@ -4,17 +4,6 @@
 #include "ScreenPos.hlsl"
 #include "Fog.hlsl"
 
-#ifndef D3D11
-
-// D3D9 uniforms
-uniform float2 cNoiseSpeed;
-uniform float cNoiseTiling;
-uniform float cNoiseStrength;
-uniform float cFresnelPower;
-uniform float3 cWaterTint;
-
-#else
-
 // D3D11 constant buffers
 #ifdef COMPILEVS
 cbuffer CustomVS : register(b6)
@@ -31,8 +20,6 @@ cbuffer CustomPS : register(b6)
 }
 #endif
 
-#endif
-
 void VS(float4 iPos : POSITION,
     float3 iNormal: NORMAL,
     float2 iTexCoord : TEXCOORD0,
@@ -44,7 +31,7 @@ void VS(float4 iPos : POSITION,
     out float2 oWaterUV : TEXCOORD2,
     out float3 oNormal : TEXCOORD3,
     out float4 oEyeVec : TEXCOORD4,
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         out float oClip : SV_CLIPDISTANCE0,
     #endif
     out float4 oPos : OUTPOSITION)
@@ -61,7 +48,7 @@ void VS(float4 iPos : POSITION,
     oNormal = GetWorldNormal(modelMatrix);
     oEyeVec = float4(cCameraPos - worldPos, GetDepth(oPos));
 
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         oClip = dot(oPos, cClipPlane);
     #endif
 }
@@ -72,7 +59,7 @@ void PS(
     float2 iWaterUV : TEXCOORD2,
     float3 iNormal : TEXCOORD3,
     float4 iEyeVec : TEXCOORD4,
-    #if defined(D3D11) && defined(CLIPPLANE)
+    #if defined(CLIPPLANE)
         float iClip : SV_CLIPDISTANCE0,
     #endif
     out float4 oColor : OUTCOLOR0)


### PR DESCRIPTION
Related:
* https://github.com/urho3d/Urho3D/commit/0990fd72f239594fae113820233d1f858325f8dd#diff-66b75ef4fad81df67423c996c489e52b3400a48502c61784edddeb0c4d607ad1
* https://github.com/urho3d/Urho3D/issues/3037