### PR TITLE
Doxygen: enable MULTILINE_CPP_IS_BRIEF

### DIFF
--- a/Docs/Doxyfile.in
+++ b/Docs/Doxyfile.in
@@ -209,7 +209,7 @@ QT_AUTOBRIEF           = NO
 # not recognized any more.
 # The default value is: NO.
 
-MULTILINE_CPP_IS_BRIEF = NO
+MULTILINE_CPP_IS_BRIEF = YES
 
 # If the INHERIT_DOCS tag is set to YES then an undocumented member inherits the
 # documentation from any documented member that it re-implements.


### PR DESCRIPTION
Motivation:

```
    /// Set the Interpolation Mode.
    /// @property
    void SetInterpolationMode(InterpolationMode interpolationMode);
```

interpreted as a detailed description without brief description:

![test](https://user-images.githubusercontent.com/13021826/192445507-e6979291-528b-42ab-9608-d82e42f649f7.png)

With enabled MULTILINE_CPP_IS_BRIEF entire comment is interpreted as brief.

To add detailed description empty line or `\details` command can be used:

```
/// Ssfsdfds (aaaaaaaaaa)
/// sdfsdfds
///
/// Detailed comment
int aaa;
    
/// SAdsafsdf
/// sdfsdfdsf
/// \details Detailed comment
float bbbb;
```
