### PR TITLE
Fix setWindowTitle in emscripten SDL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ build/
 # Qt Creator project settings
 /CMakeLists.txt.user
 
+# VSCode project settings
+/.vscode/
+
 # JetBrains IDE project settings
 /.idea/
 /cmake-build-*/

--- a/Source/ThirdParty/SDL/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/Source/ThirdParty/SDL/src/video/emscripten/SDL_emscriptenvideo.c
@@ -348,8 +348,8 @@ Emscripten_SetWindowFullscreen(_THIS, SDL_Window * window, SDL_VideoDisplay * di
 static void
 Emscripten_SetWindowTitle(_THIS, SDL_Window * window) {
     EM_ASM_INT({
-      if (typeof Module['setWindowTitle'] !== 'undefined') {
-        Module['setWindowTitle'](UTF8ToString($0));
+      if (typeof setWindowTitle !== 'undefined') {
+        setWindowTitle(UTF8ToString($0));
       }
       return 0;
     }, window->title);


### PR DESCRIPTION
In upstream SDL newer versions this is fixed - so updating SDL would also fix this issue.

The docs say the SDK is tested against emscripten 2.0.8, version 2.0.8 (all the way back to around 1.39 I believe?) require the setWindowTitle EM_ASM in SDL to be updated as is here.

Without this, building urho with emscripten 2.0.8 works, but all of the examples crash in chrome and firefox.

Also added a git ignore entry for vscode project files