### PR TITLE
Check MinGW compatibility | Linux_MinGW forkflow: upgrade Ubuntu to 22.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -479,7 +479,7 @@ jobs:
         xvfb-run ctest --test-dir $HOME/projects/UrhoApp_build
 
   Linux_MinGW:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: init
     if: needs.init.outputs.skip == '0'
 

--- a/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11ShaderVariation.cpp
+++ b/Source/Urho3D/GraphicsAPI/Direct3D11/D3D11ShaderVariation.cpp
@@ -14,6 +14,11 @@
 
 #include <d3dcompiler.h>
 
+// https://github.com/urho3d/Urho3D/issues/2887
+#if defined(__MINGW32__) && !defined(D3D_COMPILER_VERSION)
+#error Please update MinGW
+#endif
+
 #include "../../DebugNew.h"
 
 namespace Urho3D


### PR DESCRIPTION
Upgraded Ubuntu have newest MinGW version

Issue: https://github.com/urho3d/Urho3D/issues/2887

Another PR: https://github.com/urho3d/Urho3D/pull/2936
