### PR TITLE
Fix: samples not builded when compiled through Android Studio

### DIFF
--- a/android/launcher-app/CMakeLists.txt
+++ b/android/launcher-app/CMakeLists.txt
@@ -2,7 +2,7 @@
 # License: MIT
 
 # Set CMake minimum version
-cmake_minimum_required (VERSION 3.10.2)
+cmake_minimum_required (VERSION 3.15)
 
 # Set project name
 project (Urho3D-Launcher)
@@ -12,6 +12,8 @@ set (CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/Modules)
 
 # Include UrhoCommon.cmake module after setting project name
 include (UrhoCommon)
+
+set(URHO3D_SAMPLES 1)
 
 add_subdirectory (${CMAKE_CURRENT_SOURCE_DIR}/../../Source/Tools/Urho3DPlayer Urho3DPlayer)
 add_subdirectory (${CMAKE_CURRENT_SOURCE_DIR}/../../Source/Samples Samples)


### PR DESCRIPTION
Perhaps there is a better way to set the environment variable in Android Studio, but I do not know it.