### PR TITLE
PrimitiveTypes: do not use std::uint64_t and etc for underlying types

### DIFF
--- a/Source/Urho3D/Base/PrimitiveTypes.h
+++ b/Source/Urho3D/Base/PrimitiveTypes.h
@@ -4,21 +4,20 @@
 #pragma once
 
 #include <cstddef> // std::byte
-#include <cstdint> // std::int8_t, ...
 
 // User can inject Urho3D::PrimitiveTypes into other namespace
 namespace Urho3D::PrimitiveTypes
 {
 
-// https://en.cppreference.com/w/cpp/types/integer
-using i8 = std::int8_t;
-using u8 = std::uint8_t;
-using i16 = std::int16_t;
-using u16 = std::uint16_t;
-using i32 = std::int32_t;
-using u32 = std::uint32_t;
-using i64 = std::int64_t;
-using u64 = std::uint64_t;
+// https://en.cppreference.com/w/cpp/language/types
+using i8 = signed char;
+using u8 = unsigned char;
+using i16 = short;
+using u16 = unsigned short;
+using i32 = int;
+using u32 = unsigned;
+using i64 = long long;
+using u64 = unsigned long long;
 
 // Unicode code point (UTF-32 code unit)
 using c32 = char32_t;


### PR DESCRIPTION
The underlying type of int64_t is different on different platforms
* gcc 32, clang 32, vs 32, vs 64 - long long
* gcc 64, clang 64 - long

This cause problems in some situations. For example `int64_t x; Variant(x);` just not compile on clang 64 (compiler cannot choose which of the integer constructors to use)
