### PR TITLE
Fix Android launcher

### DIFF
--- a/android/launcher-app/src/main/AndroidManifest.xml
+++ b/android/launcher-app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
+		android:extractNativeLibs="true"
         android:supportsRtl="true">
         <activity
             android:name=".LauncherActivity"

--- a/android/launcher-app/src/main/AndroidManifest.xml
+++ b/android/launcher-app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
-		android:extractNativeLibs="true"
+        android:extractNativeLibs="true"
         android:supportsRtl="true">
         <activity
             android:name=".LauncherActivity"


### PR DESCRIPTION
При сборке под свежим gradle без этого флага Android не распаковывает нативные либы и лончер не видит примеры для запуска.