### PR TITLE
Fix to build on wayland 1.21

### DIFF
--- a/Source/ThirdParty/SDL/src/video/wayland/SDL_waylanddyn.h
+++ b/Source/ThirdParty/SDL/src/video/wayland/SDL_waylanddyn.h
@@ -77,6 +77,9 @@ void SDL_WAYLAND_UnloadSymbols(void);
 #define wl_proxy_add_listener (*WAYLAND_wl_proxy_add_listener)
 #define wl_proxy_marshal_constructor (*WAYLAND_wl_proxy_marshal_constructor)
 #define wl_proxy_marshal_constructor_versioned (*WAYLAND_wl_proxy_marshal_constructor_versioned)
+#define wl_proxy_marshal_flags (*WAYLAND_wl_proxy_marshal_flags)
+#define wl_proxy_marshal_array_flags (*WAYLAND_wl_proxy_marshal_array_flags)
+#define wl_proxy_get_version (*WAYLAND_wl_proxy_get_version)
 
 #define wl_seat_interface (*WAYLAND_wl_seat_interface)
 #define wl_surface_interface (*WAYLAND_wl_surface_interface)

--- a/Source/ThirdParty/SDL/src/video/wayland/SDL_waylandsym.h
+++ b/Source/ThirdParty/SDL/src/video/wayland/SDL_waylandsym.h
@@ -40,6 +40,7 @@ SDL_WAYLAND_SYM(void, wl_proxy_destroy, (struct wl_proxy *))
 SDL_WAYLAND_SYM(int, wl_proxy_add_listener, (struct wl_proxy *, void (**)(void), void *))
 SDL_WAYLAND_SYM(void, wl_proxy_set_user_data, (struct wl_proxy *, void *))
 SDL_WAYLAND_SYM(void *, wl_proxy_get_user_data, (struct wl_proxy *))
+SDL_WAYLAND_SYM(uint32_t, wl_proxy_get_version, (struct wl_proxy *))
 SDL_WAYLAND_SYM(uint32_t, wl_proxy_get_id, (struct wl_proxy *))
 SDL_WAYLAND_SYM(const char *, wl_proxy_get_class, (struct wl_proxy *))
 SDL_WAYLAND_SYM(void, wl_proxy_set_queue, (struct wl_proxy *, struct wl_event_queue *))
@@ -69,6 +70,11 @@ SDL_WAYLAND_SYM(struct wl_proxy *, wl_proxy_marshal_constructor, (struct wl_prox
 
 SDL_WAYLAND_MODULE(WAYLAND_CLIENT_1_10)
 SDL_WAYLAND_SYM(struct wl_proxy *, wl_proxy_marshal_constructor_versioned, (struct wl_proxy *proxy, uint32_t opcode, const struct wl_interface *interface, uint32_t version, ...))
+
+SDL_WAYLAND_MODULE(WAYLAND_CLIENT_1_20)
+SDL_WAYLAND_SYM(struct wl_proxy*, wl_proxy_marshal_flags, (struct wl_proxy *proxy, uint32_t opcode, const struct wl_interface *interfac, uint32_t version, uint32_t flags, ...))
+SDL_WAYLAND_SYM(struct wl_proxy*, wl_proxy_marshal_array_flags, (struct wl_proxy *proxy, uint32_t opcode, const struct wl_interface *interface, uint32_t version,  uint32_t flags, union wl_argument *args))
+
 
 SDL_WAYLAND_INTERFACE(wl_seat_interface)
 SDL_WAYLAND_INTERFACE(wl_surface_interface)


### PR DESCRIPTION
При сборке под Wayland 1.21 появляются ошибки линковки по типу:
```
undefined reference to `wl_proxy_get_version'
```

Вдохновившись этим патчем я заставил Urho3D собраться под Wayland 1.21.
https://github.com/libsdl-org/SDL/pull/5092

Движок всё ещё требует SDL_VIDEODRIVER=wayland чтобы запускаться под Wayland'ом, но в целом работает.
